### PR TITLE
Enable NullAway for the PiranhaJava core.

### DIFF
--- a/java/gradle/dependencies.gradle
+++ b/java/gradle/dependencies.gradle
@@ -28,8 +28,10 @@ def build = [
     errorProneJavac         : "com.google.errorprone:javac:9+181-r4173-1",
     errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
     gradleErrorPronePlugin  : "net.ltgt.gradle:gradle-errorprone-plugin:0.0.16",
-    jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",
     googleJsonSimple        : "com.googlecode.json-simple:json-simple:1.1.1",
+    jsr305Annotations       : "com.google.code.findbugs:jsr305:3.0.2",
+    inferAnnotations        : "com.facebook.infer.annotation:infer-annotation:0.11.0",
+    nullaway                : "com.uber.nullaway:nullaway:0.7.10",
 ]
 
 def test = [

--- a/java/piranha/build.gradle
+++ b/java/piranha/build.gradle
@@ -20,6 +20,8 @@ plugins {
   id "java"
   // For code coverage:
   id 'jacoco'
+  // For NullAway, just in case
+  id "net.ltgt.errorprone"
 }
 
 sourceCompatibility = "1.8"
@@ -37,6 +39,24 @@ dependencies {
     testCompile(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }
+
+    // Check with NullAway
+    annotationProcessor deps.build.nullaway
+    compileOnly deps.build.jsr305Annotations
+    compileOnly deps.build.inferAnnotations // @Initializer annotation
+
+    errorprone deps.build.errorProneCore
+    errorproneJavac deps.build.errorProneJavac
+}
+
+tasks.withType(JavaCompile) {
+  // remove the if condition if you want to run NullAway on test code
+  if (!name.toLowerCase().contains("test")) {
+    options.errorprone {
+      check("NullAway", CheckSeverity.ERROR)
+      option("NullAway:AnnotatedPackages", "com.uber")
+    }
+  }
 }
 
 javadoc {

--- a/java/piranha/src/main/java/com/uber/piranha/PiranhaMethodRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/PiranhaMethodRecord.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import java.text.ParseException;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /** A class repesenting a method configuration record from properties.json */
 final class PiranhaMethodRecord {
@@ -81,6 +82,7 @@ final class PiranhaMethodRecord {
    * @param key - key to check the corresponding value
    * @return String if value is a non-empty string, null otherwise
    */
+  @Nullable
   private static String getValueStringFromMap(Map<String, Object> map, String key) {
     Object value = map.get(key);
     if (value instanceof String && !value.equals("")) {
@@ -96,6 +98,7 @@ final class PiranhaMethodRecord {
    * @param map - map corresponding to a method property
    * @return argumentIndex if argument index is a non-negative integer, null otherwise
    */
+  @Nullable
   private static Integer getArgumentIndexFromMap(Map<String, Object> map) {
     Object value = map.get(ARGUMENT_INDEX_KEY);
     if (value instanceof Long) {


### PR DESCRIPTION
This adds NullAway to our build for PiranhaJava code, excluding test code and sample projects for now.

No NPEs found, but there are some preconditions that was good to document/encode.