### PR TITLE
Piranha Swift properties.json

### DIFF
--- a/swift/Examples/sample.swift
+++ b/swift/Examples/sample.swift
@@ -1,0 +1,32 @@
+/**
+ *    Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+
+
+// Simple flag cleanup in conditional
+if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.featureFlag) {
+    f1();
+ } else {
+    f2();
+ }
+
+// Assignment cleanup
+var a = isToggleDisabled(ExperimentNamesSwift.featureFlag)
+if(a) {
+   f1()
+} else {
+   f2()
+}

--- a/swift/README.md
+++ b/swift/README.md
@@ -18,7 +18,7 @@ USAGE: <piranha_exe> cleanup-stale-flags [--source-file <source-file>] [--config
 
 OPTIONS:
   -s, --source-file <source-file>
-                          Input Source File that needs to run piranha 
+                          Input source file for Piranha
   -c, --config-file <config-file>
                           Path of configuration file for Piranha 
   -f, --flag <flag>       Name of the stale flag 
@@ -26,6 +26,68 @@ OPTIONS:
   -t, --treated           If this option is supplied, the flag is treated, otherwise it is control. 
   -h, --help              Show help information.
 ```
+
+### Example 
+
+Consider the following properties file `properties.json`.
+
+```json
+{
+  "methodProperties": [
+    {
+      "methodName": "isToggleDisabled",
+      "flagType": "control",
+      "flagIndex": 0
+    },
+    {
+      "methodName": "isFlagTreated",
+      "flagType": "treated",
+      "flagIndex": 0
+    },
+    {
+      "methodName": "isToggleEnabled",
+      "flagType": "treated",
+      "flagIndex": 0
+    }
+  ]
+}
+```
+
+This specifies a list of flag APIs each of which return a boolean value. It is assumed that a method returns `true` iff the `flagType` specified in the properties file matches the flag behaviour specified at runtime. For example, if the flag behavior is `treated`, `isFlagTreated(flag)` will return `true` and `isToggleDisabled(flag)` will return `false`.
+
+The following code in `Examples/sample.swift` contains the stale flag `featureFlag`
+
+```swift
+// Simple flag cleanup in conditional
+if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.featureFlag) {
+    f1();
+ } else {
+    f2();
+ }
+
+// Assignment cleanup
+var a = isToggleDisabled(ExperimentNamesSwift.featureFlag)
+if(a) {
+   f1()
+} else {
+   f2()
+}
+
+```
+When this file is run through Piranha with the command 
+
+```
+piranha_exe cleanup-stale-flags -c properties.json -s Examples/sample.swift -f featureFlag --treated
+```
+
+It yields the following output:
+
+```swift
+f1()
+f2()
+```
+
+Note that code-style and comments are preserved wherever possible by default.
 
 
 

--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
@@ -18,23 +18,7 @@ import Foundation
 import SwiftSyntax
 
 class XPFlagCleaner: SyntaxRewriter {
-    // specifies the type of APIs
-    enum API {
-        case isTreated
-        case isControl
-        case isInControlGroup
-        case isInTreatmentGroup
-        case isTesting
-        case isUnknown
-    }
-
-    struct FlagAPI {
-        var api: String
-        var type: API
-        var flagIndex: Int?
-        var groupIndex: Int?
-    }
-
+    
     // specifies the value returned by evaluating the expression
     private enum Value {
         case isTrue
@@ -50,13 +34,11 @@ class XPFlagCleaner: SyntaxRewriter {
         case unknown
     }
 
-    private var configFile: URL
-    private var configurationParsed: Bool = false
+    private let config: PiranhaConfig
     
-    private var SELFDOT: String = "self."
-    private var UNKNOWN: String = "unknown"
+    private let SELFDOT: String = "self."
+    private let UNKNOWN: String = "unknown"
 
-    private var flagAPIArr: [FlagAPI] = []
     private var valueMap = [String: Value]()
     private var deepCleanMap = [String: Value]()
     private var fieldMap = [String: Bool]()
@@ -71,74 +53,17 @@ class XPFlagCleaner: SyntaxRewriter {
     private var isDeepCleanPass: Bool
     private var shouldDeepClean: Bool
 
-    init(with configFile: URL, flag flagName: String, behavior isTreated: Bool, group groupName: String) {
-        self.configFile = configFile
+    init(with config: PiranhaConfig,
+         flag flagName: String,
+         behavior isTreated: Bool,
+         group groupName: String) {
+        self.config = config
         self.flagName = flagName
         self.isTreated = isTreated
         self.groupName = groupName
 
         isDeepCleanPass = false
         shouldDeepClean = false
-    }
-
-    /* Format of config file
-     apiType1=api1(_,flagName,groupName,_);api2(flagName,...)
-     apiType2=api2(_,_,groupName)
-     ...
-     */
-
-    private func parseConfiguration() {
-        configurationParsed = true
-        var flagIndex: Int?
-        var groupIndex: Int?
-        var type: API
-
-        do {
-            let configText = try String(contentsOf: configFile, encoding: .utf8)
-            // each line contains some apiType.
-            let lineArr = configText.components(separatedBy: .newlines)
-            for line in lineArr {
-                let lineInfo = line.components(separatedBy: "=")
-                guard lineInfo.count >= 2 else { break }
-
-                switch lineInfo[0] {
-                case "treatedMethods": type = API.isTreated
-                case "controlGroupMethods": type = API.isInControlGroup
-                case "treatmentGroupMethods": type = API.isInTreatmentGroup
-                case "testingMethods": type = API.isTesting
-                default: type = API.isUnknown
-                }
-
-                // for each method defined for this api type,
-                // extract the funcName, flagIndex (where flagName is present) and
-                // groupIndex (if groupName is present) and then add this to
-                // the flagAPIarr containing the configuration
-                for method in lineInfo[1].components(separatedBy: ";") {
-                    let funcInfo = method.components(separatedBy: "(")
-                    guard funcInfo.count >= 2 else { break }
-                    let funcName = funcInfo[0]
-                    let parameters = funcInfo[1].components(separatedBy: ")")[0].components(separatedBy: ",")
-                    flagIndex = nil
-                    groupIndex = nil
-
-                    for (loopindex, parameter) in parameters.enumerated() {
-                        switch parameter {
-                        case "flagName": flagIndex = loopindex
-                        case "groupName": groupIndex = loopindex
-                        default:
-                            if parameter != "_" {
-                                print("Incorrect configuration")
-                                exit(-1)
-                            }
-                        }
-                    }
-                    flagAPIArr.append(FlagAPI(api: funcName, type: type, flagIndex: flagIndex, groupIndex: groupIndex))
-                }
-            }
-        } catch {
-            print("Configuration error.")
-            exit(-1)
-        }
     }
 
     // checks for the binary operator to handle and/or
@@ -200,25 +125,22 @@ class XPFlagCleaner: SyntaxRewriter {
     }
 
     // gets the type of the flag API
-    private func flagApiType(of node: FunctionCallExprSyntax) -> API {
-        if !configurationParsed {
-            parseConfiguration()
-        }
-        for element in flagAPIArr {
-            if node.calledExpression.description.hasSuffix(element.api),
-                element.flagIndex != nil,
-                match(in: node, name: flagName, at: element.flagIndex!) {
+    private func flagApiType(of node: FunctionCallExprSyntax) -> Method.FlagType? {
+        for method in config.methods {
+            if node.calledExpression.description.hasSuffix(method.methodName),
+               method.flagIndex != nil,
+                match(in: node, name: flagName, at: method.flagIndex!) {
                 var foundMatch = true
                 // if there is a groupIndex and it doesn't match with groupName,
-                if element.groupIndex != nil, !match(in: node, name: groupName, at: element.groupIndex!) {
+                if method.groupIndex != nil, !match(in: node, name: groupName, at: method.groupIndex!) {
                     foundMatch = false
                 }
                 if foundMatch {
-                    return element.type
+                    return method.flagType
                 }
             }
         }
-        return API.isUnknown
+        return nil
     }
 
     // appends the input statements to the result node and returns the updated result node along with information on whether the last node is a return
@@ -327,11 +249,14 @@ class XPFlagCleaner: SyntaxRewriter {
             }
         } else if let functionCallExprNode = FunctionCallExprSyntax.init(node) {
             // handles flag API calls
-            let api = flagApiType(of: functionCallExprNode)
+            guard let api = flagApiType(of: functionCallExprNode) else {
+                return cache(expression: Syntax(functionCallExprNode),
+                             with: Value.isBot)
+            }
             var value = Value.isBot
-            if (api == API.isTreated) || (api == API.isInTreatmentGroup) {
+            if api == .treated || api == .treatmentGroup {
                 value = (isTreated ? Value.isTrue : Value.isFalse)
-            } else if (api == API.isInControlGroup) || (api == API.isControl) {
+            } else if api == .controlGroup || api == .control {
                 value = (isTreated ? Value.isFalse : Value.isTrue)
             }
             return cache(expression: Syntax(functionCallExprNode), with: value)
@@ -562,7 +487,7 @@ class XPFlagCleaner: SyntaxRewriter {
         if rhs.count == 1 {
             if let node = element(from: exprlist, at: 2),
                 let callExpr = FunctionCallExprSyntax.init(Syntax(node)) {
-                if flagApiType(of: callExpr) == API.isTesting {
+                if flagApiType(of: callExpr) == .testing {
                     return SyntaxFactory.makeBlankExprList()
                 } else {
                     let rhsValue = evaluate(expression: Syntax(node))
@@ -792,7 +717,7 @@ class XPFlagCleaner: SyntaxRewriter {
                     return visit(SyntaxFactory.makeBlankVariableDecl())
                 }
                 if let value = FunctionCallExprSyntax.init(Syntax(rhs.value)) {
-                    if (flagApiType(of: value) == API.isTesting) || (evaluate(expression: Syntax(rhs.value)) != Value.isBot) {
+                    if (flagApiType(of: value) == .testing) || (evaluate(expression: Syntax(rhs.value)) != Value.isBot) {
                         return visit(SyntaxFactory.makeBlankVariableDecl())
                     }
                 }
@@ -850,7 +775,7 @@ class XPFlagCleaner: SyntaxRewriter {
                     }
                 }
             } else if let callNode = FunctionCallExprSyntax.init(statement.item),
-                flagApiType(of: callNode) == API.isTesting {
+                      flagApiType(of: callNode) == .testing {
                 // do nothing, as the test API needs to be discarded
             } else {
                 newBody = newBody.appending(statement)

--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
@@ -128,8 +128,7 @@ class XPFlagCleaner: SyntaxRewriter {
     private func flagApiType(of node: FunctionCallExprSyntax) -> Method.FlagType? {
         for method in config.methods {
             if node.calledExpression.description.hasSuffix(method.methodName),
-               method.flagIndex != nil,
-                match(in: node, name: flagName, at: method.flagIndex!) {
+                match(in: node, name: flagName, at: method.flagIndex) {
                 var foundMatch = true
                 // if there is a groupIndex and it doesn't match with groupName,
                 if method.groupIndex != nil, !match(in: node, name: groupName, at: method.groupIndex!) {
@@ -249,14 +248,11 @@ class XPFlagCleaner: SyntaxRewriter {
             }
         } else if let functionCallExprNode = FunctionCallExprSyntax.init(node) {
             // handles flag API calls
-            guard let api = flagApiType(of: functionCallExprNode) else {
-                return cache(expression: Syntax(functionCallExprNode),
-                             with: Value.isBot)
-            }
             var value = Value.isBot
-            if api == .treated || api == .treatmentGroup {
+            let api = flagApiType(of: functionCallExprNode)
+            if api == .treated  {
                 value = (isTreated ? Value.isTrue : Value.isFalse)
-            } else if api == .controlGroup || api == .control {
+            } else if api == .control {
                 value = (isTreated ? Value.isFalse : Value.isTrue)
             }
             return cache(expression: Syntax(functionCallExprNode), with: value)

--- a/swift/Sources/PiranhaKit/InputCommand/PiranhaCommand.swift
+++ b/swift/Sources/PiranhaKit/InputCommand/PiranhaCommand.swift
@@ -65,10 +65,12 @@ struct CleanupStaleFlagsCommand: ParsableCommand {
     
     func run() throws {
         guard let sourceFileURL = sourceFile,
-              let config = try configFile?.config() else {
+              let configFileURL = configFile else {
             // This ideally shouldn't happen since validation runs before the run phase that ensures that invariant is satisfied.
             throw ValidationError("Invalid file paths")
         }
+        let config = try PiranhaConfigProviderDefaultImpl().config(fromFileAtURL: configFileURL)
+        
         let parsed = try SyntaxParser.parse(sourceFileURL)
         
         let cleaner = XPFlagCleaner(with: config,
@@ -87,16 +89,3 @@ struct CleanupStaleFlagsCommand: ParsableCommand {
         print(refactoredOutput, terminator: "")
     }
 }
-
-extension URL {
-    func config() throws -> PiranhaConfig {
-        do {
-            let properties = try Data(contentsOf: self)
-            return try JSONDecoder().decode(PiranhaConfig.self,
-                                            from: properties)
-        } catch {
-            throw ValidationError("Invalid configuration")
-        }
-    }
-}
-

--- a/swift/Sources/PiranhaKit/InputCommand/PiranhaCommand.swift
+++ b/swift/Sources/PiranhaKit/InputCommand/PiranhaCommand.swift
@@ -69,7 +69,7 @@ struct CleanupStaleFlagsCommand: ParsableCommand {
             // This ideally shouldn't happen since validation runs before the run phase that ensures that invariant is satisfied.
             throw ValidationError("Invalid file paths")
         }
-        let config = try PiranhaConfigProviderDefaultImpl().config(fromFileAtURL: configFileURL)
+        let config = try PiranhaConfigProviderDefaultImpl().config(fromFileURL: configFileURL)
         
         let parsed = try SyntaxParser.parse(sourceFileURL)
         

--- a/swift/Sources/PiranhaKit/InputCommand/PiranhaConfigProvider.swift
+++ b/swift/Sources/PiranhaKit/InputCommand/PiranhaConfigProvider.swift
@@ -1,5 +1,5 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ *    Copyright (c) 2021 Uber Technologies, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/swift/Sources/PiranhaKit/InputCommand/PiranhaConfigProvider.swift
+++ b/swift/Sources/PiranhaKit/InputCommand/PiranhaConfigProvider.swift
@@ -18,12 +18,12 @@ import ArgumentParser
 import Foundation
 
 protocol PiranhaConfigProviding {
-    func config(fromFileAtURL url: URL) throws -> PiranhaConfig
+    func config(fromFileURL url: URL) throws -> PiranhaConfig
 }
 
 struct PiranhaConfigProviderDefaultImpl: PiranhaConfigProviding {
     
-    func config(fromFileAtURL url: URL) throws -> PiranhaConfig {
+    func config(fromFileURL url: URL) throws -> PiranhaConfig {
         do {
             let properties = try Data(contentsOf: url)
             return try JSONDecoder().decode(PiranhaConfig.self,

--- a/swift/Sources/PiranhaKit/InputCommand/PiranhaConfigProvider.swift
+++ b/swift/Sources/PiranhaKit/InputCommand/PiranhaConfigProvider.swift
@@ -1,0 +1,26 @@
+//
+//  File.swift
+//  
+//
+//  Created by Chirag Ramani on 15/04/21.
+//
+
+import ArgumentParser
+import Foundation
+
+protocol PiranhaConfigProviding {
+    func config(fromFileAtURL url: URL) throws -> PiranhaConfig
+}
+
+struct PiranhaConfigProviderDefaultImpl: PiranhaConfigProviding {
+    
+    func config(fromFileAtURL url: URL) throws -> PiranhaConfig {
+        do {
+            let properties = try Data(contentsOf: url)
+            return try JSONDecoder().decode(PiranhaConfig.self,
+                                            from: properties)
+        } catch {
+            throw ValidationError("Invalid configuration")
+        }
+    }
+}

--- a/swift/Sources/PiranhaKit/InputCommand/PiranhaConfigProvider.swift
+++ b/swift/Sources/PiranhaKit/InputCommand/PiranhaConfigProvider.swift
@@ -1,9 +1,18 @@
-//
-//  File.swift
-//  
-//
-//  Created by Chirag Ramani on 15/04/21.
-//
+/**
+ *    Copyright (c) 2019 Uber Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
 import ArgumentParser
 import Foundation

--- a/swift/Sources/PiranhaKit/InputCommand/Validators/CleanupStaleFlagsCommandInputValidator.swift
+++ b/swift/Sources/PiranhaKit/InputCommand/Validators/CleanupStaleFlagsCommandInputValidator.swift
@@ -33,6 +33,8 @@ struct CleanupStaleFlagsCommandInputValidator {
             throw ValidationError("Please provide valid config file path")
         }
         
+        _ = try configFileURL.config()
+        
         
         guard !flag.isEmpty else {
             throw ValidationError("Please provide valid flag name")

--- a/swift/Sources/PiranhaKit/InputCommand/Validators/CleanupStaleFlagsCommandInputValidator.swift
+++ b/swift/Sources/PiranhaKit/InputCommand/Validators/CleanupStaleFlagsCommandInputValidator.swift
@@ -19,6 +19,12 @@ import ArgumentParser
 
 struct CleanupStaleFlagsCommandInputValidator {
     
+    private let configProvider: PiranhaConfigProviding
+    
+    init(configProvider: PiranhaConfigProviding = PiranhaConfigProviderDefaultImpl()) {
+        self.configProvider = configProvider
+    }
+    
     func validateInput(sourceFileURL: URL?,
                        configFileURL: URL?,
                        flag: String,
@@ -33,7 +39,7 @@ struct CleanupStaleFlagsCommandInputValidator {
             throw ValidationError("Please provide valid config file path")
         }
         
-        _ = try configFileURL.config()
+        _ = try configProvider.config(fromFileAtURL: configFileURL)
         
         
         guard !flag.isEmpty else {

--- a/swift/Sources/PiranhaKit/InputCommand/Validators/CleanupStaleFlagsCommandInputValidator.swift
+++ b/swift/Sources/PiranhaKit/InputCommand/Validators/CleanupStaleFlagsCommandInputValidator.swift
@@ -39,7 +39,7 @@ struct CleanupStaleFlagsCommandInputValidator {
             throw ValidationError("Please provide valid config file path")
         }
         
-        _ = try configProvider.config(fromFileAtURL: configFileURL)
+        _ = try configProvider.config(fromFileURL: configFileURL)
         
         
         guard !flag.isEmpty else {

--- a/swift/Sources/PiranhaKit/MethodProperties.swift
+++ b/swift/Sources/PiranhaKit/MethodProperties.swift
@@ -1,0 +1,40 @@
+/**
+ *    Copyright (c) 2019 Uber Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import Foundation
+
+struct PiranhaConfig: Codable {
+    enum CodingKeys: String, CodingKey {
+        case methods = "methodProperties"
+    }
+    
+    let methods: [Method]
+}
+
+struct Method: Codable {
+    let methodName: String
+    let flagType: FlagType
+    let flagIndex: Int?
+    let groupIndex: Int?
+    
+    enum FlagType: String, Codable {
+        case treated
+        case control
+        case controlGroup
+        case treatmentGroup
+        case testing
+    }
+}

--- a/swift/Sources/PiranhaKit/MethodProperties.swift
+++ b/swift/Sources/PiranhaKit/MethodProperties.swift
@@ -24,17 +24,15 @@ struct PiranhaConfig: Codable {
     let methods: [Method]
 }
 
-struct Method: Codable {
+struct Method: Codable, Equatable {
     let methodName: String
     let flagType: FlagType
-    let flagIndex: Int?
+    let flagIndex: Int
     let groupIndex: Int?
     
     enum FlagType: String, Codable {
         case treated
         case control
-        case controlGroup
-        case treatmentGroup
         case testing
     }
 }

--- a/swift/piranha.properties
+++ b/swift/piranha.properties
@@ -1,4 +1,0 @@
-treatedMethods=isTreated(flagName)
-controlGroupMethods=isInControlGroup(flagName) 
-treatmentGroupMethods=isInTreatmentGroup(groupName,flagName)
-testingMethods=addTreatedExperiment(flagName);removeTreatedExperiment(flagName);addExperimentParameter(flagName);experimentParameter(_,flagName)

--- a/swift/properties.json
+++ b/swift/properties.json
@@ -1,0 +1,40 @@
+{
+    "methodProperties": [
+        {
+            "methodName": "isTreated",
+            "flagType": "treated",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "isInControlGroup",
+            "flagType": "controlGroup",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "isInTreatmentGroup",
+            "flagType": "treatmentGroup",
+            "flagIndex": 1,
+            "groupIndex": 0
+        },
+        {
+            "methodName": "addTreatedExperiment",
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "removeTreatedExperiment",
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "addExperimentParameter",
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "experimentParameter",
+            "flagType": "testing",
+            "flagIndex": 1
+        }
+    ]
+}

--- a/swift/properties.json
+++ b/swift/properties.json
@@ -7,12 +7,12 @@
         },
         {
             "methodName": "isInControlGroup",
-            "flagType": "controlGroup",
+            "flagType": "control",
             "flagIndex": 0
         },
         {
             "methodName": "isInTreatmentGroup",
-            "flagType": "treatmentGroup",
+            "flagType": "treated",
             "flagIndex": 1,
             "groupIndex": 0
         },

--- a/swift/test.sh
+++ b/swift/test.sh
@@ -11,7 +11,7 @@ trap "cleanup" INT TERM EXIT
 piranha_exe=artifact/piranha/bin/Piranha
 
 tempfile=mktemp
-$piranha_exe cleanup-stale-flags -c piranha.properties -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
+swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/treated.swift)
 
 if [ "$CHANGES" != "" ]
@@ -22,7 +22,7 @@ then
 fi
 
 
-$piranha_exe cleanup-stale-flags -c piranha.properties -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
+swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/control.swift)
 
 if [ "$CHANGES" != "" ]

--- a/swift/test.sh
+++ b/swift/test.sh
@@ -11,7 +11,7 @@ trap "cleanup" INT TERM EXIT
 piranha_exe=artifact/piranha/bin/Piranha
 
 tempfile=mktemp
-swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
+$piranha_exe cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/treated.swift)
 
 if [ "$CHANGES" != "" ]
@@ -22,7 +22,7 @@ then
 fi
 
 
-swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
+$piranha_exe cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/control.swift)
 
 if [ "$CHANGES" != "" ]

--- a/swift/tests/CleanupStaleFlagsCommandInputValidatorTests.swift
+++ b/swift/tests/CleanupStaleFlagsCommandInputValidatorTests.swift
@@ -1,5 +1,5 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ *    Copyright (c) 2021 Uber Technologies, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ final class CleanupStaleFlagsCommandInputValidatorTest: XCTestCase {
                            "Please provide valid source file path")
         } catch let error {
             // then
-            XCTFail("Only ValidatorError is expected from CleanupStaleFlagsCommandInputValidator but receieved: \(error.localizedDescription)")
+            XCTFail("Only ValidationError is expected from CleanupStaleFlagsCommandInputValidator but received: \(error.localizedDescription)")
         }
     }
     
@@ -70,7 +70,7 @@ final class CleanupStaleFlagsCommandInputValidatorTest: XCTestCase {
                            "Please provide valid config file path")
         } catch let error {
             // then
-            XCTFail("Only ValidatorError is expected from CleanupStaleFlagsCommandInputValidator but receieved: \(error.localizedDescription)")
+            XCTFail("Only ValidationError is expected from CleanupStaleFlagsCommandInputValidator but received: \(error.localizedDescription)")
         }
     }
     
@@ -90,7 +90,7 @@ final class CleanupStaleFlagsCommandInputValidatorTest: XCTestCase {
                            "Please provide valid flag name")
         } catch let error {
             // then
-            XCTFail("Only ValidatorError is expected from CleanupStaleFlagsCommandInputValidator but receieved: \(error.localizedDescription)")
+            XCTFail("Only ValidationError is expected from CleanupStaleFlagsCommandInputValidator but received: \(error.localizedDescription)")
         }
     }
     
@@ -113,7 +113,7 @@ final class CleanupStaleFlagsCommandInputValidatorTest: XCTestCase {
                            "Invalid configuration")
         } catch let error {
             // then
-            XCTFail("Only ValidatorError is expected from CleanupStaleFlagsCommandInputValidator but receieved: \(error.localizedDescription)")
+            XCTFail("Only ValidationError is expected from CleanupStaleFlagsCommandInputValidator but received: \(error.localizedDescription)")
         }
     }
     
@@ -132,7 +132,7 @@ final class CleanupStaleFlagsCommandInputValidatorTest: XCTestCase {
             XCTFail("No error is expected for valid input but received: \(error.message)")
         } catch let error {
             // then
-            XCTFail("No error is expected for valid input but receieved: \(error.localizedDescription)")
+            XCTFail("No error is expected for valid input but received: \(error.localizedDescription)")
         }
     }
 }

--- a/swift/tests/CleanupStaleFlagsCommandInputValidatorTests.swift
+++ b/swift/tests/CleanupStaleFlagsCommandInputValidatorTests.swift
@@ -150,7 +150,7 @@ private final class MockFileManager: FileManager {
 private final class MockPiranhaConfigProvider: PiranhaConfigProviding {
     var configHandler: ((_ url: URL) throws -> PiranhaConfig)!
     
-    func config(fromFileAtURL url: URL) throws -> PiranhaConfig {
+    func config(fromFileURL url: URL) throws -> PiranhaConfig {
         try configHandler(url)
     }
 }

--- a/swift/tests/CleanupStaleFlagsCommandInputValidatorTests.swift
+++ b/swift/tests/CleanupStaleFlagsCommandInputValidatorTests.swift
@@ -98,7 +98,7 @@ final class CleanupStaleFlagsCommandInputValidatorTest: XCTestCase {
         // given
         fileManager.fileExistsHandler = { _ in true }
         configProvider.configHandler = { _ in
-            throw ValidationError("Inalid configuration")
+            throw ValidationError("Invalid configuration")
         }
         
         // when
@@ -110,7 +110,7 @@ final class CleanupStaleFlagsCommandInputValidatorTest: XCTestCase {
         } catch let error as ValidationError {
             // then
             XCTAssertEqual(error.message,
-                           "Inalid configuration")
+                           "Invalid configuration")
         } catch let error {
             // then
             XCTFail("Only ValidatorError is expected from CleanupStaleFlagsCommandInputValidator but receieved: \(error.localizedDescription)")

--- a/swift/tests/CleanupStaleFlagsCommandTests.swift
+++ b/swift/tests/CleanupStaleFlagsCommandTests.swift
@@ -1,5 +1,5 @@
 /**
- *    Copyright (c) 2019 Uber Technologies, Inc.
+ *    Copyright (c) 2021 Uber Technologies, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/swift/tests/PiranhaConfigProviderDefaultImplTests.swift
+++ b/swift/tests/PiranhaConfigProviderDefaultImplTests.swift
@@ -1,0 +1,291 @@
+/**
+ *    Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import Foundation
+@testable import PiranhaKit
+import XCTest
+import ArgumentParser
+
+final class PiranhaConfigProviderDefaultImplTests: XCTestCase {
+    
+    private let sut = PiranhaConfigProviderDefaultImpl()
+    private let configURL = FileManager.default.temporaryDirectory.appendingPathComponent("config.json")
+    
+    override func tearDown() {
+        super.tearDown()
+        try? FileManager.default.removeItem(at: configURL)
+    }
+    
+    func test_invalidConfig_methodNameMissing() {
+        // given
+        try! invalidConfig_methodNameMissing.write(to: configURL,
+                                                   atomically: false,
+                                                   encoding: .utf8)
+        do {
+            // when
+            _ = try sut.config(fromFileURL: configURL)
+            // then
+            XCTFail("Invalid config should be constructed")
+        } catch let error as ValidationError {
+            XCTAssertEqual(error.message, "Invalid configuration")
+        } catch let error {
+            // then
+            XCTFail("No error is expected for valid input but received: \(error.localizedDescription)")
+        }
+    }
+    
+    func test_invalidConfig_flagIndexMissing() {
+        // given
+        try! invalidConfig_flagIndexMissing.write(to: configURL,
+                                                  atomically: false,
+                                                  encoding: .utf8)
+        do {
+            // when
+            _ = try sut.config(fromFileURL: configURL)
+            // then
+            XCTFail("Invalid config should be constructed")
+        } catch let error as ValidationError {
+            XCTAssertEqual(error.message, "Invalid configuration")
+        } catch let error {
+            // then
+            XCTFail("No error is expected for valid input but received: \(error.localizedDescription)")
+        }
+    }
+    
+    func test_invalidConfig_flagTypeMissing() {
+        // given
+        try! invalidConfig_flagTypeMissing.write(to: configURL,
+                                                 atomically: false,
+                                                 encoding: .utf8)
+        do {
+            // when
+            _ = try sut.config(fromFileURL: configURL)
+            // then
+            XCTFail("Invalid config should be constructed")
+        } catch let error as ValidationError {
+            XCTAssertEqual(error.message, "Invalid configuration")
+        } catch let error {
+            // then
+            XCTFail("No error is expected for valid input but received: \(error.localizedDescription)")
+        }
+    }
+    
+    func test_validConfig() {
+        // given
+        try! validConfig.write(to: configURL,
+                               atomically: false,
+                               encoding: .utf8)
+        
+        // when
+        let config = try! sut.config(fromFileURL: configURL)
+        
+        // then
+        XCTAssertEqual(config.methods.count, 7)
+        XCTAssertEqual(config.methods[0], PiranhaKit.Method(methodName: "isTreated",
+                                                            flagType: .treated,
+                                                            flagIndex: 0,
+                                                            groupIndex: nil))
+        XCTAssertEqual(config.methods[1], PiranhaKit.Method(methodName: "isInControlGroup",
+                                                            flagType: .control,
+                                                            flagIndex: 0,
+                                                            groupIndex: nil))
+        XCTAssertEqual(config.methods[2], PiranhaKit.Method(methodName: "isInTreatmentGroup",
+                                                            flagType: .treated,
+                                                            flagIndex: 1,
+                                                            groupIndex: 0))
+        XCTAssertEqual(config.methods[3], PiranhaKit.Method(methodName: "addTreatedExperiment",
+                                                            flagType: .testing,
+                                                            flagIndex: 0,
+                                                            groupIndex: nil))
+        XCTAssertEqual(config.methods[4], PiranhaKit.Method(methodName: "removeTreatedExperiment",
+                                                            flagType: .testing,
+                                                            flagIndex: 0,
+                                                            groupIndex: nil))
+        XCTAssertEqual(config.methods[5], PiranhaKit.Method(methodName: "addExperimentParameter",
+                                                            flagType: .testing,
+                                                            flagIndex: 0,
+                                                            groupIndex: nil))
+        XCTAssertEqual(config.methods[6], PiranhaKit.Method(methodName: "experimentParameter",
+                                                            flagType: .testing,
+                                                            flagIndex: 1,
+                                                            groupIndex: nil))
+    }
+    
+    // MARK: Configs
+    
+    private let invalidConfig_methodNameMissing =
+        """
+    {
+    "methodProperties": [
+        {
+            "methodName": "isTreated",
+            "flagType": "treated",
+            "flagIndex": 0
+        },
+        {
+            "flagType": "control",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "isInTreatmentGroup",
+            "flagType": "treated",
+            "flagIndex": 1,
+            "groupIndex": 0
+        },
+        {
+            "methodName": "addTreatedExperiment",
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "addExperimentParameter",
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "experimentParameter",
+            "flagType": "testing",
+            "flagIndex": 1
+        }
+    ]
+    }
+    """
+    
+    private let invalidConfig_flagIndexMissing =
+        """
+    {
+    "methodProperties": [
+        {
+            "methodName": "isTreated",
+            "flagType": "treated",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "isInControlGroup",
+            "flagType": "control",
+        },
+        {
+            "methodName": "isInTreatmentGroup",
+            "flagType": "treated",
+            "groupIndex": 0
+        },
+        {
+            "methodName": "addTreatedExperiment",
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "addExperimentParameter",
+            "flagType": "testing",
+        },
+        {
+            "methodName": "experimentParameter",
+            "flagType": "testing",
+            "flagIndex": 1
+        }
+    ]
+    }
+    """
+    
+    private let invalidConfig_flagTypeMissing =
+        """
+    {
+    "methodProperties": [
+        {
+            "methodName": "isTreated",
+            "flagType": "treated",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "isInControlGroup",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "isInTreatmentGroup",
+            "flagType": "treated",
+            "groupIndex": 0
+        },
+        {
+            "methodName": "addTreatedExperiment",
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "addExperimentParameter",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "experimentParameter",
+            "flagType": "testing",
+            "flagIndex": 1
+        }
+    ]
+    }
+    """
+    
+    private let validConfig =
+        """
+    {
+    "methodProperties": [
+        {
+            "methodName": "isTreated",
+            "flagType": "treated",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "isInControlGroup",
+            "flagType": "control",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "isInTreatmentGroup",
+            "flagType": "treated",
+            "flagIndex": 1,
+            "groupIndex": 0
+        },
+        {
+            "methodName": "addTreatedExperiment",
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "removeTreatedExperiment",
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "addExperimentParameter",
+            "flagType": "testing",
+            "flagIndex": 0
+        },
+        {
+            "methodName": "experimentParameter",
+            "flagType": "testing",
+            "flagIndex": 1
+        }
+    ]
+    }
+    """
+}
+


### PR DESCRIPTION
Adds support for https://github.com/uber/piranha/issues/52

Migrating current usage of .properties to use a json file instead. This addresses the above issue as well as aim to achieve parity with Piranha JS.

**Please note:** This doesn't change any functionality related to AST rewriting. 