### PR TITLE
[PiranhaJava] Upgrade Error Prone dependency to 2.4.0

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -4,7 +4,7 @@
 
 ### Overview
 
-Piranha requires that you build your code with [Error Prone](http://errorprone.info), version 2.3.2 or higher.  See the [Error Prone documentation](http://errorprone.info/docs/installation) for instructions on getting started with Error Prone and integration with your build system.  
+Piranha requires that you build your code with [Error Prone](http://errorprone.info), version 2.4.0 or higher.  See the [Error Prone documentation](http://errorprone.info/docs/installation) for instructions on getting started with Error Prone and integration with your build system.  
 
 While not required, we strongly recommend that you use Piranha in combination with an automated code formatter, such as [Google Java Format](https://github.com/google/google-java-format) running as a pre-commit hook. This is because Piranha will transform code without any particular way to configure code style guidelines into the tool directly. While we strive to produce clean and readable refactorings by default, no commitment exists to any particular whitespace, line length, or styling behavior, nor even consistency between Piranha minor versions.
 
@@ -24,7 +24,7 @@ targetCompatibility = "1.8"
 
 dependencies {
   annotationProcessor "com.uber.piranha:piranha:0.1.0"
-  errorprone "com.google.errorprone:error_prone_core:2.3.2"
+  errorprone "com.google.errorprone:error_prone_core:2.4.0"
   errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 }
 
@@ -220,7 +220,7 @@ This example is present in the [sample](https://github.com/uber/piranha/tree/mas
             <path>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
-              <version>2.3.2</version>
+              <version>2.4.0</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/java/gradle/dependencies.gradle
+++ b/java/gradle/dependencies.gradle
@@ -15,7 +15,7 @@
  */
 
 def versions = [
-    errorProne             : "2.3.2",
+    errorProne             : "2.4.0",
 ]
 
 def apt = [

--- a/java/piranha/src/main/java/com/uber/piranha/PiranhaMethodRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/PiranhaMethodRecord.java
@@ -1,7 +1,6 @@
 package com.uber.piranha;
 
 import com.google.common.collect.ImmutableMap;
-import java.text.ParseException;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -117,7 +116,8 @@ final class PiranhaMethodRecord {
    * @param methodPropertyEntry The decoded json entry (as a Map of property names to values)
    * @param isArgumentIndexOptional Whether argumentIdx should be treated as optional
    * @return A PiranhaMethodRecord corresponding to the given map/json record.
-   * @throws ParseException
+   * @throws PiranhaConfigurationException if there was any issue reading or parsing the
+   *     configuration file.
    */
   static PiranhaMethodRecord parseFromJSONPropertyEntryMap(
       Map<String, Object> methodPropertyEntry, boolean isArgumentIndexOptional)

--- a/java/piranha/src/main/java/com/uber/piranha/UsageCounter.java
+++ b/java/piranha/src/main/java/com/uber/piranha/UsageCounter.java
@@ -39,17 +39,6 @@ public final class UsageCounter {
     /* Helper class only, not instantiable */
   }
 
-  private static boolean symbolHasSuppressUnusedCheckerWarningsAnnotation(
-      Symbol symbol, String checkerName) {
-    SuppressWarnings annotation = symbol.getAnnotation(SuppressWarnings.class);
-    if (annotation != null) {
-      for (String s : annotation.value()) {
-        if (s.equals(checkerName)) return true;
-      }
-    }
-    return false;
-  }
-
   public static ImmutableMap<Symbol, CounterData> getUsageCounts(VisitorState state) {
     return getUsageCounts(state, state.getPath());
   }
@@ -71,7 +60,6 @@ public final class UsageCounter {
 
     for (VariableTree decl : callScanner.declaredParamVars.keySet()) {
       Symbol s = ASTHelpers.getSymbol(decl);
-      Symbol.MethodSymbol mSym = callScanner.declaredParamVars.get(decl);
       CounterData counterData =
           new CounterData(
               DeclType.PARAM,

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -640,8 +640,8 @@ public class XPFlagCleaner extends BugChecker
     return Description.NO_MATCH;
   }
 
-  @SuppressWarnings(
-      "TreeToString") // Likely worth fixing, not sure of a better way to match import FQNs.
+  // Likely worth fixing, not sure of a better way to match import FQNs:
+  @SuppressWarnings("TreeToString")
   @Override
   public Description matchImport(ImportTree importTree, VisitorState visitorState) {
     if (importTree.isStatic()) {
@@ -699,8 +699,7 @@ public class XPFlagCleaner extends BugChecker
   }
 
   // Pretty sure the Tree.toString() API is our best option here, but be aware of the issues listed
-  // in:
-  // https://errorprone.info/bugpattern/TreeToString
+  // in: https://errorprone.info/bugpattern/TreeToString
   // e.g. comments and whitespace might be removed, which could be retrieved through
   // `VisitorState#getSourceForNode`
   // (but that makes the actual AST rewriting harder).

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -72,7 +72,23 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-/** @author murali@uber.com (Murali Krishna Ramanathan) */
+/**
+ * This is the core PiranhaJava checker and code rewriting class.
+ *
+ * <p>This checker iterates over the AST of each compilation unit, performing the following steps:
+ * a) Replaces occurrences of flag checking APIs with boolean constants based on Piranha's
+ * configuration and flag name arguments, and removes outdated flag setting operations. b)
+ * Simplifies boolean expressions including these new constants. c) Deletes code that has become
+ * unreachable due to conditional guards which can no longer evaluate to true. d) Deletes outdated
+ * enums and classes representing the removed flags and/or their treatment conditions.
+ *
+ * <p>In some cases, Piranha/XPFlagCleaner will want to delete a whole file. Since EP has no
+ * facilities for creating a patch that removes an entire file, it will instead replace its contents
+ * by an empty enum/class and add a special comment indicating it must be removed. Automated scripts
+ * using this code can then perform the actual file deletion previous to creating a PR or diff.
+ *
+ * @author murali@uber.com (Murali Krishna Ramanathan)
+ */
 @AutoService(BugChecker.class)
 @BugPattern(
     name = "Piranha",
@@ -104,7 +120,6 @@ public class XPFlagCleaner extends BugChecker
       ImmutableSet.of("control", "enabled", "disabled", "treatment", "treated");
 
   private static final int DONTCARE = -1;
-  private static final int ZERO = 0;
   private static final String TRUE = "true";
   private static final String FALSE = "false";
   private static final String EMPTY = "";
@@ -411,7 +426,7 @@ public class XPFlagCleaner extends BugChecker
   /**
    * Checks for {@link Symbol} and the flag name
    *
-   * @param argSym
+   * @param argSym a symbol
    * @return True if matches. Otherwise false
    */
   private boolean isSymbolAndMatchesFlagName(Symbol argSym) {
@@ -421,7 +436,7 @@ public class XPFlagCleaner extends BugChecker
   /**
    * Checks for {@link com.sun.tools.javac.code.Symbol.VarSymbol} and the flag name
    *
-   * @param argSym
+   * @param argSym a symbol
    * @return True if matches. Otherwise false
    */
   private boolean isVarSymbolAndMatchesFlagName(Symbol argSym) {
@@ -435,7 +450,7 @@ public class XPFlagCleaner extends BugChecker
   /**
    * Checks for {@link LiteralTree} and the flag name
    *
-   * @param arg
+   * @param arg an expression tree
    * @return True if matches. Otherwise false
    */
   private boolean isLiteralTreeAndMatchesFlagName(ExpressionTree arg) {
@@ -625,6 +640,8 @@ public class XPFlagCleaner extends BugChecker
     return Description.NO_MATCH;
   }
 
+  @SuppressWarnings(
+      "TreeToString") // Likely worth fixing, not sure of a better way to match import FQNs.
   @Override
   public Description matchImport(ImportTree importTree, VisitorState visitorState) {
     if (importTree.isStatic()) {
@@ -681,6 +698,13 @@ public class XPFlagCleaner extends BugChecker
     return updateCode(x, tree, tree, state);
   }
 
+  // Pretty sure the Tree.toString() API is our best option here, but be aware of the issues listed
+  // in:
+  // https://errorprone.info/bugpattern/TreeToString
+  // e.g. comments and whitespace might be removed, which could be retrieved through
+  // `VisitorState#getSourceForNode`
+  // (but that makes the actual AST rewriting harder).
+  @SuppressWarnings("TreeToString")
   @Override
   public Description matchBinary(BinaryTree tree, VisitorState state) {
     if (overLaps(tree, state)) {
@@ -825,7 +849,10 @@ public class XPFlagCleaner extends BugChecker
         for (ExpressionTree et : at.getArguments()) {
           if (et.getKind() == Kind.ASSIGNMENT) {
             AssignmentTree assn = (AssignmentTree) et;
-            if (assn.getExpression().toString().endsWith(xpFlagName)) {
+            if (ASTHelpers.getSymbol(assn.getExpression())
+                .getQualifiedName()
+                .toString()
+                .endsWith(xpFlagName)) {
               Description.Builder builder = buildDescription(tree);
               SuggestedFix.Builder fixBuilder = SuggestedFix.builder();
               if (isTreated) {

--- a/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
@@ -38,32 +38,37 @@ public class XPFlagCleanerTest {
 
   @Before
   public void setup() {
-    compilationHelper = CompilationTestHelper.newInstance(XPFlagCleaner.class, getClass());
-    compilationHelper.setArgs(Arrays.asList("-d", temporaryFolder.getRoot().getAbsolutePath()));
+    compilationHelper =
+        CompilationTestHelper.newInstance(XPFlagCleaner.class, getClass())
+            .setArgs(Arrays.asList("-d", temporaryFolder.getRoot().getAbsolutePath()));
   }
 
   @Test
   public void test_xpflagsPositiveCases() {
-    compilationHelper.setArgs(
-        Arrays.asList(
-            "-d",
-            temporaryFolder.getRoot().getAbsolutePath(),
-            "-XepOpt:Piranha:FlagName=STALE_FLAG",
-            "-XepOpt:Piranha:IsTreated=true",
-            "-XepOpt:Piranha:Config=config/properties.json"));
-    compilationHelper.addSourceFile("XPFlagCleanerPositiveCases.java").doTest();
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:Piranha:FlagName=STALE_FLAG",
+                "-XepOpt:Piranha:IsTreated=true",
+                "-XepOpt:Piranha:Config=config/properties.json"))
+        .addSourceFile("XPFlagCleanerPositiveCases.java")
+        .doTest();
   }
 
   @Test
   public void test_xpflagsNegativeCases() {
-    compilationHelper.setArgs(
-        Arrays.asList(
-            "-d",
-            temporaryFolder.getRoot().getAbsolutePath(),
-            "-XepOpt:Piranha:FlagName=STALE_FLAG",
-            "-XepOpt:Piranha:IsTreated=true",
-            "-XepOpt:Piranha:Config=config/properties.json"));
-    compilationHelper.addSourceFile("XPFlagCleanerNegativeCases.java").doTest();
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:Piranha:FlagName=STALE_FLAG",
+                "-XepOpt:Piranha:IsTreated=true",
+                "-XepOpt:Piranha:Config=config/properties.json"))
+        .addSourceFile("XPFlagCleanerNegativeCases.java")
+        .doTest();
   }
 
   @Test
@@ -77,13 +82,10 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-
-    BugCheckerRefactoringTestHelper.ExpectOutput eo =
-        bcr.addInput("XPFlagCleanerPositiveCases.java");
-    eo.addOutput("XPFlagCleanerPositiveCasesTreatment.java");
-
-    bcr.doTest();
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInput("XPFlagCleanerPositiveCases.java")
+        .addOutput("XPFlagCleanerPositiveCasesTreatment.java")
+        .doTest();
   }
 
   @Test
@@ -98,7 +100,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
 
@@ -153,9 +155,8 @@ public class XPFlagCleanerTest {
             " public String groupToString() {",
             "  return \"A\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   @Test
@@ -170,7 +171,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
 
@@ -224,9 +225,8 @@ public class XPFlagCleanerTest {
             " public String groupToString() {",
             "  return \"Treated\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   @Test
@@ -240,13 +240,10 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-
-    BugCheckerRefactoringTestHelper.ExpectOutput eo =
-        bcr.addInput("XPFlagCleanerPositiveCases.java");
-    eo.addOutput("XPFlagCleanerPositiveCasesControl.java");
-
-    bcr.doTest();
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInput("XPFlagCleanerPositiveCases.java")
+        .addOutput("XPFlagCleanerPositiveCasesControl.java")
+        .doTest();
   }
 
   private BugCheckerRefactoringTestHelper addHelperClasses(BugCheckerRefactoringTestHelper bcr)
@@ -265,7 +262,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
 
@@ -299,9 +296,8 @@ public class XPFlagCleanerTest {
             " public boolean return_contains_stale_flag() {",
             "  return true;",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   @Test
@@ -315,13 +311,10 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-
-    BugCheckerRefactoringTestHelper.ExpectOutput eo =
-        bcr.addInput("XPFlagCleanerNegativeCases.java");
-
-    eo.expectUnchanged();
-    bcr.doTest();
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInput("XPFlagCleanerNegativeCases.java")
+        .expectUnchanged()
+        .doTest();
   }
 
   @Test
@@ -335,7 +328,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -358,9 +351,8 @@ public class XPFlagCleanerTest {
             " public String evaluate() {",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   @Test
@@ -374,7 +366,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -396,9 +388,8 @@ public class XPFlagCleanerTest {
             " public String evaluate() {",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   @Test
@@ -412,7 +403,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -434,9 +425,8 @@ public class XPFlagCleanerTest {
             "  if (experimentation.isToggleDisabled(\"NOT_STALE_FLAG\")) { return \"X\"; }",
             "     else { return \"Y\";}",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   @Test
@@ -450,7 +440,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -474,9 +464,8 @@ public class XPFlagCleanerTest {
             "  if (experimentation.isToggleDisabled(STALE_FLAG_CONSTANTS)) { return \"X\"; }",
             "     else { return \"Y\";}",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   @Test
@@ -490,13 +479,10 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-
-    BugCheckerRefactoringTestHelper.ExpectOutput eo =
-        bcr.addInput("XPFlagCleanerPositiveCases.java");
-    eo.addOutput("XPFlagCleanerPositiveCasesTreatment.java");
-
-    bcr.doTest();
+    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath())
+        .addInput("XPFlagCleanerPositiveCases.java")
+        .addOutput("XPFlagCleanerPositiveCasesTreatment.java")
+        .doTest();
   }
 
   /*
@@ -517,7 +503,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
             "XPFlagCleanerSinglePositiveCase.java",
@@ -544,9 +530,8 @@ public class XPFlagCleanerTest {
             "     else { int d = 2;}",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -566,7 +551,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -594,9 +579,8 @@ public class XPFlagCleanerTest {
             "     else { int d = 2;}",
             "     return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -617,7 +601,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -642,9 +626,8 @@ public class XPFlagCleanerTest {
             "     else { int b = 2;}",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -665,7 +648,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -690,9 +673,8 @@ public class XPFlagCleanerTest {
             "     else { int b = 2;}",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -712,7 +694,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -747,9 +729,8 @@ public class XPFlagCleanerTest {
             "  int g = 1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -770,9 +751,9 @@ public class XPFlagCleanerTest {
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
     // can be removed after Piranha implements two pass analysis
-    bcr.allowBreakingChanges();
+    bcr = bcr.allowBreakingChanges();
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -808,9 +789,8 @@ public class XPFlagCleanerTest {
             "  int g = 1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -830,7 +810,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -858,9 +838,8 @@ public class XPFlagCleanerTest {
             "  int c = 1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -881,9 +860,9 @@ public class XPFlagCleanerTest {
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
     // can be removed after Piranha implements two pass analysis
-    bcr.allowBreakingChanges();
+    bcr = bcr.allowBreakingChanges();
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -912,9 +891,8 @@ public class XPFlagCleanerTest {
             "  int c = 1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -934,9 +912,9 @@ public class XPFlagCleanerTest {
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
     // can be removed after Piranha implements two pass analysis
-    bcr.allowBreakingChanges();
+    bcr = bcr.allowBreakingChanges();
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -972,9 +950,8 @@ public class XPFlagCleanerTest {
             "  int c = 1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -993,7 +970,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1033,9 +1010,8 @@ public class XPFlagCleanerTest {
             "  if (experimentation.isToggleDisabled(STALE_FLAG_CONSTANTS)) { return \"X\"; }",
             "     else { return \"Y\";}",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1054,7 +1030,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1089,9 +1065,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1110,7 +1085,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1148,9 +1123,8 @@ public class XPFlagCleanerTest {
             "  if (experimentation.isToggleDisabled(\"STALE_FLAG\")) { return \"X\"; }",
             "     else { return \"Y\";}",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1169,7 +1143,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1204,9 +1178,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1224,7 +1197,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1262,9 +1235,8 @@ public class XPFlagCleanerTest {
             "  if (experimentation.isToggleDisabled(\"STALE_FLAG\")) { return \"X\"; }",
             "     else { return \"Y\";}",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1283,7 +1255,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1318,9 +1290,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1339,10 +1310,10 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     // can be removed after Piranha implements two pass analysis
-    bcr.allowBreakingChanges();
+    bcr = bcr.allowBreakingChanges();
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1378,9 +1349,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1398,7 +1368,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1438,9 +1408,8 @@ public class XPFlagCleanerTest {
             "  if (experimentation.isToggleDisabled(STALE_FLAG_CONSTANTS)) { return \"X\"; }",
             "     else { return \"Y\";}",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1458,10 +1427,10 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     // can be removed after Piranha implements two pass analysis
-    bcr.allowBreakingChanges();
+    bcr = bcr.allowBreakingChanges();
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1497,9 +1466,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1517,7 +1485,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1557,9 +1525,8 @@ public class XPFlagCleanerTest {
             "  if (experimentation.isToggleDisabled(STALE_FLAG_CONSTANTS)) { return \"X\"; }",
             "     else { return \"Y\";}",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1579,10 +1546,10 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     // can be removed after Piranha implements two pass analysis
-    bcr.allowBreakingChanges();
+    bcr = bcr.allowBreakingChanges();
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1617,9 +1584,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1640,7 +1606,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1676,9 +1642,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1696,7 +1661,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1734,9 +1699,8 @@ public class XPFlagCleanerTest {
             "  if (experimentation.isToggleDisabled(\"STALE_FLAG\")) { return \"X\"; }",
             "     else { return \"Y\";}",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1756,7 +1720,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1790,9 +1754,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1813,7 +1776,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1847,9 +1810,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1868,7 +1830,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1903,9 +1865,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1924,10 +1885,10 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     // can be removed after Piranha implements two pass analysis
-    bcr.allowBreakingChanges();
+    bcr = bcr.allowBreakingChanges();
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -1963,9 +1924,8 @@ public class XPFlagCleanerTest {
             "  int c =1;",
             "  return \"Y\";",
             " }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*
@@ -1983,7 +1943,7 @@ public class XPFlagCleanerTest {
     BugCheckerRefactoringTestHelper bcr =
         BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
 
-    bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = addHelperClasses(bcr);
     bcr.addInputLines(
@@ -2027,9 +1987,8 @@ public class XPFlagCleanerTest {
             "  if (experimentation.isToggleDisabled(\"STALE_FLAG\")) { return \"X\"; }",
             "     else { return \"Y\";}",
             "  }",
-            "}");
-
-    bcr.doTest();
+            "}")
+        .doTest();
   }
 
   /*


### PR DESCRIPTION
This upgrades both the version of Error Prone used to check our code,
as well as the version PiranhaJava depens on.

See https://github.com/google/error-prone/releases/tag/v2.4.0

This PR also fixes most of the issues raised by the new EP version
in our codebase (mostly around fluent test APIs and javadoc).