### PR TITLE
Add TREATED to common group names (do not try to remove)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ objc/piranha-objc
 swift/artifact
 swift/Piranha.xcodeproj
 swift/Package.resolved
+**/*.iml

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -90,8 +90,12 @@ public class XPFlagCleaner extends BugChecker
         BugChecker.VariableTreeMatcher,
         BugChecker.MethodTreeMatcher {
 
+  /**
+   * Do not try to auto-delete imports with these common/generic names, as multiple treament groups
+   * for different flags are likely to re-use these names.
+   */
   private static final ImmutableSet<String> COMMON_GROUP_NAMES =
-      ImmutableSet.of("control", "enabled", "disabled", "treatment");
+      ImmutableSet.of("control", "enabled", "disabled", "treatment", "treated");
 
   private static final int DONTCARE = -1;
 


### PR DESCRIPTION
The list of common/generic group names was missing this, which can cause
unrelated `import static ... XEnum.TREATED;` statements to be deleted.
We skip this kind of deletion for group names that are likely to clash
between experiment flags.

This PR also includes a unit test for this behavior.