### PR TITLE
[PiranhaJava] Update RELEASING.md instructions.

### DIFF
--- a/java/RELEASING.md
+++ b/java/RELEASING.md
@@ -4,10 +4,10 @@ Releasing
  1. Change the version in `gradle.properties` to a non-SNAPSHOT version.
  2. Update the `CHANGELOG.md` for the impending release.
  3. Update the `README.md` with the new version.
- 4. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
- 5. `git tag -a vX.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
+ 4. `git commit -am "[PiranhaJava] Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
+ 5. `git tag -a vX.Y.Z-java -m "PiranhaJava Version X.Y.Z"` (where X.Y.Z is the new version)
  6. `./gradlew clean uploadArchives`
  7. Update the `gradle.properties` to the next SNAPSHOT version.
- 8. `git commit -am "Prepare next development version."`
+ 8. `git commit -am "[PiranhaJava] Prepare next development version."`
  9. `git push && git push --tags`
  10. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.


### PR DESCRIPTION
The new instructions ensure that `[PiranhaJava]` appears
in commits related to releasing a new PiranhaJava version.
Additionally, tags for PiranhaJava version X.Y.Z now
include `-java`.

This is also intended as a template for releasing instructions
for Piranha versions for other supported languages, in terms
of commit titles and git tags.