### PR TITLE
Fix swift-tools-version in Package.swift

### DIFF
--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,3 +1,6 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 /**
  *    Copyright (c) 2019 Uber Technologies, Inc.
  *
@@ -13,9 +16,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-// swift-tools-version:5.1
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 


### PR DESCRIPTION
When running `swift build` in the 'swift' subdirectory, I get the following error:

```
/Users/ben/src/third-party/piranha/swift: error: package at '/Users/ben/src/third-party/piranha/swift' is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:5.1' to specify the current tools version
```

The `// swift-tools-version:5.1` declaration needs to be the first line of the Package.swift file to be picked up correctly by Swift tools. I've moved it above the licensing notice which has fixed it for me!