### PR TITLE
[PiranhaSwift] Handle string literal flags

### DIFF
--- a/swift/src/CleanupStaleFlags/StaleFlagCleaner.swift
+++ b/swift/src/CleanupStaleFlags/StaleFlagCleaner.swift
@@ -185,10 +185,16 @@ class XPFlagCleaner: SyntaxRewriter {
     private func match(in node: FunctionCallExprSyntax,
                        name: String, at index: Int) -> Bool {
         if node.argumentList.count > 0,
-            let argument = argument(arglist: node.argumentList, index),
-            let expr = MemberAccessExprSyntax.init(Syntax(argument.expression)),
-            expr.name.description == name {
-            return true
+            let argument = argument(arglist: node.argumentList, index) {
+            if let expr = MemberAccessExprSyntax.init(Syntax(argument.expression)),
+               expr.name.description == name {
+               return true
+            }
+            if let expr = StringLiteralExprSyntax.init(Syntax(argument.expression)) {
+                if name == expr.description.replacingOccurrences(of: "\"", with: "") {
+                   return true
+               }
+            }
         }
         return false
     }

--- a/swift/tests/control.swift
+++ b/swift/tests/control.swift
@@ -52,6 +52,7 @@ extension ParamManager {
 protocol CachedExperimenting {
     func isInControlGroup(forExperiment experimentKey: ExperimentKeying) -> Bool
     func isTreated(forExperiment experimentKey: ExperimentKeying) -> Bool
+    func isTreated(for experimentKey: String) -> Bool
     func addTreatedExperiment(forExperiment experimentKey: ExperimentKeying) -> Bool
     func removeTreatedExperiment(forExperiment experimentKey: ExperimentKeying) -> Bool
     func isInTreatmentGroup(treatmentGroup treatmentGroupKey: TreatmentGroupKeying, forExperiment experimentKey: ExperimentKeying) -> Bool
@@ -265,6 +266,10 @@ class SwiftExamples {
     // Test for T2606011
     private var shouldDoSomething: Bool {
         return false
+    }
+
+    func testStringFlag() {
+        print("string constant 2")
     }
 
     private let engineeringFlags: [ExperimentNamesLoyalty] = [

--- a/swift/tests/testfile.swift
+++ b/swift/tests/testfile.swift
@@ -55,6 +55,7 @@ extension ParamManager {
 protocol CachedExperimenting {
     func isInControlGroup(forExperiment experimentKey: ExperimentKeying) -> Bool
     func isTreated(forExperiment experimentKey: ExperimentKeying) -> Bool
+    func isTreated(for experimentKey: String) -> Bool
     func addTreatedExperiment(forExperiment experimentKey: ExperimentKeying) -> Bool
     func removeTreatedExperiment(forExperiment experimentKey: ExperimentKeying) -> Bool
     func isInTreatmentGroup(treatmentGroup treatmentGroupKey: TreatmentGroupKeying, forExperiment experimentKey: ExperimentKeying) -> Bool
@@ -511,6 +512,18 @@ class SwiftExamples {
     // Test for T2606011
     private var shouldDoSomething: Bool {
         return cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment)
+    }
+
+
+    func testStringFlag() {
+        if cachedExperiments.isTreated(for: "test_experiment") {
+           print("string constant 1")
+        }
+
+        if !cachedExperiments.isTreated(for: "test_experiment") {
+           print("string constant 2")
+        }
+
     }
     
     private let engineeringFlags: [ExperimentNamesLoyalty] = [

--- a/swift/tests/treated.swift
+++ b/swift/tests/treated.swift
@@ -52,6 +52,7 @@ extension ParamManager {
 protocol CachedExperimenting {
     func isInControlGroup(forExperiment experimentKey: ExperimentKeying) -> Bool
     func isTreated(forExperiment experimentKey: ExperimentKeying) -> Bool
+    func isTreated(for experimentKey: String) -> Bool
     func addTreatedExperiment(forExperiment experimentKey: ExperimentKeying) -> Bool
     func removeTreatedExperiment(forExperiment experimentKey: ExperimentKeying) -> Bool
     func isInTreatmentGroup(treatmentGroup treatmentGroupKey: TreatmentGroupKeying, forExperiment experimentKey: ExperimentKeying) -> Bool
@@ -349,6 +350,10 @@ class SwiftExamples {
     // Test for T2606011
     private var shouldDoSomething: Bool {
         return true
+    }
+
+    func testStringFlag() {
+       print("string constant 1")
     }
 
     private let engineeringFlags: [ExperimentNamesLoyalty] = [


### PR DESCRIPTION
This change will enable cleaning up code where flags are used as string literals as part of the API. 