### PR TITLE
Removing trailing comma if applicable

### DIFF
--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
@@ -562,14 +562,14 @@ class XPFlagCleaner: SyntaxRewriter {
         }
 
         var result = SyntaxFactory.makeBlankConditionElementList()
-
+        
         for expr in node {
             let value = evaluate(expression: expr.condition)
             if value != Value.isTrue {
                 result = result.appending(expr)
             }
         }
-
+        result.removeLastTrailingCommaIfNeeded()
         return super.visit(result)
     }
 

--- a/swift/Sources/PiranhaKit/Utils/ConditionElementListSyntax+Extensions.swift
+++ b/swift/Sources/PiranhaKit/Utils/ConditionElementListSyntax+Extensions.swift
@@ -1,0 +1,31 @@
+/**
+ *    Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import SwiftSyntax
+
+extension ConditionElementListSyntax {
+    /// Returns a new Element with trailing comma removed.
+    /// For ex: "x," becomes  "x"
+    mutating func removeLastTrailingCommaIfNeeded() {
+        guard let lastElement = last,
+              let trailingComma = lastElement.trailingComma else { return }
+        let element = ConditionElementSyntax { (builder) in
+            builder.useCondition(lastElement.condition.withTrailingTrivia(trailingComma.trailingTrivia))
+        }
+        self = self.replacing(childAt: lastElement.indexInParent,
+                              with: element)
+    }
+}

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -131,6 +131,10 @@ class SwiftExamples {
     private lazy var fieldA: Bool = !cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment)
 
     func test_expressions() {
+        
+        if x, cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) {
+            print("x")
+        }
 
         if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) {
             print("treated")

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -120,6 +120,10 @@ class SwiftExamples {
     private let fieldZ: Bool
 
     func test_expressions() {
+        
+        if x {
+            print("x")
+        }
         print("treated")
 
         if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment_suffix) {

--- a/swift/tests/UtilsTests/ConditionElementListSyntaxExtensionsTests.swift
+++ b/swift/tests/UtilsTests/ConditionElementListSyntaxExtensionsTests.swift
@@ -1,0 +1,58 @@
+/**
+ *    Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import Foundation
+import SwiftSyntax
+@testable import PiranhaKit
+import XCTest
+
+final class ConditionElementListSyntaxExtensionsTests: XCTestCase {
+    
+    func test_removeLastTrailingCommaIfNeeded_trailingCommaPresent() {
+        // given
+        var result = SyntaxFactory.makeBlankConditionElementList()
+        let condition = SyntaxFactory.makeConditionElement(condition: SyntaxFactory.makeIdentifier("x")._syntaxNode,
+                                                           trailingComma: nil)
+        result = result.appending(.init({ (builder) in
+            builder.useCondition(condition._syntaxNode)
+            builder.useTrailingComma(SyntaxFactory.makeCommaToken())
+        }))
+        XCTAssertEqual(result.description, "x,")
+        
+        // when
+        result.removeLastTrailingCommaIfNeeded()
+        
+        // then
+        XCTAssertEqual(result.description, "x")
+    }
+    
+    func test_removeLastTrailingCommaIfNeeded_trailingCommaNotPresent() {
+        // given
+        var result = SyntaxFactory.makeBlankConditionElementList()
+        let condition = SyntaxFactory.makeConditionElement(condition: SyntaxFactory.makeIdentifier("x")._syntaxNode,
+                                                           trailingComma: nil)
+        result = result.appending(.init({ (builder) in
+            builder.useCondition(condition._syntaxNode)
+        }))
+        XCTAssertEqual(result.description, "x")
+        
+        // when
+        result.removeLastTrailingCommaIfNeeded()
+        
+        // then
+        XCTAssertEqual(result.description, "x")
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/uber/piranha/issues/23

**Context:** Incase there is a trailing comma in the ConditionElementListSyntax, the PR aims to re-write the syntax node by removing the trailing comma if applicable. Suitable test-cases are added to cover the rewriting part.