### PR TITLE
[PiranhaJava] Add unit test clean up heuristic based on setter calls.

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -72,8 +72,9 @@ The required top-level field is `methodProperties`.
 Within that, there is an array of JSON objects, having the required fields `methodName`, `flagType` and `argumentIndex`.
 The optional fields are `returnType`, `receiverType`.
 
-The `flagType` with `treated` are the APIs which correspond to the treatment behavior of the flag, `control` correspond to the control behavior of the flag. In the above example, the API `flagEnabled` corresponds to treatment behavior. Hence, when the `IsTreated` Piranha argument is set to `true`, `flagEnabled(SAMPLE_STALE_FLAG)` will be evaluated to `true`. Similarly, `flagDisabled(SAMPLE_STALE_FLAG)` which corresponds to the control behavior will evaluate to `false`. 
-The `flagType` with `empty` specifies the APIs which need to be discarded from the code. For example, if `enableFlag` is listed as a method in properties.json, with `flagType=empty`, a statement `enableFlag(SAMPLE_STALE_FLAG);` will be deleted from the code. 
+The `flagType` of `treated` are the APIs which correspond to checking for the treatment behavior of the flag, `control` correspond to checking for the control behavior of the flag. In the above example, the API `flagEnabled` corresponds to treatment behavior. Hence, when the `IsTreated` Piranha argument is set to `true`, `flagEnabled(SAMPLE_STALE_FLAG)` will be evaluated to `true`. Similarly, `flagDisabled(SAMPLE_STALE_FLAG)` which corresponds to the control behavior will evaluate to `false`.
+The `flagType` of `set_treated` and `set_control` represent APIs that force the value of the flag (to `treated` or `control`, respectively). These APIs are often used as part of testing, and Piranha includes (optional) logic to remove unit tests which set the value of removed flags to an impossible treatment condition (see `cleanupOptions` in the example `properties.json`). Elsewhere in the code, these calls will simply be removed with the flag.
+The `flagType` of `empty` specifies the APIs which need to be discarded from the code. For example, if `refreshFlag` is listed as a method in properties.json, with `flagType=empty`, a statement `refreshFlag(SAMPLE_STALE_FLAG);` will be deleted from the code.
 
 The `argumentIndex` field specifies where to look for the flag name (given by `-XepOpt:Piranha:FlagName`) in the method's arguments. We follow 0 based indexing.
 If your toggle methods take no arguments, or if you want to delete all occurrences of a given `methodName` irrespective of their arguments, you can set the `Piranha:ArgumentIndexOptional` to `true` to make specifying `argumentIndex` optional.
@@ -93,7 +94,7 @@ will be refactored to
 public void some_unit_test() { ... }
 ```
 
-when `IsTreated` is `true`, and will be deleted completely when `IsTreated` is `false`. 
+when `IsTreated` is `true`, and will be deleted completely when `IsTreated` is `false`.
 
 Finally, the setting `linkURL` in the properties file is to provide a URL describing the Piranha tooling and any custom configurations associated with the codebase. 
 
@@ -145,11 +146,16 @@ where `properties.json` contains the following,
       },
       {
         "methodName": "enableFlag",
-        "flagType": "empty",
+        "flagType": "set_treated",
         "argumentIndex": 0
       },
       {
         "methodName": "disableFlag",
+        "flagType": "set_control",
+        "argumentIndex": 0
+      },
+      {
+        "methodName": "refreshFlag",
         "flagType": "empty",
         "argumentIndex": 0
       }

--- a/java/piranha/config/properties.json
+++ b/java/piranha/config/properties.json
@@ -19,12 +19,12 @@
     },
     {
       "methodName": "putToggleEnabled",
-      "flagType": "empty",
+      "flagType": "set_treated",
       "argumentIndex": 0
     },
     {
       "methodName": "putToggleDisabled",
-      "flagType": "empty",
+      "flagType": "set_control",
       "argumentIndex": 0
     },
     {
@@ -51,5 +51,9 @@
         "flag" : "$value",
         "treated" : "false"
     }
-  ]
+  ],
+  "cleanupOptions": {
+    "tests.clean_by_setters_heuristic.enabled" : true,
+    "tests.clean_by_setters_heuristic.linesLimit" : 100
+  }
 }

--- a/java/piranha/config/properties.json
+++ b/java/piranha/config/properties.json
@@ -55,6 +55,6 @@
   "cleanupOptions": {
     "tests.clean_by_setters_heuristic.enabled" : true,
     "tests.clean_by_setters_heuristic.ignore_other_flag_sets" : false,
-    "tests.clean_by_setters_heuristic.linesLimit" : 100
+    "tests.clean_by_setters_heuristic.lines_limit" : 100
   }
 }

--- a/java/piranha/src/main/java/com/uber/piranha/PiranhaUtils.java
+++ b/java/piranha/src/main/java/com/uber/piranha/PiranhaUtils.java
@@ -13,8 +13,11 @@
  */
 package com.uber.piranha;
 
+import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.util.TreePath;
 
 public class PiranhaUtils {
   public static final String DELETE_REQUEST_COMMENT =
@@ -24,5 +27,21 @@ public class PiranhaUtils {
 
   public static String expressionToSimpleName(ExpressionTree tree) {
     return ASTHelpers.getSymbol(tree).getSimpleName().toString();
+  }
+
+  public static boolean isUnitTestMethod(MethodTree tree, VisitorState state) {
+    // A simple heuristic, but useful for now. Consider supporting other testing frameworks in the
+    // future.
+    return ASTHelpers.hasAnnotation(tree, "org.junit.Test", state);
+  }
+
+  public static boolean isPrefixPath(TreePath prefix, TreePath path) {
+    while (path != null) {
+      if (path.equals(prefix)) {
+        return true;
+      }
+      path = path.getParentPath();
+    }
+    return false;
   }
 }

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -150,6 +150,8 @@ public class XPFlagCleaner extends BugChecker
     IS_TREATED,
     IS_CONTROL,
     IS_TREATMENT_GROUP_CHECK,
+    SET_TREATED,
+    SET_CONTROL,
     DELETE_METHOD,
     UNKNOWN
   }
@@ -180,6 +182,10 @@ public class XPFlagCleaner extends BugChecker
   private boolean countsCollected = false;
   @Nullable private ImmutableMap<Symbol, UsageCounter.CounterData> usageCounts = null;
   @Nullable private Map<Symbol, Integer> deletedUsages = null;
+
+  // Set to skip refactoring under a given path (e.g. because we have deleted the entire AST under
+  // that path)
+  @Nullable private TreePath skipWithinPath = null;
 
   /**
    * Copied from NullAway comment. Error Prone requires us to have an empty constructor for each
@@ -229,6 +235,16 @@ public class XPFlagCleaner extends BugChecker
       throw new PiranhaConfigurationException("Piranha:Config is missing");
     }
     initialized = true;
+  }
+
+  private boolean shouldSkip(VisitorState state) {
+    return disabled
+        || (skipWithinPath != null && PiranhaUtils.isPrefixPath(skipWithinPath, state.getPath()));
+  }
+
+  // When deleting a large block of code, skip scanning statements/expressions within that path
+  private void skipWithin(TreePath path) {
+    skipWithinPath = path;
   }
 
   // We call this lazily only when needed, meaning when a symbol usage is first deleted for this
@@ -574,7 +590,7 @@ public class XPFlagCleaner extends BugChecker
 
   @Override
   public Description matchClass(ClassTree classTree, VisitorState visitorState) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(visitorState)) return Description.NO_MATCH;
     Symbol.ClassSymbol classSymbol = ASTHelpers.getSymbol(classTree);
     if (classSymbol.getKind().equals(ElementKind.ENUM) && isTreatmentGroupEnum(classSymbol)) {
       treatmentGroupsEnum = classSymbol.fullname.toString();
@@ -598,7 +614,7 @@ public class XPFlagCleaner extends BugChecker
   @SuppressWarnings("TreeToString")
   @Override
   public Description matchImport(ImportTree importTree, VisitorState visitorState) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(visitorState)) return Description.NO_MATCH;
     if (importTree.isStatic()) {
       Tree importIdentifier = importTree.getQualifiedIdentifier();
       if (importIdentifier.getKind().equals(Kind.MEMBER_SELECT)) {
@@ -633,7 +649,7 @@ public class XPFlagCleaner extends BugChecker
 
   @Override
   public Description matchAssignment(AssignmentTree tree, VisitorState state) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(state)) return Description.NO_MATCH;
     if (tree.getExpression().getKind().equals(Kind.BOOLEAN_LITERAL) || overLaps(tree, state)) {
       return Description.NO_MATCH;
     }
@@ -643,7 +659,7 @@ public class XPFlagCleaner extends BugChecker
 
   @Override
   public Description matchUnary(UnaryTree tree, VisitorState state) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(state)) return Description.NO_MATCH;
     if (overLaps(tree, state)) {
       return Description.NO_MATCH;
     }
@@ -653,7 +669,7 @@ public class XPFlagCleaner extends BugChecker
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(state)) return Description.NO_MATCH;
     if (overLaps(tree, state)) {
       return Description.NO_MATCH;
     }
@@ -670,7 +686,7 @@ public class XPFlagCleaner extends BugChecker
   @SuppressWarnings("TreeToString")
   @Override
   public Description matchBinary(BinaryTree tree, VisitorState state) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(state)) return Description.NO_MATCH;
     if (overLaps(tree, state)) {
       return Description.NO_MATCH;
     }
@@ -721,7 +737,7 @@ public class XPFlagCleaner extends BugChecker
 
   @Override
   public Description matchExpressionStatement(ExpressionStatementTree tree, VisitorState state) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(state)) return Description.NO_MATCH;
     if (overLaps(tree, state)) {
       return Description.NO_MATCH;
     }
@@ -729,7 +745,9 @@ public class XPFlagCleaner extends BugChecker
     if (tree.getExpression().getKind().equals(Kind.METHOD_INVOCATION)) {
       MethodInvocationTree mit = (MethodInvocationTree) tree.getExpression();
       API api = getXPAPI(mit);
-      if (api.equals(API.DELETE_METHOD)) {
+      if (api.equals(API.DELETE_METHOD)
+          || api.equals(API.SET_TREATED)
+          || api.equals(API.SET_CONTROL)) {
         Description.Builder builder = buildDescription(tree);
         SuggestedFix.Builder fixBuilder = SuggestedFix.builder();
         fixBuilder.delete(tree);
@@ -744,7 +762,7 @@ public class XPFlagCleaner extends BugChecker
 
   @Override
   public Description matchReturn(ReturnTree tree, VisitorState state) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(state)) return Description.NO_MATCH;
     if (overLaps(tree, state)) {
       return Description.NO_MATCH;
     }
@@ -779,7 +797,7 @@ public class XPFlagCleaner extends BugChecker
 
   @Override
   public Description matchVariable(VariableTree tree, VisitorState state) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(state)) return Description.NO_MATCH;
     Symbol sym = FindIdentifiers.findIdent(xpFlagName, state);
     // Check if this is the flag definition and remove it.
     if (sym != null && sym.isEnum() && sym.equals(ASTHelpers.getSymbol(tree))) {
@@ -805,41 +823,155 @@ public class XPFlagCleaner extends BugChecker
     return Description.NO_MATCH;
   }
 
+  private void recursiveScanTestMethodStats(
+      BlockTree blockTree, TestMethodCounters counters, int depth) {
+    for (StatementTree statement : blockTree.getStatements()) {
+      if (statement.getKind().equals(Tree.Kind.BLOCK)) {
+        recursiveScanTestMethodStats(blockTree, counters, depth + 1);
+      } else if (statement.getKind().equals(Kind.EXPRESSION_STATEMENT)) {
+        counters.statements += 1;
+        ExpressionTree expr = ((ExpressionStatementTree) statement).getExpression();
+        if (!expr.getKind().equals(Kind.METHOD_INVOCATION)) {
+          continue;
+        }
+        MethodInvocationTree mit = (MethodInvocationTree) expr;
+        if (!mit.getMethodSelect().getKind().equals(Tree.Kind.MEMBER_SELECT)) {
+          continue; // Can't resolve to API call
+        }
+        MemberSelectTree mst = (MemberSelectTree) mit.getMethodSelect();
+        String methodName = mst.getIdentifier().toString();
+        // We scan for config method records of type SET_* here directly, since getXPAPI(...) will
+        // resolve
+        // only when the flag name matches, and we want to verify that no calls are being made to
+        // set
+        // unrelated flags (i.e. count them in counters.allSetters).
+        for (PiranhaMethodRecord methodRecord : config.getMethodRecordsForName(methodName)) {
+          if (methodRecord.getApiType().equals(XPFlagCleaner.API.SET_TREATED)) {
+            counters.allSetters += 1;
+            // If the test is asking for the flag in treated condition, but we are setting it to
+            // control (in a top level statement), then this test is obsolete.
+            // Remember that we are scanning for all setters, however, so now we must check that
+            // call is for the
+            // flag being passed to Piranha.
+            if (!isTreated && depth == 0) {
+              if (getXPAPI(mit).equals(API.SET_TREATED)) {
+                counters.topLevelObsoleteSetters += 1;
+              }
+            }
+          } else if (methodRecord.getApiType().equals(XPFlagCleaner.API.SET_CONTROL)) {
+            counters.allSetters += 1;
+            // Analogous to the case above, but now we are checking if the test is asking for the
+            // flag in the control
+            // condition, while we are setting it to treated everywhere
+            if (isTreated && depth == 0) {
+              if (getXPAPI(mit).equals(API.SET_CONTROL)) {
+                counters.topLevelObsoleteSetters += 1;
+              }
+            }
+          }
+        }
+      } else {
+        counters.statements += 1;
+      }
+    }
+  }
+
+  /**
+   * This method implements the clean up heuristic requested by the
+   * tests.clean_by_setters_heuristic.enabled option.
+   *
+   * <p>The heuristic uses calls to set_treated/set_control API methods.
+   *
+   * <p>Under this heuristic, a test method is cleaned up iff:
+   *
+   * <ol>
+   *   <li>The method has a call to a set_treated/set_control API method as a top-level (unnested)
+   *       statement, where:
+   *       <ol>
+   *         <li>The flag being set matches the flag being cleaned up by Piranha
+   *         <li>The test is checking for the opposite of the treatment condition being set (i.e.
+   *             set_treated for a flag being refactored globally as control, or set_control for a
+   *             flag being globally refactored as treated)
+   *         <li>This call can be repeated
+   *       </ol>
+   *   <li>The method has no other calls for set_treated/set_control API methods for other flags or
+   *       conditions
+   *   <li>The method length does not exceed tests.clean_by_setters_heuristic.linesLimit (long unit
+   *       tests are more likely to be testing multiple things)
+   *       <ol>
+   *
+   * @param tree A method tree that has already been detected as being an unit test method.
+   * @return whether the method should be deleted based on the heuristic above.
+   */
+  private boolean shouldCleanBySetters(MethodTree tree) {
+    // This assumes that the method was already detected as a unit test and the corresponding
+    // heuristic is enabled
+    TestMethodCounters counters = new TestMethodCounters();
+    // Count statements, all setter calls, and relevant top-level obsolete setters for the current
+    // flag
+    recursiveScanTestMethodStats(tree.getBody(), counters, 0);
+    if (config.testMethodCleanupSizeLimit() < counters.statements) {
+      // Skip, test method too large.
+      return false;
+    }
+    if (counters.topLevelObsoleteSetters > 0
+        && counters.topLevelObsoleteSetters == counters.allSetters) {
+      // All calls to flag setting methods in this test are in the top level scope and setting the
+      // flag to a now
+      // impossible value. The whole test should be deleted as per this heuristic.
+      return true;
+    }
+    // Heuristic doesn't match, unsafe to clean
+    return false;
+  }
+
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(state)) return Description.NO_MATCH;
 
     boolean deleteMethod = false;
     List<AnnotationTree> deletableAnnotations = new ArrayList<>();
     // Deletable identifiers used as part of the argument to an annotation, for when the entire
     // annotation doesn't need to be deleted
     List<ExpressionTree> deletableIdentifiers = new ArrayList<>();
-    for (ResolvedTestAnnotation resolved : config.resolveTestAnnotations(tree, state)) {
-      Set<AnnotationArgument> matchedFlagsWorkingSet = new HashSet<>();
-      for (AnnotationArgument testedFlag : resolved.getFlags()) {
-        if (testedFlag.getValue().equals(xpFlagName)) {
-          if (isTreated == resolved.isTreated()) {
-            // Annotation requests the same treatment state as what Piranha is setting the flag to
-            matchedFlagsWorkingSet.add(testedFlag);
-          } else {
-            // Annotation (and therefore test method) requests a different (now impossible)
-            // treatment, compared to what Piranha is setting the flag to.
-            deleteMethod = true;
+    final ImmutableSet<ResolvedTestAnnotation> resolvedTestAnnotations =
+        config.resolveTestAnnotations(tree, state);
+    if (resolvedTestAnnotations.size() != 0) {
+      // If there are any test annotations for this method, then we clean up based on those. We do
+      // this even if
+      // the method is not otherwise a recognized test method (e.g. marked @Test) and we ignore all
+      // other
+      // applicable clean up heuristics
+      for (ResolvedTestAnnotation resolved : resolvedTestAnnotations) {
+        Set<AnnotationArgument> matchedFlagsWorkingSet = new HashSet<>();
+        for (AnnotationArgument testedFlag : resolved.getFlags()) {
+          if (testedFlag.getValue().equals(xpFlagName)) {
+            if (isTreated == resolved.isTreated()) {
+              // Annotation requests the same treatment state as what Piranha is setting the flag to
+              matchedFlagsWorkingSet.add(testedFlag);
+            } else {
+              // Annotation (and therefore test method) requests a different (now impossible)
+              // treatment, compared to what Piranha is setting the flag to.
+              deleteMethod = true;
+            }
           }
         }
+        // Should we delete the full annotation, or specific flags within it? Depends if all
+        // flags mentioned within the annotation have been matched or not:
+        if (matchedFlagsWorkingSet.size() == resolved.getFlags().size()) {
+          deletableAnnotations.add(resolved.getSourceTree());
+        } else {
+          // Only remove the matched flag references, but preserve the annotation and its
+          // references to remaining flags
+          matchedFlagsWorkingSet
+              .stream()
+              .forEach(arg -> deletableIdentifiers.add(arg.getSourceTree()));
+        }
+        matchedFlagsWorkingSet.clear();
       }
-      // Should we delete the full annotation, or specific flags within it? Depends if all
-      // flags mentioned within the annotation have been matched or not:
-      if (matchedFlagsWorkingSet.size() == resolved.getFlags().size()) {
-        deletableAnnotations.add(resolved.getSourceTree());
-      } else {
-        // Only remove the matched flag references, but preserve the annotation and its
-        // references to remaining flags
-        matchedFlagsWorkingSet
-            .stream()
-            .forEach(arg -> deletableIdentifiers.add(arg.getSourceTree()));
-      }
-      matchedFlagsWorkingSet.clear();
+    } else if (config.shouldCleanTestMethodsByContent()
+        && PiranhaUtils.isUnitTestMethod(tree, state)) {
+      deleteMethod = shouldCleanBySetters(tree);
     }
     // Early exit for no changes required:
     if (!deleteMethod && deletableAnnotations.size() == 0 && deletableIdentifiers.size() == 0) {
@@ -852,6 +984,7 @@ public class XPFlagCleaner extends BugChecker
     if (deleteMethod) {
       fixBuilder.delete(tree);
       decrementAllSymbolUsages(tree, state, fixBuilder);
+      skipWithin(state.getPath()); // Deleting full method, skip refactorings within it
     } else {
       // Otherwise, we might still need to clean up individual obsolete test annotations and flag
       // references within multi-flag annotations.
@@ -873,7 +1006,7 @@ public class XPFlagCleaner extends BugChecker
   @Override
   public Description matchConditionalExpression(
       ConditionalExpressionTree tree, VisitorState state) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(state)) return Description.NO_MATCH;
     if (overLaps(tree, state)) {
       return Description.NO_MATCH;
     }
@@ -909,7 +1042,7 @@ public class XPFlagCleaner extends BugChecker
 
   @Override
   public Description matchIf(IfTree ifTree, VisitorState visitorState) {
-    if (disabled) return Description.NO_MATCH;
+    if (shouldSkip(visitorState)) return Description.NO_MATCH;
     if (overLaps(ifTree, visitorState)) {
       return Description.NO_MATCH;
     }
@@ -1046,5 +1179,21 @@ public class XPFlagCleaner extends BugChecker
       return statements.size() > 0 && statements.get(statements.size() - 1) instanceof ReturnTree;
     }
     return false;
+  }
+
+  /**
+   * A small tuple of counters for scanning unit tests to be deleted by the setters heuristic. See
+   * {@link #shouldCleanBySetters(MethodTree)}
+   */
+  private static final class TestMethodCounters {
+    public long statements;
+    public int topLevelObsoleteSetters;
+    public int allSetters;
+
+    public TestMethodCounters() {
+      this.statements = 0;
+      this.topLevelObsoleteSetters = 0;
+      this.allSetters = 0;
+    }
   }
 }

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -896,7 +896,7 @@ public class XPFlagCleaner extends BugChecker
    *       </ol>
    *   <li>The method has no other calls for set_treated/set_control API methods for other flags or
    *       conditions
-   *   <li>The method length does not exceed tests.clean_by_setters_heuristic.linesLimit (long unit
+   *   <li>The method length does not exceed tests.clean_by_setters_heuristic.lines_limit (long unit
    *       tests are more likely to be testing multiple things)
    *       <ol>
    *

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -914,12 +914,15 @@ public class XPFlagCleaner extends BugChecker
       // Skip, test method too large.
       return false;
     }
-    if (counters.topLevelObsoleteSetters > 0
-        && counters.topLevelObsoleteSetters == counters.allSetters) {
-      // All calls to flag setting methods in this test are in the top level scope and setting the
-      // flag to a now
-      // impossible value. The whole test should be deleted as per this heuristic.
-      return true;
+    if (counters.topLevelObsoleteSetters > 0) {
+      if (config.shouldIgnoreOtherSettersWhenCleaningTests()) {
+        // Ignore other setter calls
+        return true;
+      } else if (counters.topLevelObsoleteSetters == counters.allSetters) {
+        // All calls to flag setting methods in this test are in the top level scope and setting the
+        // flag to a now impossible value. The whole test should be deleted as per this heuristic.
+        return true;
+      }
     }
     // Heuristic doesn't match, unsafe to clean
     return false;

--- a/java/piranha/src/main/java/com/uber/piranha/config/Config.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/Config.java
@@ -36,11 +36,18 @@ public final class Config {
       "tests.clean_by_setters_heuristic.enabled";
   private static final String OPT_TESTS_CLEAN_BY_SETTERS_LIMIT =
       "tests.clean_by_setters_heuristic.linesLimit";
+  private static final String OPT_TESTS_CLEAN_BY_SETTERS_IGNORE_OTHERS =
+      "tests.clean_by_setters_heuristic.ignore_other_flag_sets";
   private static final ImmutableSet<String> ALL_OPTS =
-      ImmutableSet.of(OPT_TESTS_CLEAN_BY_SETTERS_ENABLED, OPT_TESTS_CLEAN_BY_SETTERS_LIMIT);
+      ImmutableSet.of(
+          OPT_TESTS_CLEAN_BY_SETTERS_ENABLED,
+          OPT_TESTS_CLEAN_BY_SETTERS_LIMIT,
+          OPT_TESTS_CLEAN_BY_SETTERS_IGNORE_OTHERS);
 
   /* Defaults for named clean up options */
+  private static final boolean DEFAULT_TESTS_CLEAN_BY_SETTERS_ENABLED = false;
   private static final long DEFAULT_TESTS_CLEAN_BY_SETTERS_LIMIT = 100;
+  private static final boolean DEFAULT_TESTS_CLEAN_BY_SETTERS_IGNORE_OTHERS = false;
 
   /**
    * configMethodsMap is a map where key is method name and value is a list where each item in the
@@ -131,13 +138,21 @@ public final class Config {
    * @return a boolean representing whether this type of clean up is enabled or not.
    */
   public boolean shouldCleanTestMethodsByContent() {
-    return cleanupOptions.containsKey(OPT_TESTS_CLEAN_BY_SETTERS_ENABLED);
+    return (boolean)
+        cleanupOptions.getOrDefault(
+            OPT_TESTS_CLEAN_BY_SETTERS_ENABLED, DEFAULT_TESTS_CLEAN_BY_SETTERS_ENABLED);
   }
 
   public long testMethodCleanupSizeLimit() {
     return (long)
         cleanupOptions.getOrDefault(
             OPT_TESTS_CLEAN_BY_SETTERS_LIMIT, DEFAULT_TESTS_CLEAN_BY_SETTERS_LIMIT);
+  }
+
+  public boolean shouldIgnoreOtherSettersWhenCleaningTests() {
+    return (boolean)
+        cleanupOptions.getOrDefault(
+            OPT_TESTS_CLEAN_BY_SETTERS_IGNORE_OTHERS, DEFAULT_TESTS_CLEAN_BY_SETTERS_IGNORE_OTHERS);
   }
 
   // End of OPT_* retrieval methods
@@ -168,7 +183,8 @@ public final class Config {
   }
 
   private static void validateConfigOptsValue(String valK, Object v) {
-    if (OPT_TESTS_CLEAN_BY_SETTERS_ENABLED.equals(valK)) {
+    if (OPT_TESTS_CLEAN_BY_SETTERS_ENABLED.equals(valK)
+        || OPT_TESTS_CLEAN_BY_SETTERS_IGNORE_OTHERS.equals(valK)) {
       requireType(valK, v, Boolean.class);
     } else if (OPT_TESTS_CLEAN_BY_SETTERS_LIMIT.equals(valK)) {
       requireType(valK, v, Long.class);

--- a/java/piranha/src/main/java/com/uber/piranha/config/Config.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/Config.java
@@ -1,6 +1,8 @@
 package com.uber.piranha.config;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
@@ -27,6 +29,18 @@ public final class Config {
   private static final String LINK_URL_KEY = "linkURL";
   private static final String ANNOTATIONS_KEY = "annotations";
   private static final String METHODS_KEY = "methodProperties";
+  private static final String CLEANUP_OPTS_KEY = "cleanupOptions";
+
+  /* Named clean up options within the cleanupOptions property, all are optional */
+  private static final String OPT_TESTS_CLEAN_BY_SETTERS_ENABLED =
+      "tests.clean_by_setters_heuristic.enabled";
+  private static final String OPT_TESTS_CLEAN_BY_SETTERS_LIMIT =
+      "tests.clean_by_setters_heuristic.linesLimit";
+  private static final ImmutableSet<String> ALL_OPTS =
+      ImmutableSet.of(OPT_TESTS_CLEAN_BY_SETTERS_ENABLED, OPT_TESTS_CLEAN_BY_SETTERS_LIMIT);
+
+  /* Defaults for named clean up options */
+  private static final long DEFAULT_TESTS_CLEAN_BY_SETTERS_LIMIT = 100;
 
   /**
    * configMethodsMap is a map where key is method name and value is a list where each item in the
@@ -44,6 +58,13 @@ public final class Config {
    */
   private final TestAnnotationResolver testAnnotationResolver;
 
+  /**
+   * cleanupOptions stores the misc cleanup configuration options stored in the cleanupOptions
+   * section of properties.json. These are generally a set of heuristics for Piranha to use in
+   * particular scenarios.
+   */
+  private final ImmutableMap<String, Object> cleanupOptions;
+
   private final String linkURL;
 
   // Constructor is private, a Config object can be generated using the class' static methods,
@@ -51,9 +72,11 @@ public final class Config {
   private Config(
       ImmutableMultimap<String, PiranhaMethodRecord> configMethodProperties,
       TestAnnotationResolver testAnnotationResolver,
+      ImmutableMap<String, Object> cleanupOptions,
       String linkURL) {
     this.configMethodProperties = configMethodProperties;
     this.testAnnotationResolver = testAnnotationResolver;
+    this.cleanupOptions = cleanupOptions;
     this.linkURL = linkURL;
   }
 
@@ -95,6 +118,63 @@ public final class Config {
    */
   public String getLinkURL() {
     return linkURL;
+  }
+
+  // Start of OPT_* retrieval methods
+
+  /**
+   * Whether or not Piranha should try to clean up unit test methods based on the API calls inside
+   * the method.
+   *
+   * <p>Generally, this will be based on instances of set_treated and set_control API methods
+   *
+   * @return a boolean representing whether this type of clean up is enabled or not.
+   */
+  public boolean shouldCleanTestMethodsByContent() {
+    return cleanupOptions.containsKey(OPT_TESTS_CLEAN_BY_SETTERS_ENABLED);
+  }
+
+  public long testMethodCleanupSizeLimit() {
+    return (long)
+        cleanupOptions.getOrDefault(
+            OPT_TESTS_CLEAN_BY_SETTERS_LIMIT, DEFAULT_TESTS_CLEAN_BY_SETTERS_LIMIT);
+  }
+
+  // End of OPT_* retrieval methods
+
+  private static String validateConfigOptsKey(Object k) {
+    if (!(k instanceof String)) {
+      throw new PiranhaConfigurationException(
+          String.format(
+              "Invalid key inside cleanupOptions: %s (clean up option keys must be strings)",
+              k.toString()));
+    }
+    if (!ALL_OPTS.contains(k)) {
+      throw new PiranhaConfigurationException(
+          String.format(
+              "Unrecognized key inside cleanupOptions: %s (not a valid Piranha cleanup option)",
+              k.toString()));
+    }
+    return (String) k;
+  }
+
+  private static void requireType(String valK, Object v, Class<? extends Object> klass) {
+    if (!klass.isInstance(v)) {
+      throw new PiranhaConfigurationException(
+          String.format(
+              "Invalid value %s for key %s inside cleanupOptions (expected type %s)",
+              v.toString(), valK, klass.toString()));
+    }
+  }
+
+  private static void validateConfigOptsValue(String valK, Object v) {
+    if (OPT_TESTS_CLEAN_BY_SETTERS_ENABLED.equals(valK)) {
+      requireType(valK, v, Boolean.class);
+    } else if (OPT_TESTS_CLEAN_BY_SETTERS_LIMIT.equals(valK)) {
+      requireType(valK, v, Long.class);
+    } else {
+      Preconditions.checkArgument(false, "Default case should be unreachable.");
+    }
   }
 
   /**
@@ -160,7 +240,22 @@ public final class Config {
       } else {
         throw new PiranhaConfigurationException("methodProperties not found, required.");
       }
-      return new Config(methodsBuilder.build(), annotationResolverBuilder.build(), linkURL);
+      ImmutableMap.Builder<String, Object> cleanupOptionsBuilder = ImmutableMap.builder();
+      final Object configOptsObj = propertiesJson.get(CLEANUP_OPTS_KEY);
+      if (configOptsObj != null && configOptsObj instanceof JSONObject) {
+        final JSONObject configOpts = (JSONObject) configOptsObj;
+        configOpts.forEach(
+            (k, v) -> {
+              String valK = validateConfigOptsKey(k);
+              validateConfigOptsValue(valK, v);
+              cleanupOptionsBuilder.put(valK, v);
+            });
+      }
+      return new Config(
+          methodsBuilder.build(),
+          annotationResolverBuilder.build(),
+          cleanupOptionsBuilder.build(),
+          linkURL);
     } catch (IOException fnfe) {
       throw new PiranhaConfigurationException(
           "Error reading config file " + Paths.get(configFile).toAbsolutePath() + " : " + fnfe);
@@ -195,6 +290,9 @@ public final class Config {
    */
   public static Config emptyConfig() {
     return new Config(
-        ImmutableMultimap.of(), TestAnnotationResolver.builder().build(), DEFAULT_PIRANHA_URL);
+        ImmutableMultimap.of(),
+        TestAnnotationResolver.builder().build(),
+        ImmutableMap.of(),
+        DEFAULT_PIRANHA_URL);
   }
 }

--- a/java/piranha/src/main/java/com/uber/piranha/config/Config.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/Config.java
@@ -35,7 +35,7 @@ public final class Config {
   private static final String OPT_TESTS_CLEAN_BY_SETTERS_ENABLED =
       "tests.clean_by_setters_heuristic.enabled";
   private static final String OPT_TESTS_CLEAN_BY_SETTERS_LIMIT =
-      "tests.clean_by_setters_heuristic.linesLimit";
+      "tests.clean_by_setters_heuristic.lines_limit";
   private static final String OPT_TESTS_CLEAN_BY_SETTERS_IGNORE_OTHERS =
       "tests.clean_by_setters_heuristic.ignore_other_flag_sets";
   private static final ImmutableSet<String> ALL_OPTS =

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaMethodRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaMethodRecord.java
@@ -69,6 +69,8 @@ public final class PiranhaMethodRecord {
     ImmutableMap.Builder<String, XPFlagCleaner.API> builder = new ImmutableMap.Builder<>();
     builder.put("treated", XPFlagCleaner.API.IS_TREATED);
     builder.put("control", XPFlagCleaner.API.IS_CONTROL);
+    builder.put("set_treated", XPFlagCleaner.API.SET_TREATED);
+    builder.put("set_control", XPFlagCleaner.API.SET_CONTROL);
     builder.put("empty", XPFlagCleaner.API.DELETE_METHOD);
     builder.put("treatmentGroup", XPFlagCleaner.API.IS_TREATMENT_GROUP_CHECK);
     return builder.build();

--- a/java/piranha/src/test/java/com/uber/piranha/TestCaseCleanUpTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/TestCaseCleanUpTest.java
@@ -30,7 +30,7 @@ import org.junit.runners.JUnit4;
 public class TestCaseCleanUpTest {
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  private BugCheckerRefactoringTestHelper addToggleTestingAnnotationHelperClass(
+  private BugCheckerRefactoringTestHelper addExperimentFlagEnums(
       BugCheckerRefactoringTestHelper bcr) {
     return bcr.addInputLines(
             "TestExperimentName.java",
@@ -46,8 +46,12 @@ public class TestCaseCleanUpTest {
             "public enum TestExperimentName {",
             " OTHER_FLAG_1,",
             " OTHER_FLAG_2,",
-            "}")
-        .addInputLines(
+            "}");
+  }
+
+  private BugCheckerRefactoringTestHelper addToggleTestingAnnotationHelperClass(
+      BugCheckerRefactoringTestHelper bcr) {
+    return bcr.addInputLines(
             "ToggleTesting.java",
             "package com.uber.piranha;",
             "import java.lang.annotation.ElementType;",
@@ -171,6 +175,7 @@ public class TestCaseCleanUpTest {
     bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = PiranhaTestingHelpers.addHelperClasses(bcr);
+    bcr = addExperimentFlagEnums(bcr); // Adds STALE_FLAG, etc enums
     bcr = addToggleTestingAnnotationHelperClass(bcr); // Adds @ToggleTesting
     bcr.addInputLines(
             "TestClass.java",
@@ -205,6 +210,7 @@ public class TestCaseCleanUpTest {
     bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = PiranhaTestingHelpers.addHelperClasses(bcr);
+    bcr = addExperimentFlagEnums(bcr); // Adds STALE_FLAG, etc enums
     bcr = addToggleTestingAnnotationHelperClass(bcr); // Adds @ToggleTesting
     bcr.addInputLines(
             "TestClass.java",
@@ -238,6 +244,7 @@ public class TestCaseCleanUpTest {
     bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = PiranhaTestingHelpers.addHelperClasses(bcr);
+    bcr = addExperimentFlagEnums(bcr); // Adds STALE_FLAG, etc enums
     bcr = addToggleTestingAnnotationHelperClass(bcr); // Adds @ToggleTesting
     bcr.addInputLines(
             "TestClass.java",
@@ -275,6 +282,7 @@ public class TestCaseCleanUpTest {
     bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = PiranhaTestingHelpers.addHelperClasses(bcr);
+    bcr = addExperimentFlagEnums(bcr); // Adds STALE_FLAG, etc enums
     bcr = addToggleTestingAnnotationHelperClass(bcr); // Adds @ToggleTesting
     bcr.addInputLines(
             "TestClass.java",
@@ -311,6 +319,7 @@ public class TestCaseCleanUpTest {
     bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
 
     bcr = PiranhaTestingHelpers.addHelperClasses(bcr);
+    bcr = addExperimentFlagEnums(bcr); // Adds STALE_FLAG, etc enums
     bcr = addToggleTestingAnnotationHelperClass(bcr); // Adds @ToggleTesting
     bcr.addInputLines(
             "TestClass.java",
@@ -500,6 +509,250 @@ public class TestCaseCleanUpTest {
             "  public void y () {}",
             "  @NewToggleTreated(\"OTHER_FLAG_1\")",
             "  public void w () {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testCleanBySettersHeuristicMinimal() throws IOException {
+
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "false");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr = PiranhaTestingHelpers.addHelperClasses(bcr);
+    bcr = addExperimentFlagEnums(bcr); // Adds STALE_FLAG, etc enums
+    bcr.addInputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_StaleFlag_treated() {",
+            "     experimentation.putToggleEnabled(STALE_FLAG);",
+            "     System.err.println(\"To be removed\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testCleanBySettersHeuristicControl() throws IOException {
+
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "false");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr = PiranhaTestingHelpers.addHelperClasses(bcr);
+    bcr = addExperimentFlagEnums(bcr); // Adds STALE_FLAG, etc enums
+    bcr.addInputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG_1;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_StaleFlag_treated() {",
+            "     experimentation.putToggleEnabled(STALE_FLAG);",
+            "     System.err.println(\"To be removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_StaleFlag_control() {",
+            "     experimentation.putToggleDisabled(STALE_FLAG);",
+            "     System.err.println(\"Call above removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_treated() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_control() {",
+            "     experimentation.putToggleDisabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_BothFlags_treated() {",
+            "     experimentation.putToggleEnabled(STALE_FLAG);",
+            "     experimentation.putToggleEnabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Call removed\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG_1;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_StaleFlag_control() {",
+            "     System.err.println(\"Call above removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_treated() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_control() {",
+            "     experimentation.putToggleDisabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_BothFlags_treated() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Call removed\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testCleanBySettersHeuristicTreatment() throws IOException {
+
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "true");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr = PiranhaTestingHelpers.addHelperClasses(bcr);
+    bcr = addExperimentFlagEnums(bcr); // Adds STALE_FLAG, etc enums
+    bcr.addInputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG_1;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_StaleFlag_treated() {",
+            "     experimentation.putToggleEnabled(STALE_FLAG);",
+            "     System.err.println(\"Call above removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_StaleFlag_control() {",
+            "     experimentation.putToggleDisabled(STALE_FLAG);",
+            "     System.err.println(\"To be removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_treated() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_control() {",
+            "     experimentation.putToggleDisabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_BothFlags_control() {",
+            "     experimentation.putToggleDisabled(STALE_FLAG);",
+            "     experimentation.putToggleDisabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Call removed\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG_1;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_StaleFlag_treated() {",
+            "     System.err.println(\"Call above removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_treated() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_control() {",
+            "     experimentation.putToggleDisabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_BothFlags_control() {",
+            "     experimentation.putToggleDisabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Call removed\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testCleanBySettersHeuristicIgnoreNested() throws IOException {
+
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "false");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr = PiranhaTestingHelpers.addHelperClasses(bcr);
+    bcr = addExperimentFlagEnums(bcr); // Adds STALE_FLAG, etc enums
+    bcr.addInputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_StaleFlag_treated(int x) {",
+            "     if (x == 1) {",
+            "       experimentation.putToggleEnabled(STALE_FLAG);",
+            "       System.err.println(\"Call removed\");",
+            "     }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_StaleFlag_treated(int x) {",
+            "     if (x == 1) {",
+            "       System.err.println(\"Call removed\");",
+            "     }",
+            "  }",
             "}")
         .doTest();
   }

--- a/java/piranha/src/test/java/com/uber/piranha/TestCaseCleanUpTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/TestCaseCleanUpTest.java
@@ -756,4 +756,81 @@ public class TestCaseCleanUpTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void testCleanBySettersHeuristicIgnoreSettersForOtherFlags() throws IOException {
+
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "false");
+    b.putFlag(
+        "Piranha:Config",
+        "src/test/resources/config/properties_test_clean_by_setters_ignore_others.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr = PiranhaTestingHelpers.addHelperClasses(bcr);
+    bcr = addExperimentFlagEnums(bcr); // Adds STALE_FLAG, etc enums
+    bcr.addInputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG_1;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_StaleFlag_treated() {",
+            "     experimentation.putToggleEnabled(STALE_FLAG);",
+            "     System.err.println(\"To be removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_StaleFlag_control() {",
+            "     experimentation.putToggleDisabled(STALE_FLAG);",
+            "     System.err.println(\"Call above removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_treated() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_control() {",
+            "     experimentation.putToggleDisabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_BothFlags_treated() {",
+            "     experimentation.putToggleEnabled(STALE_FLAG);",
+            "     experimentation.putToggleEnabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Call removed\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG_1;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_StaleFlag_control() {",
+            "     System.err.println(\"Call above removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_treated() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_control() {",
+            "     experimentation.putToggleDisabled(OTHER_FLAG_1);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/java/piranha/src/test/resources/config/properties_test_clean_by_setters_ignore_others.json
+++ b/java/piranha/src/test/resources/config/properties_test_clean_by_setters_ignore_others.json
@@ -42,19 +42,19 @@
   "annotations": [
     "ToggleTesting",
     {
-        "name" : "NewToggleTreated",
-        "flag" : "$value",
-        "treated" : "true"
+      "name" : "NewToggleTreated",
+      "flag" : "$value",
+      "treated" : "true"
     },
     {
-        "name" : "NewToggleControl",
-        "flag" : "$value",
-        "treated" : "false"
+      "name" : "NewToggleControl",
+      "flag" : "$value",
+      "treated" : "false"
     }
   ],
   "cleanupOptions": {
     "tests.clean_by_setters_heuristic.enabled" : true,
-    "tests.clean_by_setters_heuristic.ignore_other_flag_sets" : false,
+    "tests.clean_by_setters_heuristic.ignore_other_flag_sets" : true,
     "tests.clean_by_setters_heuristic.linesLimit" : 100
   }
 }

--- a/java/piranha/src/test/resources/config/properties_test_clean_by_setters_ignore_others.json
+++ b/java/piranha/src/test/resources/config/properties_test_clean_by_setters_ignore_others.json
@@ -55,6 +55,6 @@
   "cleanupOptions": {
     "tests.clean_by_setters_heuristic.enabled" : true,
     "tests.clean_by_setters_heuristic.ignore_other_flag_sets" : true,
-    "tests.clean_by_setters_heuristic.linesLimit" : 100
+    "tests.clean_by_setters_heuristic.lines_limit" : 100
   }
 }


### PR DESCRIPTION
This PR does three things:

1) Add `set_treated` and `set_control` as types of flag APIs
2) Add a section to our `properties.json` configuration file for
   setting up case-specific refactoring options (`cleanupOptions`)
3) Add an option to enable a new unit test method clean up heuristic
   based on calls to `set_treated` and `set_control` methods.

This heuristic is enabled through the `tests.clean_by_setters_heuristic.enabled`
clean up option. When enabled, Piranha will clean up any methods marked at
`@Test`, matching the following criteria:

I.   The method has a call to a `set_treated`/`set_control` API method as a
     top-level (unnested) statement, where:
      a) The flag being set matches the flag being cleaned up by Piranha
      b) The test is checking for the opposite of the treatment condition
         being set (i.e. `set_treated` for a flag being refactored globally
         as control, or `set_control` for a flag being globally refactored
         as treated)
      c) This call can be repeated
II.  The method has no other calls for `set_treated`/`set_control` API methods
     for other flags or conditions
III. The method length does not exceed `tests.clean_by_setters_heuristic.linesLimit`
     (long unit tests are more likely to be testing multiple things).