### PR TITLE
[PiranhaSwift] Update PiranhaSwift to use SwiftSyntax 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ matrix:
 
     - language: swift
       os: osx
-      osx_image: xcode11.3
-      env: SWIFT=5.1
+      osx_image: xcode11.6
+      env: SWIFT=5.2
       before_script:
         - cd swift/
       script:

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .macOS(.v10_14),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50100.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50200.0")),
     ],
     targets: [
         .target(

--- a/swift/src/CleanupStaleFlags/StaleFlagCleanerLauncher.swift
+++ b/swift/src/CleanupStaleFlags/StaleFlagCleanerLauncher.swift
@@ -19,7 +19,7 @@ import SwiftSyntax
 
 // groupname is optional. the other arguments are necessary
 class StaleFlagCleanerLauncher: CommandLauncher {
-    let command: Command = .cleanupStaleFlags
+     let command: Command = .cleanupStaleFlags
 
     func launch(_ args: [String]) throws {
         var sourceFile = URL(fileURLWithPath: "")

--- a/swift/tests/control.swift
+++ b/swift/tests/control.swift
@@ -139,6 +139,7 @@ class SwiftExamples {
         y = false
         y = false
         y = x
+        print("1")
         print("not treated / control")
         return
     }
@@ -245,10 +246,9 @@ class SwiftExamples {
             print("control1")
         }
 
-        var v = false
-        v = true
+        v1 = true
 
-        v = cachedExperiments?.isInControlGroup(forExperiment: ExperimentNamesSwift.test_second_experiment) ?? false
+        v2 = cachedExperiments?.isInControlGroup(forExperiment: ExperimentNamesSwift.test_second_experiment) ?? false
     }
 
     private let conj1: Bool

--- a/swift/tests/testfile.swift
+++ b/swift/tests/testfile.swift
@@ -127,6 +127,8 @@ class SwiftExamples {
     private let fieldY: Bool
     private let fieldZ: Bool
 
+    private lazy var fieldA: Bool = !cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment)
+
     func test_expressions() {
 
         if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) {
@@ -196,6 +198,12 @@ class SwiftExamples {
         y = cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment)
         y = cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) && x
         y = cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) || x
+        
+        if fieldA {
+            print("1")
+        } else {
+            print("2")
+        }
 
         guard cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) else {
             print("not treated / control")
@@ -215,7 +223,7 @@ class SwiftExamples {
         xyz = getParam(abc)
         getParam(p1)
         getParam(p2)
-        getParam(xyz) 
+        getParam(xyz)
     }
 
 
@@ -484,9 +492,8 @@ class SwiftExamples {
         }
 
         var v = cachedExperiments?.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) ?? false
-        v = cachedExperiments?.isInControlGroup(forExperiment: ExperimentNamesSwift.test_experiment) ?? false
-
-        v = cachedExperiments?.isInControlGroup(forExperiment: ExperimentNamesSwift.test_second_experiment) ?? false
+        v1 = cachedExperiments?.isInControlGroup(forExperiment: ExperimentNamesSwift.test_experiment) ?? false
+        v2 = cachedExperiments?.isInControlGroup(forExperiment: ExperimentNamesSwift.test_second_experiment) ?? false
     }
 
     private let conj1: Bool
@@ -505,7 +512,7 @@ class SwiftExamples {
     private var shouldDoSomething: Bool {
         return cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment)
     }
-
+    
     private let engineeringFlags: [ExperimentNamesLoyalty] = [
         .loyalty_credits_purchase_selection_rib_refactor,
         .loyalty_card_banner_impression_fix,

--- a/swift/tests/treated.swift
+++ b/swift/tests/treated.swift
@@ -174,9 +174,10 @@ class SwiftExamples {
         y = true
         y = x
         y = true
-
+        print("2")
+        
         print("treated")
-
+      
         while true {
 
         }
@@ -330,10 +331,9 @@ class SwiftExamples {
             print("control1")
         }
 
-        var v = true
-        v = false
+        v1 = false
 
-        v = cachedExperiments?.isInControlGroup(forExperiment: ExperimentNamesSwift.test_second_experiment) ?? false
+        v2 = cachedExperiments?.isInControlGroup(forExperiment: ExperimentNamesSwift.test_second_experiment) ?? false
     }
 
     private let conj1: Bool


### PR DESCRIPTION
1. Upgrade PiranhaSwift to use SwiftSyntax 5.2
2. Fixes a couple of refactoring bugs: 
     ` private lazy var xyz = cachedExperiments.isInControlGroup(...)` is correctly refactored. (this was completely discarded earlier)
     `private lazy var xyz = !cachedExperiments.....` is also correctly refactored. (earlier, only the RHS was refactored).  