### PR TITLE
[PiranhaJava] Fail hard in the presence of configuration errors.

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -191,6 +191,8 @@ public class MyClass {
 
 This example is present in the [sample](https://github.com/uber/piranha/tree/master/java/sample/) directory. 
 
+IMPORTANT: Please note that the gradle build script included in that directory assumes that the sample will be built as part of the full Piranha Java build project (i.e. it depends on other gradle files within that project and assumes some setup done by them). If you wish to build the `sample` project as a standalone, you might need to recreate the `build.gradle` file included there using the instructions elsewhere in this readme.
+
 ### Maven Instructions
 
 * For the example Piranha configuration discussed above, follow steps given for the ErrorProne [example](https://github.com/google/error-prone/blob/master/examples/maven/pom.xml) to setup the `pom.xml` to run with ErrorProne.

--- a/java/piranha/src/main/java/com/uber/piranha/PiranhaConfigurationException.java
+++ b/java/piranha/src/main/java/com/uber/piranha/PiranhaConfigurationException.java
@@ -1,6 +1,10 @@
 package com.uber.piranha;
 
-public class PiranhaConfigurationException extends Exception {
+/**
+ * An exception thrown when Piranha's configuration is invalid. This is a runtime exception and will
+ * crash piranha, as the tool can't proceed with incorrect configuration.
+ */
+final class PiranhaConfigurationException extends RuntimeException {
 
   public PiranhaConfigurationException(String message) {
     super(message);

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -253,7 +253,8 @@ public class XPFlagCleaner extends BugChecker
         }
         configMethodProperties = builder.build();
       } catch (IOException fnfe) {
-        throw new PiranhaConfigurationException("Error reading config file. " + fnfe);
+        throw new PiranhaConfigurationException(
+            "Error reading config file " + Paths.get(configFile).toAbsolutePath() + " : " + fnfe);
       } catch (ParseException pe) {
         String extraWarning = "";
         if (configFile.endsWith(".properties")) {

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -130,7 +130,6 @@ public class XPFlagCleaner extends BugChecker
    */
   private boolean initialized = false;
 
-  private boolean disabled = false;
   @Nullable private ErrorProneFlags flags = null;
 
   private String xpFlagName = "_xpflag_dummy";
@@ -330,16 +329,12 @@ public class XPFlagCleaner extends BugChecker
   @Override
   public Description matchCompilationUnit(
       CompilationUnitTree compilationUnitTree, VisitorState visitorState) {
-    if (!initialized && !disabled) {
+    if (!initialized) {
       Preconditions.checkNotNull(
           flags,
           "The configuration-aware constructor should have been called at this point, and flags set to "
               + "a non-null value.");
-      try {
-        init(flags);
-      } catch (PiranhaConfigurationException pe) {
-        disabled = true;
-      }
+      init(flags);
     }
     if (countsCollected) {
       // Clear out this info
@@ -367,7 +362,7 @@ public class XPFlagCleaner extends BugChecker
       }
       MemberSelectTree mst = (MemberSelectTree) mit.getMethodSelect();
       String methodName = mst.getIdentifier().toString();
-      if (!disabled && configMethodProperties.containsKey(methodName)) {
+      if (configMethodProperties.containsKey(methodName)) {
         return getXPAPI(mit, configMethodProperties.get(methodName));
       }
     }

--- a/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
@@ -2213,10 +2213,8 @@ public class XPFlagCleanerTest {
   @Test
   public void testPiranhaCrashOnNoConfig() {
     // Error Prone turns Runtime Exceptions inside EP into blocks of text (including the exception
-    // trace)
-    // inside a new AssertionError exception. This is actually looking for
-    // PiranhaConfigurationException
-    // inside XPFlagCleaner.
+    // trace) inside a new AssertionError exception. This is actually looking for
+    // PiranhaConfigurationException inside XPFlagCleaner.
     expectedEx.expect(AssertionError.class);
     expectedEx.expectMessage(
         "An unhandled exception was thrown by the Error Prone static analysis plugin");
@@ -2244,10 +2242,8 @@ public class XPFlagCleanerTest {
   @Test
   public void testPiranhaCrashOnOldConfig() {
     // Error Prone turns Runtime Exceptions inside EP into blocks of text (including the exception
-    // trace)
-    // inside a new AssertionError exception. This is actually looking for
-    // PiranhaConfigurationException
-    // inside XPFlagCleaner.
+    // trace) inside a new AssertionError exception. This is actually looking for
+    // PiranhaConfigurationException inside XPFlagCleaner.
     expectedEx.expect(AssertionError.class);
     expectedEx.expectMessage(
         "An unhandled exception was thrown by the Error Prone static analysis plugin");

--- a/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
@@ -1930,69 +1930,6 @@ public class XPFlagCleanerTest {
 
   /*
    * Uses "properties_test_invalid.json" instead of "properties.json".
-   * In it, the required top-level "methodProperties" is not present.
-   * As a result, refactoring will not be carried out, except for unreachable code.
-   * */
-  @Test
-  public void refactorUnreachableWhenInvalidConfigFile() throws IOException {
-    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
-    b.putFlag("Piranha:FlagName", "STALE_FLAG");
-    b.putFlag("Piranha:IsTreated", "true");
-    b.putFlag("Piranha:Config", "src/test/resources/config/invalid/properties_test_invalid.json");
-
-    BugCheckerRefactoringTestHelper bcr =
-        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
-
-    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
-
-    bcr = addHelperClasses(bcr);
-    bcr.addInputLines(
-            "XPFlagCleanerSinglePositiveCase.java",
-            "package com.uber.piranha;",
-            "class XPFlagCleanerSinglePositiveCase {",
-            " private XPTest experimentation;",
-            " public String evaluate() {",
-            "  if (experimentation.isToggleEnabled(\"STALE_FLAG\")) { int a = 1; }",
-            "     else { int b = 2;}",
-            "  if (experimentation.isFlagTreated(\"STALE_FLAG\")) { int c = 1; }",
-            "     else { int d = 2;}",
-            "  if (true) {",
-            "    int q = 1;",
-            "  }",
-            "  else {",
-            "    int w = 2;",
-            "  }",
-            "  if (false) {",
-            "    int e = 1;",
-            "  }",
-            "  else {",
-            "    int r = 2;",
-            "  }",
-            "  if (experimentation.isToggleDisabled(\"STALE_FLAG\")) { return \"X\"; }",
-            "     else { return \"Y\";}",
-            "  }",
-            "}")
-        .addOutputLines(
-            "XPFlagCleanerSinglePositiveCase.java",
-            "package com.uber.piranha;",
-            "class XPFlagCleanerSinglePositiveCase {",
-            " private XPTest experimentation;",
-            " public String evaluate() {",
-            "  if (experimentation.isToggleEnabled(\"STALE_FLAG\")) { int a = 1; }",
-            "     else { int b = 2;}",
-            "  if (experimentation.isFlagTreated(\"STALE_FLAG\")) { int c = 1; }",
-            "     else { int d = 2;}",
-            "  int q = 1;",
-            "  int r = 2;",
-            "  if (experimentation.isToggleDisabled(\"STALE_FLAG\")) { return \"X\"; }",
-            "     else { return \"Y\";}",
-            "  }",
-            "}")
-        .doTest();
-  }
-
-  /*
-   * Uses "properties_test_invalid.json" instead of "properties.json".
    * When "methodProperties" is not specified,
    * raise PiranhaConfigurationException with appropriate exception message.
    * */
@@ -2267,5 +2204,69 @@ public class XPFlagCleanerTest {
 
     XPFlagCleaner flagCleaner = new XPFlagCleaner();
     flagCleaner.init(b.build());
+  }
+
+  /**
+   * This test ensures 'PiranhaConfigurationException' is propagated as en error if the
+   * configuration file is missing
+   */
+  @Test
+  public void testPiranhaCrashOnNoConfig() {
+    // Error Prone turns Runtime Exceptions inside EP into blocks of text (including the exception
+    // trace)
+    // inside a new AssertionError exception. This is actually looking for
+    // PiranhaConfigurationException
+    // inside XPFlagCleaner.
+    expectedEx.expect(AssertionError.class);
+    expectedEx.expectMessage(
+        "An unhandled exception was thrown by the Error Prone static analysis plugin");
+    expectedEx.expectMessage(
+        "PiranhaConfigurationException: Error reading config file. java.io.IOException: Provided config file not found");
+
+    CompilationTestHelper compilationHelper =
+        CompilationTestHelper.newInstance(XPFlagCleaner.class, getClass());
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:Piranha:FlagName=noop",
+                "-XepOpt:Piranha:IsTreated=true",
+                "-XepOpt:Piranha:Config=src/test/resources/config/nonexistent_file"))
+        .addSourceLines("Dummy.java", "package com.uber.piranha;", "class Dummy {", "}")
+        .doTest();
+  }
+
+  /**
+   * This test ensures 'PiranhaConfigurationException' is propagated as en error if the
+   * configuration file is using the outdated .properties format
+   */
+  @Test
+  public void testPiranhaCrashOnOldConfig() {
+    // Error Prone turns Runtime Exceptions inside EP into blocks of text (including the exception
+    // trace)
+    // inside a new AssertionError exception. This is actually looking for
+    // PiranhaConfigurationException
+    // inside XPFlagCleaner.
+    expectedEx.expect(AssertionError.class);
+    expectedEx.expectMessage(
+        "An unhandled exception was thrown by the Error Prone static analysis plugin");
+    expectedEx.expectMessage(
+        "PiranhaConfigurationException: Invalid or incorrectly formatted config file. ");
+    expectedEx.expectMessage(
+        "WARNING: With version 0.1.0, PiranhaJava has changed its configuration file format to json");
+
+    CompilationTestHelper compilationHelper =
+        CompilationTestHelper.newInstance(XPFlagCleaner.class, getClass());
+    compilationHelper
+        .setArgs(
+            Arrays.asList(
+                "-d",
+                temporaryFolder.getRoot().getAbsolutePath(),
+                "-XepOpt:Piranha:FlagName=noop",
+                "-XepOpt:Piranha:IsTreated=true",
+                "-XepOpt:Piranha:Config=src/test/resources/config/invalid/piranha.properties"))
+        .addSourceLines("Dummy.java", "package com.uber.piranha;", "class Dummy {", "}")
+        .doTest();
   }
 }

--- a/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
@@ -2218,8 +2218,8 @@ public class XPFlagCleanerTest {
     expectedEx.expect(AssertionError.class);
     expectedEx.expectMessage(
         "An unhandled exception was thrown by the Error Prone static analysis plugin");
-    expectedEx.expectMessage(
-        "PiranhaConfigurationException: Error reading config file. java.io.IOException: Provided config file not found");
+    expectedEx.expectMessage("PiranhaConfigurationException: Error reading config file");
+    expectedEx.expectMessage("java.io.IOException: Provided config file not found");
 
     CompilationTestHelper compilationHelper =
         CompilationTestHelper.newInstance(XPFlagCleaner.class, getClass());

--- a/java/sample/README.md
+++ b/java/sample/README.md
@@ -1,0 +1,5 @@
+NOTE: This project is currently configured to build as part of the larger `piranha/java` build. If you wish to build this sample as a standalone gradle project, you need to:
+
+1) Copy this directory and its contents outside of the Piranha project structure.
+2) Edit or make a new `build.gradle` following the instructions on the [main PiranhaJava README.md](../README.md) file.
+3) Run `gradle wrapper` and then `./gradlew build` ("The recommended way to execute any Gradle build is with the help of the Gradle Wrapper" - [Gradle User Guide](https://docs.gradle.org/current/userguide/gradle_wrapper.html))


### PR DESCRIPTION
This makes PiranhaConfigurationException a runtime exception,
and gets rid of the `disabled` checker state. In general, it doesn't
make much sense to run Piranha with invalid configuration and
it's better to show the issue to users as visibly as possible,
since either way the tool behavior will be broken in this case.

This resolves #76 and #77.