### PR TITLE
Ignore missing headers with PiranhaObjC analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ A few additional links on Piranha:
 
 ## Support
 
-Please feel free to [open a GitHub issue](https://github.com/uber/piranha/issues) if you have any questions on how to use Piranha.  
+If you have any questions on how to use Piranha, please feel free to reach out to us on the [gitter channel](https://gitter.im/uber/piranha?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge). For bugs and enhancement requests, [open a GitHub issue](https://github.com/uber/piranha/issues).
 
 ## Contributors
 
 We'd love for you to contribute to Piranha!  Please note that once
 you create a pull request, you will be asked to sign our [Uber Contributor License Agreement](https://cla-assistant.io/uber/piranha).
+
+We are also looking for contributions to extend Piranha to other languages (C++, C#, JavaScript, Kotlin). 
 
 ## License
 Piranha is licensed under the Apache 2.0 license.  See the LICENSE file for more information.

--- a/objc/src/XPFlagRefactoring/XPFlagRefactoring.cpp
+++ b/objc/src/XPFlagRefactoring/XPFlagRefactoring.cpp
@@ -564,12 +564,17 @@ private:
 
 class XPRefactorConsumer : public ASTConsumer {
 public:
-  XPRefactorConsumer(string flagName, FlagType flagType,
+  XPRefactorConsumer(CompilerInstance &CI, string flagName, FlagType flagType,
                      bool shouldHandleMethodImpl)
       : HandlerForIf(flagName, flagType), HandlerForMethodImpl(flagName),
         HandlerForMethodInvocation(flagName), HandlerForDeclRef(flagName),
         HandlerForBinOp(flagName, flagType),
         HandlerForConditionalOp(flagName, flagType) {
+
+   // ignore missing headers
+   if(CI.hasPreprocessor()) {
+     CI.getPreprocessor().SetSuppressIncludeNotFoundError(true);
+   }
 
     // matches if([self.....<flagName>])
     Matcher.addMatcher(
@@ -714,10 +719,10 @@ private:
 
 class XPRefactorASTAction : public PluginASTAction {
 public:
-  virtual unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &Compiler,
+  virtual unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
                                                     llvm::StringRef InFile) {
     return unique_ptr<ASTConsumer>(
-        new XPRefactorConsumer(flagName, flagType, shouldHandleMethodImpl));
+        new XPRefactorConsumer(CI, flagName, flagType, shouldHandleMethodImpl));
   }
 
   bool ParseArgs(const CompilerInstance &CI, const vector<string> &args) {

--- a/objc/tests/OptimisticNamed.m
+++ b/objc/tests/OptimisticNamed.m
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
+#include "NonExistentHeader.h" // non existent header
 
 
 @protocol UBAdvancedExperimenting

--- a/objc/tests/OptimisticNamed.m.expected
+++ b/objc/tests/OptimisticNamed.m.expected
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
+#include "NonExistentHeader.h" // non existent header
 
 
 @protocol UBAdvancedExperimenting


### PR DESCRIPTION
When header files are missing, PiranhaObjC fails to refactor. See #65. 
This fixes the issue by ignoring missing headers as part of refactoring. 
Also, updated README. 