### PR TITLE
Fix overlap checking for nodes with same end position.

### DIFF
--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -326,7 +326,7 @@ public class XPFlagCleaner extends BugChecker
    * the internal expression does not happen.
    */
   private boolean overLaps(Tree t, VisitorState visitorState) {
-    if (endPos != DONTCARE && visitorState.getEndPosition(t) < endPos) {
+    if (endPos != DONTCARE && visitorState.getEndPosition(t) <= endPos) {
       return true;
     } else {
       endPos = DONTCARE;

--- a/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCases.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCases.java
@@ -253,6 +253,15 @@ class XPFlagCleanerPositiveCases {
      return;
   }
 
+  public int or_compounded_with_not(int x, boolean extra_toggle) {
+    // BUG: Diagnostic contains: Cleans stale XP flags
+    if (extra_toggle || !experimentation.isToggleDisabled(TestExperimentName.STALE_FLAG)) {
+      return 0;
+    } else {
+      return 1;
+    }
+  }
+
   class XPTest {
     public boolean isToggleEnabled(TestExperimentName x) { return true; }
     public boolean putToggleEnabled(TestExperimentName x) { return true; }

--- a/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesControl.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesControl.java
@@ -151,8 +151,13 @@ class XPFlagCleanerPositiveCases {
      return;
   }
 
-
-
+  public int or_compounded_with_not(int x, boolean extra_toggle) {
+    if (extra_toggle) {
+      return 0;
+    } else {
+      return 1;
+    }
+  }
 
 
   class XPTest {

--- a/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesTreatment.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesTreatment.java
@@ -158,6 +158,10 @@ class XPFlagCleanerPositiveCases {
      return;
   }
 
+  public int or_compounded_with_not(int x, boolean extra_toggle) {
+    return 0;
+  }
+
   class XPTest {
     public boolean isToggleEnabled(TestExperimentName x) { return true; }
     public boolean putToggleEnabled(TestExperimentName x) { return true; }


### PR DESCRIPTION
This solves an annoying off-by-one error in our overlap checking where a parent node and its child can both have the same end position. 

Previously, overlap checking was strict less-than (`<`). Thus, for example `x || !y` will analyze `y` twice, since based on that checking `x || !y` does not overlap with `!y` (they have the same end position, rather than `!y` having an earlier one).

After this chance, we check less-or-equal (`<=`) and thus catch these types of overlaps.