### PR TITLE
Enforce Google Java Format for PiranhaJava

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       before_script:
         - cd java/
       script:
-        - ./gradlew build
+        - ./gradlew verGJF build
       after_success:
         - ./gradlew jacocoTestReport coveralls
       cache:

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -35,6 +35,7 @@ subprojects { project ->
         errorproneJavac deps.build.errorProneJavac
     }
     project.tasks.withType(JavaCompile) {
+        dependsOn(installGitHooks)
         options.compilerArgs += [
             "-Xlint:unchecked",
             "-Xlint:rawtypes"
@@ -56,4 +57,17 @@ subprojects { project ->
 
 googleJavaFormat {
   toolVersion = "1.6"
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//  Google Java Format pre-commit hook installation
+//
+
+tasks.register('installGitHooks', Copy) {
+	from(file('config/hooks/pre-commit-stub')) {
+		rename 'pre-commit-stub', 'pre-commit'
+	}
+	into file('../.git/hooks')
+	fileMode 0777
 }

--- a/java/config/hooks/pre-commit
+++ b/java/config/hooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
+
+files=$((git diff --cached --name-only --diff-filter=ACMR | grep -Ei "\.java$") || true)
+if [ ! -z "${files}" ]; then
+    comma_files=$(echo "$files" | paste -s -d "," -)
+    "${REPO_ROOT_DIR}/gradlew" goJF -DgoogleJavaFormat.include="$comma_files" &>/dev/null
+    git add $(echo "$files" | paste -s -d " " -)
+fi

--- a/java/config/hooks/pre-commit
+++ b/java/config/hooks/pre-commit
@@ -4,12 +4,11 @@ set -e
 
 REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-pushd "${REPO_ROOT_DIR}/java"
+pushd "${REPO_ROOT_DIR}/java" > /dev/null
 files=$((git diff --cached --name-only --diff-filter=ACMR | grep -Ei "\.java$" | sed -e 's/^java\///') || true)
 if [ ! -z "${files}" ]; then
     comma_files=$(echo "$files" | paste -s -d "," -)
-    echo "Will run ${REPO_ROOT_DIR}/java/gradlew goJF -DgoogleJavaFormat.include=$comma_files"
     "${REPO_ROOT_DIR}/java/gradlew" goJF -DgoogleJavaFormat.include="$comma_files" &>/dev/null
     git add $(echo "$files" | paste -s -d " " -)
 fi
-popd
+popd > /dev/null

--- a/java/config/hooks/pre-commit
+++ b/java/config/hooks/pre-commit
@@ -4,9 +4,12 @@ set -e
 
 REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-files=$((git diff --cached --name-only --diff-filter=ACMR | grep -Ei "\.java$") || true)
+pushd "${REPO_ROOT_DIR}/java"
+files=$((git diff --cached --name-only --diff-filter=ACMR | grep -Ei "\.java$" | sed -e 's/^java\///') || true)
 if [ ! -z "${files}" ]; then
     comma_files=$(echo "$files" | paste -s -d "," -)
-    "${REPO_ROOT_DIR}/gradlew" goJF -DgoogleJavaFormat.include="$comma_files" &>/dev/null
+    echo "Will run ${REPO_ROOT_DIR}/java/gradlew goJF -DgoogleJavaFormat.include=$comma_files"
+    "${REPO_ROOT_DIR}/java/gradlew" goJF -DgoogleJavaFormat.include="$comma_files" &>/dev/null
     git add $(echo "$files" | paste -s -d " " -)
 fi
+popd

--- a/java/config/hooks/pre-commit-stub
+++ b/java/config/hooks/pre-commit-stub
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# stub pre-commit hook
+# just a runner for the real pre-commit script
+# if script cannot be found, exit without error
+# (to not block local commits)
+
+set -e
+
+REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
+PRE_COMMIT_SCRIPT="${REPO_ROOT_DIR}/config/hooks/pre-commit"
+
+if [ -f $PRE_COMMIT_SCRIPT ]; then
+    source $PRE_COMMIT_SCRIPT
+fi

--- a/java/config/hooks/pre-commit-stub
+++ b/java/config/hooks/pre-commit-stub
@@ -8,7 +8,7 @@
 set -e
 
 REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
-PRE_COMMIT_SCRIPT="${REPO_ROOT_DIR}/config/hooks/pre-commit"
+PRE_COMMIT_SCRIPT="${REPO_ROOT_DIR}/java/config/hooks/pre-commit"
 
 if [ -f $PRE_COMMIT_SCRIPT ]; then
     source $PRE_COMMIT_SCRIPT

--- a/java/piranha/src/main/java/com/uber/piranha/PiranhaUtils.java
+++ b/java/piranha/src/main/java/com/uber/piranha/PiranhaUtils.java
@@ -1,17 +1,15 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ * Copyright (c) 2019 Uber Technologies, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.piranha;
 
@@ -20,5 +18,4 @@ public class PiranhaUtils {
       "//[PIRANHA_DELETE_FILE_SEQ] Delete this class.\n";
 
   public static final String HELPER_CLASS = "// [PIRANHA_STALE_PLUGIN_HELPER_CLASS]";
-
 }

--- a/java/piranha/src/main/java/com/uber/piranha/UsageCounter.java
+++ b/java/piranha/src/main/java/com/uber/piranha/UsageCounter.java
@@ -1,17 +1,15 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ * Copyright (c) 2019 Uber Technologies, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.piranha;
 
@@ -34,147 +32,145 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Originally from com.uber.errorprone.checker.dagger.UsageCounter
- */
+/** Originally from com.uber.errorprone.checker.dagger.UsageCounter */
 public final class UsageCounter {
 
-    private UsageCounter() {
-        /* Helper class only, not instantiable */
+  private UsageCounter() {
+    /* Helper class only, not instantiable */
+  }
+
+  private static boolean symbolHasSuppressUnusedCheckerWarningsAnnotation(
+      Symbol symbol, String checkerName) {
+    SuppressWarnings annotation = symbol.getAnnotation(SuppressWarnings.class);
+    if (annotation != null) {
+      for (String s : annotation.value()) {
+        if (s.equals(checkerName)) return true;
+      }
+    }
+    return false;
+  }
+
+  public static ImmutableMap<Symbol, CounterData> getUsageCounts(VisitorState state) {
+    return getUsageCounts(state, state.getPath());
+  }
+
+  public static ImmutableMap<Symbol, CounterData> getUsageCounts(
+      VisitorState state, TreePath path) {
+    UsageCounter.CallScanner callScanner = new UsageCounter.CallScanner(state);
+    callScanner.scan(path, null);
+    ImmutableMap.Builder<Symbol, CounterData> builder = ImmutableMap.builder();
+    for (VariableTree decl : callScanner.declaredInjectVars) {
+      Symbol s = ASTHelpers.getSymbol(decl);
+      CounterData counterData =
+          new CounterData(
+              DeclType.FIELD,
+              decl,
+              (callScanner.usedVars.containsKey(s) ? callScanner.usedVars.get(s) : 0));
+      builder.put(s, counterData);
     }
 
-    private static boolean symbolHasSuppressUnusedCheckerWarningsAnnotation(
-            Symbol symbol, String checkerName) {
-        SuppressWarnings annotation = symbol.getAnnotation(SuppressWarnings.class);
-        if (annotation != null) {
-            for (String s : annotation.value()) {
-                if (s.equals(checkerName)) return true;
-            }
-        }
-        return false;
+    for (VariableTree decl : callScanner.declaredParamVars.keySet()) {
+      Symbol s = ASTHelpers.getSymbol(decl);
+      Symbol.MethodSymbol mSym = callScanner.declaredParamVars.get(decl);
+      CounterData counterData =
+          new CounterData(
+              DeclType.PARAM,
+              decl,
+              (callScanner.usedVars.containsKey(s) ? callScanner.usedVars.get(s) : 0));
+      builder.put(s, counterData);
+    }
+    return builder.build();
+  }
+
+  public static ImmutableMap<Symbol, Integer> getRawUsageCounts(Tree tree) {
+    RawUsageCountsScanner scanner = new RawUsageCountsScanner();
+    scanner.scan(tree, null);
+    return ImmutableMap.copyOf(scanner.usedVars);
+  }
+
+  private static void addUse(Map<Symbol, Integer> usedVars, Symbol symbol) {
+    if (usedVars.containsKey(symbol)) {
+      usedVars.put(symbol, usedVars.get(symbol) + 1);
+    } else {
+      usedVars.put(symbol, 1);
+    }
+  }
+
+  static class CallScanner extends TreePathScanner<Void, Void> {
+    final Set<VariableTree> declaredInjectVars = new LinkedHashSet<>();
+    final HashMap<VariableTree, Symbol.MethodSymbol> declaredParamVars =
+        new HashMap<VariableTree, Symbol.MethodSymbol>();
+    final Map<Symbol, Integer> usedVars = new LinkedHashMap<>();
+    final VisitorState state;
+
+    CallScanner(VisitorState state) {
+      this.state = state;
     }
 
-    public static ImmutableMap<Symbol, CounterData> getUsageCounts(VisitorState state) {
-        return getUsageCounts(state, state.getPath());
+    @Override
+    public Void visitMemberSelect(MemberSelectTree tree, Void unused) {
+      addUse(usedVars, ASTHelpers.getSymbol(tree));
+      return super.visitMemberSelect(tree, null);
     }
 
-    public static ImmutableMap<Symbol, CounterData> getUsageCounts(
-            VisitorState state, TreePath path) {
-        UsageCounter.CallScanner callScanner = new UsageCounter.CallScanner(state);
-        callScanner.scan(path, null);
-        ImmutableMap.Builder<Symbol, CounterData> builder = ImmutableMap.builder();
-        for (VariableTree decl : callScanner.declaredInjectVars) {
-            Symbol s = ASTHelpers.getSymbol(decl);
-            CounterData counterData =
-                    new CounterData(
-                            DeclType.FIELD,
-                            decl,
-                            (callScanner.usedVars.containsKey(s) ? callScanner.usedVars.get(s) : 0));
-            builder.put(s, counterData);
-        }
-
-        for (VariableTree decl : callScanner.declaredParamVars.keySet()) {
-            Symbol s = ASTHelpers.getSymbol(decl);
-            Symbol.MethodSymbol mSym = callScanner.declaredParamVars.get(decl);
-            CounterData counterData =
-                    new CounterData(
-                            DeclType.PARAM,
-                            decl,
-                            (callScanner.usedVars.containsKey(s) ? callScanner.usedVars.get(s) : 0));
-            builder.put(s, counterData);
-        }
-        return builder.build();
+    @Override
+    public Void visitIdentifier(IdentifierTree tree, Void unused) {
+      addUse(usedVars, ASTHelpers.getSymbol(tree));
+      return super.visitIdentifier(tree, null);
     }
 
-    public static ImmutableMap<Symbol, Integer> getRawUsageCounts(Tree tree) {
-        RawUsageCountsScanner scanner = new RawUsageCountsScanner();
-        scanner.scan(tree, null);
-        return ImmutableMap.copyOf(scanner.usedVars);
+    @Override
+    public Void visitMethod(MethodTree tree, Void unused) {
+      Symbol.MethodSymbol mSym = ASTHelpers.getSymbol(tree);
+      if (ASTHelpers.hasAnnotation(mSym, "dagger.Provides", state)) {
+        for (VariableTree vt : tree.getParameters()) {
+          declaredParamVars.put(vt, mSym);
+        }
+      }
+      return super.visitMethod(tree, null);
     }
 
-    private static void addUse(Map<Symbol, Integer> usedVars, Symbol symbol) {
-        if (usedVars.containsKey(symbol)) {
-            usedVars.put(symbol, usedVars.get(symbol) + 1);
-        } else {
-            usedVars.put(symbol, 1);
-        }
+    @Override
+    public Void visitVariable(VariableTree tree, Void unused) {
+      Symbol.VarSymbol vSym = ASTHelpers.getSymbol(tree);
+      if (ASTHelpers.hasAnnotation(vSym, "javax.inject.Inject", state)) {
+        declaredInjectVars.add(tree);
+      }
+      return super.visitVariable(tree, null);
+    }
+  }
+
+  static class RawUsageCountsScanner extends TreeScanner<Void, Void> {
+    final Map<Symbol, Integer> usedVars = new LinkedHashMap<>();
+
+    @Override
+    public Void visitMemberSelect(MemberSelectTree tree, Void unused) {
+      addUse(usedVars, ASTHelpers.getSymbol(tree));
+      return super.visitMemberSelect(tree, null);
     }
 
-    static class CallScanner extends TreePathScanner<Void, Void> {
-        final Set<VariableTree> declaredInjectVars = new LinkedHashSet<>();
-        final HashMap<VariableTree, Symbol.MethodSymbol> declaredParamVars =
-                new HashMap<VariableTree, Symbol.MethodSymbol>();
-        final Map<Symbol, Integer> usedVars = new LinkedHashMap<>();
-        final VisitorState state;
-
-        CallScanner(VisitorState state) {
-            this.state = state;
-        }
-
-        @Override
-        public Void visitMemberSelect(MemberSelectTree tree, Void unused) {
-            addUse(usedVars, ASTHelpers.getSymbol(tree));
-            return super.visitMemberSelect(tree, null);
-        }
-
-        @Override
-        public Void visitIdentifier(IdentifierTree tree, Void unused) {
-            addUse(usedVars, ASTHelpers.getSymbol(tree));
-            return super.visitIdentifier(tree, null);
-        }
-
-        @Override
-        public Void visitMethod(MethodTree tree, Void unused) {
-            Symbol.MethodSymbol mSym = ASTHelpers.getSymbol(tree);
-            if (ASTHelpers.hasAnnotation(mSym, "dagger.Provides", state)) {
-                for (VariableTree vt : tree.getParameters()) {
-                    declaredParamVars.put(vt, mSym);
-                }
-            }
-            return super.visitMethod(tree, null);
-        }
-
-        @Override
-        public Void visitVariable(VariableTree tree, Void unused) {
-            Symbol.VarSymbol vSym = ASTHelpers.getSymbol(tree);
-            if (ASTHelpers.hasAnnotation(vSym, "javax.inject.Inject", state)) {
-                declaredInjectVars.add(tree);
-            }
-            return super.visitVariable(tree, null);
-        }
+    @Override
+    public Void visitIdentifier(IdentifierTree tree, Void unused) {
+      addUse(usedVars, ASTHelpers.getSymbol(tree));
+      return super.visitIdentifier(tree, null);
     }
+  }
 
-    static class RawUsageCountsScanner extends TreeScanner<Void, Void> {
-        final Map<Symbol, Integer> usedVars = new LinkedHashMap<>();
+  public enum DeclType {
+    FIELD,
+    PARAM,
+  }
 
-        @Override
-        public Void visitMemberSelect(MemberSelectTree tree, Void unused) {
-            addUse(usedVars, ASTHelpers.getSymbol(tree));
-            return super.visitMemberSelect(tree, null);
-        }
+  public static class CounterData {
+    public final DeclType declType;
+    public final VariableTree declaration;
+    public final int count;
 
-        @Override
-        public Void visitIdentifier(IdentifierTree tree, Void unused) {
-            addUse(usedVars, ASTHelpers.getSymbol(tree));
-            return super.visitIdentifier(tree, null);
-        }
+    public CounterData(DeclType declType, VariableTree declaration, int count) {
+      Preconditions.checkArgument(count >= 0, "Count must be positive.");
+      this.declType = declType;
+      this.declaration = declaration;
+      this.count = count;
     }
-
-    public enum DeclType {
-        FIELD,
-        PARAM,
-    }
-
-    public static class CounterData {
-        public final DeclType declType;
-        public final VariableTree declaration;
-        public final int count;
-
-        public CounterData(DeclType declType, VariableTree declaration, int count) {
-            Preconditions.checkArgument(count >= 0, "Count must be positive.");
-            this.declType = declType;
-            this.declaration = declaration;
-            this.count = count;
-        }
-    }
+  }
 }

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -1,17 +1,15 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ * Copyright (c) 2019 Uber Technologies, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.piranha;
 
@@ -58,7 +56,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.ParseException;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -71,10 +68,11 @@ import javax.lang.model.element.ElementKind;
 
 /** @author murali@uber.com (Murali Krishna Ramanathan) */
 @AutoService(BugChecker.class)
-@BugPattern(name = "Piranha",
-        altNames = {"XPFlagCleaner"},
-        summary = "Cleans stale XP flags.",
-        severity = SUGGESTION)
+@BugPattern(
+    name = "Piranha",
+    altNames = {"XPFlagCleaner"},
+    summary = "Cleans stale XP flags.",
+    severity = SUGGESTION)
 public class XPFlagCleaner extends BugChecker
     implements BugChecker.AssignmentTreeMatcher,
         BugChecker.BinaryTreeMatcher,
@@ -292,8 +290,8 @@ public class XPFlagCleaner extends BugChecker
         ExpressionTree arg = mit.getArguments().get(0);
         Symbol argSym = ASTHelpers.getSymbol(arg);
         if (isLiteralTreeAndMatchesFlagName(arg)
-                || isVarSymbolAndMatchesFlagName(argSym)
-                || isSymbolAndMatchesFlagName(argSym)) {
+            || isVarSymbolAndMatchesFlagName(argSym)
+            || isSymbolAndMatchesFlagName(argSym)) {
           MemberSelectTree mst = (MemberSelectTree) mit.getMethodSelect();
           String methodName = mst.getIdentifier().toString();
           if (controlMethods.contains(methodName)) {
@@ -313,6 +311,7 @@ public class XPFlagCleaner extends BugChecker
 
   /**
    * Checks for {@link Symbol} and the flag name
+   *
    * @param argSym
    * @return True if matches. Otherwise false
    */
@@ -322,27 +321,28 @@ public class XPFlagCleaner extends BugChecker
 
   /**
    * Checks for {@link com.sun.tools.javac.code.Symbol.VarSymbol} and the flag name
+   *
    * @param argSym
    * @return True if matches. Otherwise false
    */
   private boolean isVarSymbolAndMatchesFlagName(Symbol argSym) {
     return argSym != null
-            && argSym instanceof Symbol.VarSymbol
-            && ((Symbol.VarSymbol) argSym).getConstantValue() != null
-            && ((Symbol.VarSymbol) argSym).getConstantValue().equals(xpFlagName);
+        && argSym instanceof Symbol.VarSymbol
+        && ((Symbol.VarSymbol) argSym).getConstantValue() != null
+        && ((Symbol.VarSymbol) argSym).getConstantValue().equals(xpFlagName);
   }
 
   /**
    * Checks for {@link LiteralTree} and the flag name
+   *
    * @param arg
    * @return True if matches. Otherwise false
    */
   private boolean isLiteralTreeAndMatchesFlagName(ExpressionTree arg) {
     return arg instanceof LiteralTree
-            && ((LiteralTree) arg).getValue() != null
-            && ((LiteralTree) arg).getValue().equals(xpFlagName);
+        && ((LiteralTree) arg).getValue() != null
+        && ((LiteralTree) arg).getValue().equals(xpFlagName);
   }
-
 
   private String stripBraces(String s) {
     if (s.startsWith("{")) {
@@ -703,7 +703,10 @@ public class XPFlagCleaner extends BugChecker
         // Fallback for single/last enum variable detection
         return buildDescription(tree).addFix(SuggestedFix.delete(tree)).build();
       }
-    } else if (sym == null && tree != null && ASTHelpers.getSymbol(tree) != null && xpFlagName.equals(ASTHelpers.getSymbol(tree).getConstantValue())) {
+    } else if (sym == null
+        && tree != null
+        && ASTHelpers.getSymbol(tree) != null
+        && xpFlagName.equals(ASTHelpers.getSymbol(tree).getConstantValue())) {
       return buildDescription(tree).addFix(SuggestedFix.delete(tree)).build();
     }
     return Description.NO_MATCH;
@@ -830,17 +833,19 @@ public class XPFlagCleaner extends BugChecker
           }
         }
       } else {
-          // The condition doesn't simplify to a constant, but the condition to some nested "else if" might.
-          if (elseStatement != null && elseStatement.getKind().equals(Kind.IF)) {
-            // Copy the initial if condition (don't mark as needing update yet)
-            replacementPrefix += "if " + visitorState.getSourceForNode(subIfTree.getCondition());
-            replacementPrefix += visitorState.getSourceForNode(subIfTree.getThenStatement()) + " else ";
-            // Then recurse on the else case
-            recurse = true;
-            subIfTree = (IfTree) elseStatement;
-            ParenthesizedTree pT = (ParenthesizedTree) subIfTree.getCondition();
-            x = evalExpr(pT, visitorState);
-          }
+        // The condition doesn't simplify to a constant, but the condition to some nested "else if"
+        // might.
+        if (elseStatement != null && elseStatement.getKind().equals(Kind.IF)) {
+          // Copy the initial if condition (don't mark as needing update yet)
+          replacementPrefix += "if " + visitorState.getSourceForNode(subIfTree.getCondition());
+          replacementPrefix +=
+              visitorState.getSourceForNode(subIfTree.getThenStatement()) + " else ";
+          // Then recurse on the else case
+          recurse = true;
+          subIfTree = (IfTree) elseStatement;
+          ParenthesizedTree pT = (ParenthesizedTree) subIfTree.getCondition();
+          x = evalExpr(pT, visitorState);
+        }
       }
     } while (recurse);
 

--- a/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
@@ -1,17 +1,15 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ * Copyright (c) 2019 Uber Technologies, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.piranha;
 
@@ -179,7 +177,7 @@ public class XPFlagCleanerTest {
 
     try {
       BugCheckerRefactoringTestHelper bcr =
-              BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+          BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
       bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
@@ -191,51 +189,51 @@ public class XPFlagCleanerTest {
               "public enum TestExperimentName {",
               " STALE_FLAG",
               "}")
-              .addOutputLines(
-                      "TestExperimentName.java",
-                      "package com.uber.piranha;",
-                      "public enum TestExperimentName {", // Ideally we would remove this too, fix later
-                      "}")
-              .addInputLines(
-                      "TestExperimentGroups.java",
-                      "package com.uber.piranha;",
-                      "public enum TestExperimentGroups {",
-                      " TREATED,",
-                      " CONTROL,",
-                      "}")
-              .addOutputLines(
-                      "TestExperimentGroups.java",
-                      "package com.uber.piranha;",
-                      "public enum TestExperimentGroups {",
-                      " TREATED,",
-                      " CONTROL,",
-                      "}")
-              .addInputLines(
-                      "XPFlagCleanerSinglePositiveCase.java",
-                      "package com.uber.piranha;",
-                      "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
-                      "import static com.uber.piranha.TestExperimentGroups.TREATED;",
-                      "class XPFlagCleanerSinglePositiveCase {",
-                      " private XPTest experimentation;",
-                      " public String groupToString() {",
-                      "  // BUG: Diagnostic contains: Cleans stale XP flags",
-                      "  if (experimentation.isToggleDisabled(STALE_FLAG)) { return \"\"; }",
-                      "  else if (experimentation.isToggleInGroup(",
-                      "            STALE_FLAG,TREATED)) { ",
-                      "    return \"Treated\";",
-                      "  } else { return \"Controll\"; }",
-                      " }",
-                      "}")
-              .addOutputLines(
-                      "XPFlagCleanerSinglePositiveCase.java",
-                      "package com.uber.piranha;",
-                      "import static com.uber.piranha.TestExperimentGroups.TREATED;",
-                      "class XPFlagCleanerSinglePositiveCase {",
-                      " private XPTest experimentation;",
-                      " public String groupToString() {",
-                      "  return \"Treated\";",
-                      " }",
-                      "}");
+          .addOutputLines(
+              "TestExperimentName.java",
+              "package com.uber.piranha;",
+              "public enum TestExperimentName {", // Ideally we would remove this too, fix later
+              "}")
+          .addInputLines(
+              "TestExperimentGroups.java",
+              "package com.uber.piranha;",
+              "public enum TestExperimentGroups {",
+              " TREATED,",
+              " CONTROL,",
+              "}")
+          .addOutputLines(
+              "TestExperimentGroups.java",
+              "package com.uber.piranha;",
+              "public enum TestExperimentGroups {",
+              " TREATED,",
+              " CONTROL,",
+              "}")
+          .addInputLines(
+              "XPFlagCleanerSinglePositiveCase.java",
+              "package com.uber.piranha;",
+              "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
+              "import static com.uber.piranha.TestExperimentGroups.TREATED;",
+              "class XPFlagCleanerSinglePositiveCase {",
+              " private XPTest experimentation;",
+              " public String groupToString() {",
+              "  // BUG: Diagnostic contains: Cleans stale XP flags",
+              "  if (experimentation.isToggleDisabled(STALE_FLAG)) { return \"\"; }",
+              "  else if (experimentation.isToggleInGroup(",
+              "            STALE_FLAG,TREATED)) { ",
+              "    return \"Treated\";",
+              "  } else { return \"Controll\"; }",
+              " }",
+              "}")
+          .addOutputLines(
+              "XPFlagCleanerSinglePositiveCase.java",
+              "package com.uber.piranha;",
+              "import static com.uber.piranha.TestExperimentGroups.TREATED;",
+              "class XPFlagCleanerSinglePositiveCase {",
+              " private XPTest experimentation;",
+              " public String groupToString() {",
+              "  return \"Treated\";",
+              " }",
+              "}");
 
       bcr.doTest();
     } catch (ParseException pe) {
@@ -304,8 +302,7 @@ public class XPFlagCleanerTest {
           .addInputLines(
               "XPFlagCleanerSinglePositiveCase.java",
               "package com.uber.piranha;",
-              "import static com.uber.piranha.TestExperimentName"
-                  + ".STALE_FLAG;",
+              "import static com.uber.piranha.TestExperimentName" + ".STALE_FLAG;",
               "class XPFlagCleanerSinglePositiveCase {",
               " private XPTest experimentation;",
               " public boolean return_contains_stale_flag() {",
@@ -365,7 +362,7 @@ public class XPFlagCleanerTest {
 
     try {
       BugCheckerRefactoringTestHelper bcr =
-              BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+          BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
       bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
@@ -382,15 +379,15 @@ public class XPFlagCleanerTest {
               "     else { return \"Y\";}",
               " }",
               "}")
-              .addOutputLines(
-                      "XPFlagCleanerSinglePositiveCase.java",
-                      "package com.uber.piranha;",
-                      "class XPFlagCleanerSinglePositiveCase {",
-                      " private XPTest experimentation;",
-                      " public String evaluate() {",
-                      "  return \"Y\";",
-                      " }",
-                      "}");
+          .addOutputLines(
+              "XPFlagCleanerSinglePositiveCase.java",
+              "package com.uber.piranha;",
+              "class XPFlagCleanerSinglePositiveCase {",
+              " private XPTest experimentation;",
+              " public String evaluate() {",
+              "  return \"Y\";",
+              " }",
+              "}");
 
       bcr.doTest();
     } catch (ParseException pe) {
@@ -409,7 +406,7 @@ public class XPFlagCleanerTest {
 
     try {
       BugCheckerRefactoringTestHelper bcr =
-              BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+          BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
       bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
@@ -425,15 +422,15 @@ public class XPFlagCleanerTest {
               "     else { return \"Y\";}",
               " }",
               "}")
-              .addOutputLines(
-                      "XPFlagCleanerSinglePositiveCase.java",
-                      "package com.uber.piranha;",
-                      "class XPFlagCleanerSinglePositiveCase {",
-                      " private XPTest experimentation;",
-                      " public String evaluate() {",
-                      "  return \"Y\";",
-                      " }",
-                      "}");
+          .addOutputLines(
+              "XPFlagCleanerSinglePositiveCase.java",
+              "package com.uber.piranha;",
+              "class XPFlagCleanerSinglePositiveCase {",
+              " private XPTest experimentation;",
+              " public String evaluate() {",
+              "  return \"Y\";",
+              " }",
+              "}");
 
       bcr.doTest();
     } catch (ParseException pe) {
@@ -452,7 +449,7 @@ public class XPFlagCleanerTest {
 
     try {
       BugCheckerRefactoringTestHelper bcr =
-              BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+          BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
       bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
@@ -467,16 +464,16 @@ public class XPFlagCleanerTest {
               "     else { return \"Y\";}",
               " }",
               "}")
-              .addOutputLines(
-                      "XPFlagCleanerSinglePositiveCase.java",
-                      "package com.uber.piranha;",
-                      "class XPFlagCleanerSinglePositiveCase {",
-                      " private XPTest experimentation;",
-                      " public String evaluate() {",
-                      "  if (experimentation.isToggleDisabled(\"NOT_STALE_FLAG\")) { return \"X\"; }",
-                      "     else { return \"Y\";}",
-                      " }",
-                      "}");
+          .addOutputLines(
+              "XPFlagCleanerSinglePositiveCase.java",
+              "package com.uber.piranha;",
+              "class XPFlagCleanerSinglePositiveCase {",
+              " private XPTest experimentation;",
+              " public String evaluate() {",
+              "  if (experimentation.isToggleDisabled(\"NOT_STALE_FLAG\")) { return \"X\"; }",
+              "     else { return \"Y\";}",
+              " }",
+              "}");
 
       bcr.doTest();
     } catch (ParseException pe) {
@@ -495,7 +492,7 @@ public class XPFlagCleanerTest {
 
     try {
       BugCheckerRefactoringTestHelper bcr =
-              BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+          BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
       bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
@@ -511,17 +508,17 @@ public class XPFlagCleanerTest {
               "     else { return \"Y\";}",
               " }",
               "}")
-              .addOutputLines(
-                      "XPFlagCleanerSinglePositiveCase.java",
-                      "package com.uber.piranha;",
-                      "class XPFlagCleanerSinglePositiveCase {",
-                      "private static final String STALE_FLAG_CONSTANTS = \"NOT_STALE_FLAG\";",
-                      " private XPTest experimentation;",
-                      " public String evaluate() {",
-                      "  if (experimentation.isToggleDisabled(STALE_FLAG_CONSTANTS)) { return \"X\"; }",
-                      "     else { return \"Y\";}",
-                      " }",
-                      "}");
+          .addOutputLines(
+              "XPFlagCleanerSinglePositiveCase.java",
+              "package com.uber.piranha;",
+              "class XPFlagCleanerSinglePositiveCase {",
+              "private static final String STALE_FLAG_CONSTANTS = \"NOT_STALE_FLAG\";",
+              " private XPTest experimentation;",
+              " public String evaluate() {",
+              "  if (experimentation.isToggleDisabled(STALE_FLAG_CONSTANTS)) { return \"X\"; }",
+              "     else { return \"Y\";}",
+              " }",
+              "}");
 
       bcr.doTest();
     } catch (ParseException pe) {

--- a/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerNegativeCases.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerNegativeCases.java
@@ -1,17 +1,15 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ * Copyright (c) 2019 Uber Technologies, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.piranha;
 
@@ -40,13 +38,13 @@ class XPFlagCleanerNegativeCases {
   private boolean tBool2 = false;
 
   public void conditional_contains_nonstale_flag() {
-    if(experimentation.isFlagTreated(TestExperimentName.RANDOM_FLAG)) {
+    if (experimentation.isFlagTreated(TestExperimentName.RANDOM_FLAG)) {
       System.out.println("Hello World");
     }
   }
 
   public void conditional_with_else_contains_nonstale_flag() {
-    if(experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG)) {
+    if (experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG)) {
       System.out.println("Hello World");
     } else {
       System.out.println("Hi world");
@@ -54,8 +52,7 @@ class XPFlagCleanerNegativeCases {
   }
 
   public void complex_conditional_contains_nonstale_flag() {
-    if(tBool1 || (tBool2 && experimentation.isToggleEnabled(TestExperimentName
-        .RANDOM_FLAG))) {
+    if (tBool1 || (tBool2 && experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG))) {
       System.out.println("Hello World");
     } else {
       System.out.println("Hi world");
@@ -69,41 +66,49 @@ class XPFlagCleanerNegativeCases {
 
     tBool = experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG) || tBool;
 
-    tBool = experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG) && (tBool1
-        || tBool2);
-
+    tBool = experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG) && (tBool1 || tBool2);
   }
 
   public boolean return_contains_nonstale_flag() {
     return experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG);
   }
 
-
   public void condexp_contains_nonstale_flag() {
-    tBool =  experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG) ? true : false;
+    tBool = experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG) ? true : false;
   }
 
   public void misc_xp_apis_containing_nonstale_flag() {
-    if(experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG) && (tBool1 ||
-        tBool2)) {}
+    if (experimentation.isToggleEnabled(TestExperimentName.RANDOM_FLAG) && (tBool1 || tBool2)) {}
 
     experimentation.putToggleEnabled(TestExperimentName.RANDOM_FLAG);
 
     experimentation.putToggleDisabled(TestExperimentName.RANDOM_FLAG);
 
-    if(experimentation.isToggledDisabled(TestExperimentName.RANDOM_FLAG) &&
-        (tBool1 || tBool2)) {}
+    if (experimentation.isToggledDisabled(TestExperimentName.RANDOM_FLAG) && (tBool1 || tBool2)) {}
   }
 
   @ToggleTesting(treated = TestExperimentName.RANDOM_FLAG)
   public void annotation_test() {}
 
-
   class XPTest {
-    public boolean isToggleEnabled(TestExperimentName x) { return true; }
-    public boolean putToggleEnabled(TestExperimentName x) { return true; }
-    public boolean isToggledDisabled(TestExperimentName x) { return true; }
-    public boolean isFlagTreated(TestExperimentName x) { return true; }
-    public boolean putToggleDisabled(TestExperimentName x) { return true; }
+    public boolean isToggleEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean putToggleEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isToggledDisabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isFlagTreated(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean putToggleDisabled(TestExperimentName x) {
+      return true;
+    }
   }
 }

--- a/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCases.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCases.java
@@ -1,29 +1,24 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ * Copyright (c) 2019 Uber Technologies, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.piranha;
 
+import dagger.Provides;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import dagger.Module;
-import dagger.Provides;
 import javax.inject.Inject;
-
 
 class XPFlagCleanerPositiveCases {
 
@@ -40,7 +35,7 @@ class XPFlagCleanerPositiveCases {
 
   @Retention(RetentionPolicy.RUNTIME)
   public @interface Autorollout {
-     boolean staged() default false;
+    boolean staged() default false;
   }
 
   @Retention(RetentionPolicy.RUNTIME)
@@ -55,14 +50,14 @@ class XPFlagCleanerPositiveCases {
 
   public void conditional_contains_stale_flag() {
     // BUG: Diagnostic contains: Cleans stale XP flags
-    if(experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
-        System.out.println("Hello World");
+    if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
+      System.out.println("Hello World");
     }
   }
 
   public void conditional_with_else_contains_stale_flag() {
     // BUG: Diagnostic contains: Cleans stale XP flags
-    if(experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
+    if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
       System.out.println("Hello World");
     } else {
       System.out.println("Hi world");
@@ -71,7 +66,7 @@ class XPFlagCleanerPositiveCases {
 
   public void complex_conditional_contains_stale_flag() {
     // BUG: Diagnostic contains: Cleans stale XP flags
-    if(true || (tBool && experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG))) {
+    if (true || (tBool && experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG))) {
       System.out.println("Hello World");
     } else {
       System.out.println("Hi world");
@@ -102,7 +97,6 @@ class XPFlagCleanerPositiveCases {
 
     // BUG: Diagnostic contains: Cleans stale XP flags
     tBool = experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG) && (tBool || true);
-
   }
 
   public boolean return_contains_stale_flag() {
@@ -112,13 +106,12 @@ class XPFlagCleanerPositiveCases {
 
   public void condexp_contains_stale_flag() {
     // BUG: Diagnostic contains: Cleans stale XP flags
-    tBool =  experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG) ? true : false;
+    tBool = experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG) ? true : false;
   }
 
   public void misc_xp_apis_containing_stale_flag() {
     // BUG: Diagnostic contains: Cleans stale XP flags
-    if(experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG) && (tBool ||
-        true)) {}
+    if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG) && (tBool || true)) {}
 
     // BUG: Diagnostic contains: Cleans stale XP flags
     experimentation.putToggleEnabled(TestExperimentName.STALE_FLAG);
@@ -130,9 +123,7 @@ class XPFlagCleanerPositiveCases {
     experimentation.putToggleDisabled(TestExperimentName.STALE_FLAG);
 
     // BUG: Diagnostic contains: Cleans stale XP flags
-    if(experimentation.isToggleDisabled(TestExperimentName.STALE_FLAG) && (tBool || true)) {}
-
-
+    if (experimentation.isToggleDisabled(TestExperimentName.STALE_FLAG) && (tBool || true)) {}
   }
 
   public int return_within_if_basic() {
@@ -167,7 +158,7 @@ class XPFlagCleanerPositiveCases {
         y++;
         return y;
       }
-      return y+10;
+      return y + 10;
     }
 
     if (x == 3) {
@@ -176,8 +167,8 @@ class XPFlagCleanerPositiveCases {
       if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
         z++;
       } else {
-        z = z*5;
-        return z+10;
+        z = z * 5;
+        return z + 10;
       }
       return z;
     }
@@ -192,65 +183,58 @@ class XPFlagCleanerPositiveCases {
   @Inject XPTest injectedExperimentsShouldBeDeleted;
 
   private int testRemovingInjectField() {
-     // BUG: Diagnostic contains: Cleans stale XP flags
-     if(injectedExperimentsShouldBeDeleted.isToggleEnabled(TestExperimentName.STALE_FLAG))
-        return 1;
-     else
-        return 2;
+    // BUG: Diagnostic contains: Cleans stale XP flags
+    if (injectedExperimentsShouldBeDeleted.isToggleEnabled(TestExperimentName.STALE_FLAG)) return 1;
+    else return 2;
   }
 
   @Inject XPTest injectedExperimentsMultipleUses;
 
   private void randomSet(XPTest x) {
-     injectedExperimentsMultipleUses = x;
+    injectedExperimentsMultipleUses = x;
   }
 
   private int testNotRemovingInjectField() {
-     // BUG: Diagnostic contains: Cleans stale XP flags
-     if(injectedExperimentsMultipleUses.isToggleEnabled(TestExperimentName.STALE_FLAG))
-        return 1;
-     else
-        return 2;
-
+    // BUG: Diagnostic contains: Cleans stale XP flags
+    if (injectedExperimentsMultipleUses.isToggleEnabled(TestExperimentName.STALE_FLAG)) return 1;
+    else return 2;
   }
 
-  @Provides public int unusedParamTestWithDeletion(XPTest x) {
-     // BUG: Diagnostic contains: Cleans stale XP flags
-     if(x.isToggleEnabled(TestExperimentName.STALE_FLAG))
-        return 1;
-     else
-        return 2;
+  @Provides
+  public int unusedParamTestWithDeletion(XPTest x) {
+    // BUG: Diagnostic contains: Cleans stale XP flags
+    if (x.isToggleEnabled(TestExperimentName.STALE_FLAG)) return 1;
+    else return 2;
   }
 
-  @Provides public int unusedParamTestWithoutDeletion(XPTest x) {
+  @Provides
+  public int unusedParamTestWithoutDeletion(XPTest x) {
 
-     if (x != null) {
-       // just another use to prevent deletion of this parameter.
-     }
+    if (x != null) {
+      // just another use to prevent deletion of this parameter.
+    }
 
-     // BUG: Diagnostic contains: Cleans stale XP flags
-     if(x.isToggleEnabled(TestExperimentName.STALE_FLAG))
-        return 1;
-     else
-        return 2;
+    // BUG: Diagnostic contains: Cleans stale XP flags
+    if (x.isToggleEnabled(TestExperimentName.STALE_FLAG)) return 1;
+    else return 2;
   }
 
   private void testMultipleCalls(int x) {
-     if (x > 0) {
-       // BUG: Diagnostic contains: Cleans stale XP flags
-       experimentation.includeEvent(TestExperimentName.STALE_FLAG);
-       // BUG: Diagnostic contains: Cleans stale XP flags
-       if(experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
-          // comment0
-          return;
-       } else {
-          // comment1
-          return;
-       }
-     }
+    if (x > 0) {
+      // BUG: Diagnostic contains: Cleans stale XP flags
+      experimentation.includeEvent(TestExperimentName.STALE_FLAG);
+      // BUG: Diagnostic contains: Cleans stale XP flags
+      if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
+        // comment0
+        return;
+      } else {
+        // comment1
+        return;
+      }
+    }
 
-     // do something here
-     return;
+    // do something here
+    return;
   }
 
   public int or_compounded_with_not(int x, boolean extra_toggle) {
@@ -266,7 +250,7 @@ class XPFlagCleanerPositiveCases {
     // BUG: Diagnostic contains: Cleans stale XP flags
     if (extra_toggle) {
       return 0;
-    } else if(experimentation.isToggleDisabled(TestExperimentName.STALE_FLAG)) {
+    } else if (experimentation.isToggleDisabled(TestExperimentName.STALE_FLAG)) {
       return 1;
     } else {
       return 2;
@@ -274,14 +258,32 @@ class XPFlagCleanerPositiveCases {
   }
 
   class XPTest {
-    public boolean isToggleEnabled(TestExperimentName x) { return true; }
-    public boolean putToggleEnabled(TestExperimentName x) { return true; }
-    public boolean includeEvent(TestExperimentName x) { return true; }
-    public boolean isToggleDisabled(TestExperimentName x) { return true; }
-    public boolean putToggleDisabled(TestExperimentName x) { return true; }
-    public boolean isFlagTreated(TestExperimentName x) { return true; }
-    public boolean isToggleInGroup(TestExperimentName x) { return true; }
+    public boolean isToggleEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean putToggleEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean includeEvent(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isToggleDisabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean putToggleDisabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isFlagTreated(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isToggleInGroup(TestExperimentName x) {
+      return true;
+    }
   }
-
-
 }

--- a/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesControl.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesControl.java
@@ -1,42 +1,38 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ * Copyright (c) 2019 Uber Technologies, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.piranha;
 
+import dagger.Provides;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import dagger.Module;
-import dagger.Provides;
 import javax.inject.Inject;
 
 class XPFlagCleanerPositiveCases {
 
   enum TestExperimentName {
-    // BUG: Diagnostic contains: Cleans stale XP flags
+  // BUG: Diagnostic contains: Cleans stale XP flags
   }
 
   enum AnotherTestExperimentName {
-    // BUG: Diagnostic contains: Cleans stale XP flags
+  // BUG: Diagnostic contains: Cleans stale XP flags
   }
 
   @Retention(RetentionPolicy.RUNTIME)
   public @interface Autorollout {
-     boolean staged() default false;
+    boolean staged() default false;
   }
 
   @Retention(RetentionPolicy.RUNTIME)
@@ -49,22 +45,19 @@ class XPFlagCleanerPositiveCases {
 
   private boolean tBool = false;
 
-  public void conditional_contains_stale_flag() {
-
-  }
+  public void conditional_contains_stale_flag() {}
 
   public void conditional_with_else_contains_stale_flag() {
-      System.out.println("Hi world");
+    System.out.println("Hi world");
   }
 
   public void complex_conditional_contains_stale_flag() {
-      System.out.println("Hello World");
+    System.out.println("Hello World");
   }
 
   public void other_api_stale_flag() {
     System.out.println("Hi world");
   }
-
 
   public void assignments_containing_stale_flag() {
     tBool = false;
@@ -76,7 +69,6 @@ class XPFlagCleanerPositiveCases {
     tBool = tBool;
 
     tBool = false;
-
   }
 
   public boolean return_contains_stale_flag() {
@@ -84,10 +76,10 @@ class XPFlagCleanerPositiveCases {
   }
 
   public void condexp_contains_stale_flag() {
-    tBool =  false;
+    tBool = false;
   }
 
-  public void misc_xp_apis_containing_stale_flag() { }
+  public void misc_xp_apis_containing_stale_flag() {}
 
   public int return_within_if_basic() {
     // BUG: Diagnostic contains: Cleans stale XP flags
@@ -101,18 +93,18 @@ class XPFlagCleanerPositiveCases {
     if (x == 1) return 76;
     if (x == 2) {
       int y = 3;
-      return y+10;
+      return y + 10;
     }
     if (x == 3) {
       int z = 4;
-      z = z*5;
-      return z+10;
+      z = z * 5;
+      return z + 10;
     }
     return 100;
   }
 
   private int testRemovingInjectField() {
-     return 2;
+    return 2;
   }
 
   @Inject XPTest injectedExperimentsMultipleUses;
@@ -122,33 +114,35 @@ class XPFlagCleanerPositiveCases {
   }
 
   private int testNotRemovingInjectField() {
-     // BUG: Diagnostic contains: Cleans stale XP flags
-     return 2;
+    // BUG: Diagnostic contains: Cleans stale XP flags
+    return 2;
   }
 
   // BUG: Diagnostic contains: Cleans stale XP flags
-  @Provides public int unusedParamTestWithDeletion() {
-     return 2;
+  @Provides
+  public int unusedParamTestWithDeletion() {
+    return 2;
   }
 
-  @Provides public int unusedParamTestWithoutDeletion(XPTest x) {
+  @Provides
+  public int unusedParamTestWithoutDeletion(XPTest x) {
 
-     if (x != null) {
-       // just another use to prevent deletion of this parameter.
-     }
+    if (x != null) {
+      // just another use to prevent deletion of this parameter.
+    }
 
-     return 2;
+    return 2;
   }
 
   // Based off D2516909
   private void testMultipleCalls(int x) {
-     if (x > 0) {
-       // comment1
-       return;
-     }
+    if (x > 0) {
+      // comment1
+      return;
+    }
 
-     // do something here
-     return;
+    // do something here
+    return;
   }
 
   public int or_compounded_with_not(int x, boolean extra_toggle) {
@@ -168,12 +162,32 @@ class XPFlagCleanerPositiveCases {
   }
 
   class XPTest {
-    public boolean isToggleEnabled(TestExperimentName x) { return true; }
-    public boolean putToggleEnabled(TestExperimentName x) { return true; }
-    public boolean includeEvent(TestExperimentName x) { return true; }
-    public boolean isToggleDisabled(TestExperimentName x) { return true; }
-    public boolean putToggleDisabled(TestExperimentName x) { return true; }
-    public boolean isFlagTreated(TestExperimentName x) { return true; }
-    public boolean isToggleInGroup(TestExperimentName x) { return true; }
+    public boolean isToggleEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean putToggleEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean includeEvent(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isToggleDisabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean putToggleDisabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isFlagTreated(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isToggleInGroup(TestExperimentName x) {
+      return true;
+    }
   }
 }

--- a/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesTreatment.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPFlagCleanerPositiveCasesTreatment.java
@@ -1,44 +1,39 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ * Copyright (c) 2019 Uber Technologies, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.piranha;
 
+import dagger.Provides;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import dagger.Module;
-import dagger.Provides;
 import javax.inject.Inject;
 
 class XPFlagCleanerPositiveCases {
 
   enum TestExperimentName {
-    // BUG: Diagnostic contains: Cleans stale XP flags
+  // BUG: Diagnostic contains: Cleans stale XP flags
   }
 
   enum AnotherTestExperimentName {
-    // BUG: Diagnostic contains: Cleans stale XP flags
+  // BUG: Diagnostic contains: Cleans stale XP flags
   }
 
   @Retention(RetentionPolicy.RUNTIME)
   public @interface Autorollout {
-     boolean staged() default false;
+    boolean staged() default false;
   }
-
 
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.METHOD})
@@ -83,23 +78,21 @@ class XPFlagCleanerPositiveCases {
   }
 
   public void condexp_contains_stale_flag() {
-    tBool =  true;
+    tBool = true;
   }
 
-  public void misc_xp_apis_containing_stale_flag() {  }
+  public void misc_xp_apis_containing_stale_flag() {}
 
   public int return_within_if_basic() {
     // BUG: Diagnostic contains: Cleans stale XP flags
     return 20;
   }
 
-
   public int return_within_if_additional(int x) {
     if (x == 0) {
       return 0;
     }
-    if (x == 1)
-      return 1;
+    if (x == 1) return 1;
     if (x == 2) {
       int y = 3;
       y++;
@@ -118,44 +111,46 @@ class XPFlagCleanerPositiveCases {
   public void annotation_test() {}
 
   private int testRemovingInjectField() {
-     return 1;
+    return 1;
   }
 
   @Inject XPTest injectedExperimentsMultipleUses;
 
   private void randomSet(XPTest x) {
-     injectedExperimentsMultipleUses = x;
+    injectedExperimentsMultipleUses = x;
   }
 
   private int testNotRemovingInjectField() {
-     // BUG: Diagnostic contains: Cleans stale XP flags
-     return 1;
+    // BUG: Diagnostic contains: Cleans stale XP flags
+    return 1;
   }
 
   // BUG: Diagnostic contains: Cleans stale XP flags
-  @Provides public int unusedParamTestWithDeletion() {
-     // BUG: Diagnostic contains: Cleans stale XP flags
-     return 1;
+  @Provides
+  public int unusedParamTestWithDeletion() {
+    // BUG: Diagnostic contains: Cleans stale XP flags
+    return 1;
   }
 
-  @Provides public int unusedParamTestWithoutDeletion(XPTest x) {
-     if (x != null) {
-       // just another use to prevent deletion of this parameter.
-     }
+  @Provides
+  public int unusedParamTestWithoutDeletion(XPTest x) {
+    if (x != null) {
+      // just another use to prevent deletion of this parameter.
+    }
 
-     // BUG: Diagnostic contains: Cleans stale XP flags
-     return 1;
+    // BUG: Diagnostic contains: Cleans stale XP flags
+    return 1;
   }
 
   // Based off D2516909
   private void testMultipleCalls(int x) {
-     if (x > 0) {
-       // comment0
-       return;
-     }
+    if (x > 0) {
+      // comment0
+      return;
+    }
 
-     // do something here
-     return;
+    // do something here
+    return;
   }
 
   public int or_compounded_with_not(int x, boolean extra_toggle) {
@@ -171,12 +166,32 @@ class XPFlagCleanerPositiveCases {
   }
 
   class XPTest {
-    public boolean isToggleEnabled(TestExperimentName x) { return true; }
-    public boolean putToggleEnabled(TestExperimentName x) { return true; }
-    public boolean includeEvent(TestExperimentName x) { return true; }
-    public boolean isToggleDisabled(TestExperimentName x) { return true; }
-    public boolean putToggleDisabled(TestExperimentName x) { return true; }
-    public boolean isFlagTreated(TestExperimentName x) { return true; }
-    public boolean isToggleInGroup(TestExperimentName x) { return true; }
+    public boolean isToggleEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean putToggleEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean includeEvent(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isToggleDisabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean putToggleDisabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isFlagTreated(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean isToggleInGroup(TestExperimentName x) {
+      return true;
+    }
   }
 }

--- a/java/piranha/src/test/resources/com/uber/piranha/XPTest.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPTest.java
@@ -1,26 +1,44 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ * Copyright (c) 2019 Uber Technologies, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.piranha;
 
 class XPTest {
-    public boolean isToggleEnabled(Object x) { return true; }
-    public boolean putToggleEnabled(Object x) { return true; }
-    public boolean includeEvent(Object x) { return true; }
-    public boolean isToggleDisabled(Object x) { return true; }
-    public boolean putToggleDisabled(Object x) { return true; }
-    public boolean isFlagTreated(Object x) { return true; }
-    public boolean isToggleInGroup(Object x, Object y) { return true; }
+  public boolean isToggleEnabled(Object x) {
+    return true;
+  }
+
+  public boolean putToggleEnabled(Object x) {
+    return true;
+  }
+
+  public boolean includeEvent(Object x) {
+    return true;
+  }
+
+  public boolean isToggleDisabled(Object x) {
+    return true;
+  }
+
+  public boolean putToggleDisabled(Object x) {
+    return true;
+  }
+
+  public boolean isFlagTreated(Object x) {
+    return true;
+  }
+
+  public boolean isToggleInGroup(Object x, Object y) {
+    return true;
+  }
 }

--- a/java/sample/src/main/java/com/uber/mylib/MyClass.java
+++ b/java/sample/src/main/java/com/uber/mylib/MyClass.java
@@ -2,9 +2,9 @@ package com.uber.mylib;
 
 // DO *NOT* MODIFY THIS FILE INSIDE main/java/src/...
 
-// This file is copied automatically from main/resources/com/uber/mylib/MyClass.bak before and after every build,
-// as part of the Piranha integration tests (the idea is not to leave the "cleaned" file lying around after Piranha
-// runs, as that pollutes the git staging area).
+// This file is copied automatically from main/resources/com/uber/mylib/MyClass.bak before and after
+// every build, as part of the Piranha integration tests (the idea is not to leave the "cleaned"
+// file lying around after Piranha runs, as that pollutes the git staging area).
 // If you need to change this file, change the copy inside main/resources/com/uber/mylib/MyClass.bak
 
 // After clean-up, this file must match main/resources/com/uber/mylib/MyClass.expect
@@ -19,23 +19,32 @@ public class MyClass {
   private XPTest expt;
 
   public void foo() {
-    if(expt.flagEnabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
+    if (expt.flagEnabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
       System.out.println("Hello World");
     }
   }
 
   public void bar() {
-    if(expt.flagDisabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
+    if (expt.flagDisabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
       System.out.println("Hi World");
     }
   }
 
   static class XPTest {
-    public boolean flagEnabled(TestExperimentName x) { return true; }
-    public boolean enableFlag(TestExperimentName x) { return true; }
-    public boolean disableFlag(TestExperimentName x) { return true; }
-    public boolean flagDisabled(TestExperimentName x) { return true; }
+    public boolean flagEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean enableFlag(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean disableFlag(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean flagDisabled(TestExperimentName x) {
+      return true;
+    }
   }
-
-
 }

--- a/java/sample/src/main/java/com/uber/mylib/MyClass.java
+++ b/java/sample/src/main/java/com/uber/mylib/MyClass.java
@@ -2,8 +2,10 @@ package com.uber.mylib;
 
 // DO *NOT* MODIFY THIS FILE INSIDE main/java/src/...
 
-// This file is copied automatically from main/resources/com/uber/mylib/MyClass.bak before and after every build,
-// as part of the Piranha integration tests (the idea is not to leave the "cleaned" file lying around after Piranha
+// This file is copied automatically from main/resources/com/uber/mylib/MyClass.bak before and after
+// every build,
+// as part of the Piranha integration tests (the idea is not to leave the "cleaned" file lying
+// around after Piranha
 // runs, as that pollutes the git staging area).
 // If you need to change this file, change the copy inside main/resources/com/uber/mylib/MyClass.bak
 
@@ -19,23 +21,32 @@ public class MyClass {
   private XPTest expt;
 
   public void foo() {
-    if(expt.flagEnabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
+    if (expt.flagEnabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
       System.out.println("Hello World");
     }
   }
 
   public void bar() {
-    if(expt.flagDisabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
+    if (expt.flagDisabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
       System.out.println("Hi World");
     }
   }
 
   static class XPTest {
-    public boolean flagEnabled(TestExperimentName x) { return true; }
-    public boolean enableFlag(TestExperimentName x) { return true; }
-    public boolean disableFlag(TestExperimentName x) { return true; }
-    public boolean flagDisabled(TestExperimentName x) { return true; }
+    public boolean flagEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean enableFlag(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean disableFlag(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean flagDisabled(TestExperimentName x) {
+      return true;
+    }
   }
-
-
 }

--- a/java/sample/src/main/java/com/uber/mylib/MyClass.java
+++ b/java/sample/src/main/java/com/uber/mylib/MyClass.java
@@ -2,10 +2,8 @@ package com.uber.mylib;
 
 // DO *NOT* MODIFY THIS FILE INSIDE main/java/src/...
 
-// This file is copied automatically from main/resources/com/uber/mylib/MyClass.bak before and after
-// every build,
-// as part of the Piranha integration tests (the idea is not to leave the "cleaned" file lying
-// around after Piranha
+// This file is copied automatically from main/resources/com/uber/mylib/MyClass.bak before and after every build,
+// as part of the Piranha integration tests (the idea is not to leave the "cleaned" file lying around after Piranha
 // runs, as that pollutes the git staging area).
 // If you need to change this file, change the copy inside main/resources/com/uber/mylib/MyClass.bak
 
@@ -21,32 +19,23 @@ public class MyClass {
   private XPTest expt;
 
   public void foo() {
-    if (expt.flagEnabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
+    if(expt.flagEnabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
       System.out.println("Hello World");
     }
   }
 
   public void bar() {
-    if (expt.flagDisabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
+    if(expt.flagDisabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
       System.out.println("Hi World");
     }
   }
 
   static class XPTest {
-    public boolean flagEnabled(TestExperimentName x) {
-      return true;
-    }
-
-    public boolean enableFlag(TestExperimentName x) {
-      return true;
-    }
-
-    public boolean disableFlag(TestExperimentName x) {
-      return true;
-    }
-
-    public boolean flagDisabled(TestExperimentName x) {
-      return true;
-    }
+    public boolean flagEnabled(TestExperimentName x) { return true; }
+    public boolean enableFlag(TestExperimentName x) { return true; }
+    public boolean disableFlag(TestExperimentName x) { return true; }
+    public boolean flagDisabled(TestExperimentName x) { return true; }
   }
+
+
 }

--- a/java/sample/src/main/resources/com/uber/mylib/MyClass.bak
+++ b/java/sample/src/main/resources/com/uber/mylib/MyClass.bak
@@ -2,9 +2,9 @@ package com.uber.mylib;
 
 // DO *NOT* MODIFY THIS FILE INSIDE main/java/src/...
 
-// This file is copied automatically from main/resources/com/uber/mylib/MyClass.bak before and after every build,
-// as part of the Piranha integration tests (the idea is not to leave the "cleaned" file lying around after Piranha
-// runs, as that pollutes the git staging area).
+// This file is copied automatically from main/resources/com/uber/mylib/MyClass.bak before and after
+// every build, as part of the Piranha integration tests (the idea is not to leave the "cleaned"
+// file lying around after Piranha runs, as that pollutes the git staging area).
 // If you need to change this file, change the copy inside main/resources/com/uber/mylib/MyClass.bak
 
 // After clean-up, this file must match main/resources/com/uber/mylib/MyClass.expect
@@ -19,23 +19,32 @@ public class MyClass {
   private XPTest expt;
 
   public void foo() {
-    if(expt.flagEnabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
+    if (expt.flagEnabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
       System.out.println("Hello World");
     }
   }
 
   public void bar() {
-    if(expt.flagDisabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
+    if (expt.flagDisabled(TestExperimentName.SAMPLE_STALE_FLAG)) {
       System.out.println("Hi World");
     }
   }
 
   static class XPTest {
-    public boolean flagEnabled(TestExperimentName x) { return true; }
-    public boolean enableFlag(TestExperimentName x) { return true; }
-    public boolean disableFlag(TestExperimentName x) { return true; }
-    public boolean flagDisabled(TestExperimentName x) { return true; }
+    public boolean flagEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean enableFlag(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean disableFlag(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean flagDisabled(TestExperimentName x) {
+      return true;
+    }
   }
-
-
 }

--- a/java/sample/src/main/resources/com/uber/mylib/MyClass.expect
+++ b/java/sample/src/main/resources/com/uber/mylib/MyClass.expect
@@ -2,9 +2,9 @@ package com.uber.mylib;
 
 // DO *NOT* MODIFY THIS FILE INSIDE main/java/src/...
 
-// This file is copied automatically from main/resources/com/uber/mylib/MyClass.bak before and after every build,
-// as part of the Piranha integration tests (the idea is not to leave the "cleaned" file lying around after Piranha
-// runs, as that pollutes the git staging area).
+// This file is copied automatically from main/resources/com/uber/mylib/MyClass.bak before and after
+// every build, as part of the Piranha integration tests (the idea is not to leave the "cleaned"
+// file lying around after Piranha runs, as that pollutes the git staging area).
 // If you need to change this file, change the copy inside main/resources/com/uber/mylib/MyClass.bak
 
 // After clean-up, this file must match main/resources/com/uber/mylib/MyClass.expect
@@ -27,11 +27,20 @@ public class MyClass {
   }
 
   static class XPTest {
-    public boolean flagEnabled(TestExperimentName x) { return true; }
-    public boolean enableFlag(TestExperimentName x) { return true; }
-    public boolean disableFlag(TestExperimentName x) { return true; }
-    public boolean flagDisabled(TestExperimentName x) { return true; }
+    public boolean flagEnabled(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean enableFlag(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean disableFlag(TestExperimentName x) {
+      return true;
+    }
+
+    public boolean flagDisabled(TestExperimentName x) {
+      return true;
+    }
   }
-
-
 }


### PR DESCRIPTION
This patch:

1. Runs GJF on all existing Java files under `java/`
2. Updates the sample app original and expected output under 
    `sample/src/main/resources/com/uber/mylib/`
3. Sets up the build so that GJF is added as a git pre-commit hook
    whenever `./gradlew` is run under `java/`
4. Adds `verGJF` to the travis build for PiranhaJava, which will 
    fail the build on any non-GJF formatted java files.