### PR TITLE
[PiranhaJava] Fix XP flag symbol matching on imports.

### DIFF
--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -671,7 +671,9 @@ public class XPFlagCleaner extends BugChecker
       Tree importIdentifier = importTree.getQualifiedIdentifier();
       if (importIdentifier.getKind().equals(Kind.MEMBER_SELECT)) {
         MemberSelectTree memberSelectTree = (MemberSelectTree) importIdentifier;
-        if (memberSelectTree.getIdentifier().toString().endsWith(xpFlagName)
+        String[] fullyQualifiedNameParts = memberSelectTree.getIdentifier().toString().split("\\.");
+        String importSimpleName = fullyQualifiedNameParts[fullyQualifiedNameParts.length - 1];
+        if (importSimpleName.equals(xpFlagName)
             || (treatmentGroupsEnum != null
                 && memberSelectTree.getExpression().toString().startsWith(treatmentGroupsEnum))) {
           return buildDescription(importTree)

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -870,7 +870,7 @@ public class XPFlagCleaner extends BugChecker
   }
 
   private boolean isCheckedXPFlagName(ExpressionTree tree) {
-    return ASTHelpers.getSymbol(tree).getQualifiedName().toString().endsWith(xpFlagName);
+    return ASTHelpers.getSymbol(tree).getSimpleName().contentEquals(xpFlagName);
   }
 
   @Override

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -672,6 +672,10 @@ public class XPFlagCleaner extends BugChecker
       if (importIdentifier.getKind().equals(Kind.MEMBER_SELECT)) {
         MemberSelectTree memberSelectTree = (MemberSelectTree) importIdentifier;
         String[] fullyQualifiedNameParts = memberSelectTree.getIdentifier().toString().split("\\.");
+        Preconditions.checkArgument(
+            fullyQualifiedNameParts.length > 0,
+            "String.split should never produce a zero-length array. "
+                + "The worst case should be the original string wrapped in a length 1 array.");
         String importSimpleName = fullyQualifiedNameParts[fullyQualifiedNameParts.length - 1];
         if (importSimpleName.equals(xpFlagName)
             || (treatmentGroupsEnum != null

--- a/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/XPFlagCleanerTest.java
@@ -2524,4 +2524,51 @@ public class XPFlagCleanerTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void testIgnoresPrefixMatchFlag() throws IOException {
+
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "false");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr = addHelperClasses(bcr);
+    bcr.addInputLines(
+            "TestExperimentName.java",
+            "package com.uber.piranha;",
+            "public enum TestExperimentName {",
+            " STALE_FLAG,",
+            " OTHER_STALE_FLAG",
+            "}")
+        .addOutputLines(
+            "TestExperimentName.java",
+            "package com.uber.piranha;",
+            "public enum TestExperimentName {",
+            " OTHER_STALE_FLAG",
+            "}")
+        .addInputLines(
+            "TestClassFullMatch.java",
+            "package com.uber.piranha;",
+            "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
+            "class TestClassFullMatch { }")
+        .addOutputLines(
+            "TestClassFullMatch.java", "package com.uber.piranha;", "class TestClassFullMatch { }")
+        .addInputLines(
+            "TestClassPartialMatch.java",
+            "package com.uber.piranha;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_STALE_FLAG;",
+            "class TestClassPartialMatch { }")
+        .addOutputLines(
+            "TestClassPartialMatch.java",
+            "package com.uber.piranha;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_STALE_FLAG;",
+            "class TestClassPartialMatch { }")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This fixes a bug where deleting flag `FOO` would cause
imports of unrelated flags ending in `FOO` as suffix
(e.g. `SOMETHING_ELSE_RELATED_TO_FOO`) being delteted.

This would result in failed builds, since everywhere else
we are correctly identifying the symbol `FOO`, so uses
of `SOMETHING_ELSE_RELATED_TO_FOO` would not have been
deleted. This was arguably preferable to an unrelated flag
being incorrectly and silently removed.

Either way, this PR resolves the issue by matching flag
symbol imports by their simple name (ie. the last component
of the Fully Qualified Name).