### PR TITLE
[PiranhaJava] Fix issue with code not being deleted across files

### DIFF
--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -359,6 +359,7 @@ public class XPFlagCleaner extends BugChecker
       init(flags);
     }
     if (disabled) return Description.NO_MATCH;
+    endPos = DONTCARE; // Important: reset end position for calculating overlaps between files/CUs
     if (countsCollected) {
       // Clear out this info
       countsCollected = false;


### PR DESCRIPTION
This fixes an issue where the end position of overlaps, as calculated
by `overLaps(...)` was sometimes not being cleared from one compilation
unit (java file) to the next. This resulted in refactorings being
skipped for the first X lines of the second (and third, and so on)
Java file being processed, where X is the last line of the the
last refactoring of the first file.

In particular, for files with similar uses of flags, this resulted
in only the uses within the first file being analyzed being properly
cleaned.

The fix is simply to reset `endPos` at the beginning of any new
compilation unit. This PR additionally adds a regression unit
test for the same issue.