### PR TITLE
Improve simplification of nested conditionals.

### DIFF
--- a/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCases.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCases.java
@@ -262,6 +262,17 @@ class XPFlagCleanerPositiveCases {
     }
   }
 
+  public int remove_else_if(boolean extra_toggle) {
+    // BUG: Diagnostic contains: Cleans stale XP flags
+    if (extra_toggle) {
+      return 0;
+    } else if(experimentation.isToggleDisabled(TestExperimentName.STALE_FLAG)) {
+      return 1;
+    } else {
+      return 2;
+    }
+  }
+
   class XPTest {
     public boolean isToggleEnabled(TestExperimentName x) { return true; }
     public boolean putToggleEnabled(TestExperimentName x) { return true; }

--- a/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesControl.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesControl.java
@@ -159,6 +159,13 @@ class XPFlagCleanerPositiveCases {
     }
   }
 
+  public int remove_else_if(boolean extra_toggle) {
+    if (extra_toggle) {
+      return 0;
+    } else {
+      return 1;
+    }
+  }
 
   class XPTest {
     public boolean isToggleEnabled(TestExperimentName x) { return true; }

--- a/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesTreatment.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesTreatment.java
@@ -162,6 +162,14 @@ class XPFlagCleanerPositiveCases {
     return 0;
   }
 
+  public int remove_else_if(boolean extra_toggle) {
+    if (extra_toggle) {
+      return 0;
+    } else {
+      return 2;
+    }
+  }
+
   class XPTest {
     public boolean isToggleEnabled(TestExperimentName x) { return true; }
     public boolean putToggleEnabled(TestExperimentName x) { return true; }


### PR DESCRIPTION
Before this fix, code like this:

```
    if (extra_toggle) {
      return 0;
    } else if(experimentation.isToggleDisabled(TestExperimentName.STALE_FLAG)) {
      return 1;
    } else {
      return 2;
    }
```

Would not simplify beyond constant propagation of the test itself, resulting in something like:

```
    if (extra_toggle) {
      return 0;
    } else if(true) {
      return 1;
    } else {
      return 2;
    }
```

Which obviously can be simplified further. This patch is a bit hacky, but it should fix that case. We might want to consider a careful re-evaluation of the algorithm for `matchIf` at some point, but that day is not today ;) 
