### PR TITLE
Adding support for control methods with more than 1 argument

### DIFF
--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -286,7 +286,7 @@ public class XPFlagCleaner extends BugChecker
         return API.UNKNOWN;
       }
 
-      if (mit.getArguments().size() == 1 || mit.getArguments().size() == 2) {
+      if (mit.getArguments().size() >= 1) {
         ExpressionTree arg = mit.getArguments().get(0);
         Symbol argSym = ASTHelpers.getSymbol(arg);
         if (isLiteralTreeAndMatchesFlagName(arg)

--- a/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
@@ -423,15 +423,15 @@ public class XPFlagCleanerTest {
               "     else { return \"Y\";}",
               " }",
               "}")
-              .addOutputLines(
-                      "XPFlagCleanerSinglePositiveCase.java",
-                      "package com.uber.piranha;",
-                      "class XPFlagCleanerSinglePositiveCase {",
-                      " private XPTest experimentation;",
-                      " public String evaluate() {",
-                      "  return \"Y\";",
-                      " }",
-                      "}");
+          .addOutputLines(
+              "XPFlagCleanerSinglePositiveCase.java",
+              "package com.uber.piranha;",
+              "class XPFlagCleanerSinglePositiveCase {",
+              " private XPTest experimentation;",
+              " public String evaluate() {",
+              "  return \"Y\";",
+              " }",
+              "}");
 
       bcr.doTest();
     } catch (ParseException pe) {

--- a/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
@@ -406,7 +406,7 @@ public class XPFlagCleanerTest {
 
     try {
       BugCheckerRefactoringTestHelper bcr =
-              BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+          BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
       bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 

--- a/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
@@ -397,6 +397,50 @@ public class XPFlagCleanerTest {
   }
 
   @Test
+  public void positiveCaseWithMultipleControlArguments() throws IOException {
+
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "true");
+    b.putFlag("Piranha:Config", "config/piranha.properties");
+
+    try {
+      BugCheckerRefactoringTestHelper bcr =
+              BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+      bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+      bcr = addHelperClasses(bcr);
+      bcr.addInputLines(
+              "XPFlagCleanerSinglePositiveCase.java",
+              "package com.uber.piranha;",
+              "class XPFlagCleanerSinglePositiveCase {",
+              "private static final String STALE_FLAG_CONSTANTS = \"STALE_FLAG\";",
+              " private XPTest experimentation;",
+              " public String evaluate() {",
+              "  // BUG: Diagnostic contains: Cleans stale XP flags",
+              "  if (experimentation.isToggleDisabled(STALE_FLAG_CONSTANTS, \"parameter1\", \"parameter2\")) { return \"X\"; }",
+              "     else { return \"Y\";}",
+              " }",
+              "}")
+              .addOutputLines(
+                      "XPFlagCleanerSinglePositiveCase.java",
+                      "package com.uber.piranha;",
+                      "class XPFlagCleanerSinglePositiveCase {",
+                      " private XPTest experimentation;",
+                      " public String evaluate() {",
+                      "  return \"Y\";",
+                      " }",
+                      "}");
+
+      bcr.doTest();
+    } catch (ParseException pe) {
+      pe.printStackTrace();
+      assert_().fail("Incorrect parameters passed to the checker");
+    }
+  }
+
+  @Test
   public void positiveCaseWithFlagNameAsStringLiteral() throws IOException {
 
     ErrorProneFlags.Builder b = ErrorProneFlags.builder();

--- a/java/piranha/src/test/resources/com/uber/piranha/XPTest.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPTest.java
@@ -30,6 +30,10 @@ class XPTest {
     return true;
   }
 
+  public boolean isToggleDisabled(Object x, Object y, Object z) {
+    return true;
+  }
+
   public boolean putToggleDisabled(Object x) {
     return true;
   }


### PR DESCRIPTION
Control methods with more than 1 argument
`getldvalue(STALE_FLAG_NAME, paramter1, parameter 2)`