### PR TITLE
[PiranhaJava] Switch Java CI to GitHub Actions.

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,0 +1,50 @@
+# GitHub CI workflow for PiranhaJava
+
+name: Java CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+defaults:
+  run:
+    working-directory: java
+
+jobs:
+  build:
+    name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            java: 8
+          - os: macos-latest
+            java: 11
+          - os: ubuntu-latest
+            java: 8
+          - os: ubuntu-latest
+            java: 11
+          - os: windows-latest
+            java: 8
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out Piranha sources
+        uses: actions/checkout@v2
+      - name: 'Set up JDK ${{ matrix.java }}'
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build and test using Gradle and Java
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: verGJF build
+      - name: Report jacoco coverage
+        uses: eskatos/gradle-command-action@v1
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        with:
+          arguments: jacocoTestReport coverallsJacoco
+        continue-on-error: true
+        if: runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/NullAway'

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -36,6 +36,7 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           build-root-directory: ./java
+          wrapper-directory: ./java
           arguments: verGJF build
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1
@@ -43,6 +44,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
           build-root-directory: ./java
+          wrapper-directory: ./java
           arguments: jacocoTestReport coverallsJacoco
         continue-on-error: true
         if: runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/piranha'

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -21,8 +21,9 @@ jobs:
             java: 8
           - os: ubuntu-latest
             java: 11
-          - os: windows-latest
-            java: 8
+          # Windows is unsupported for now
+          # - os: windows-latest
+          #   java: 8
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -37,7 +38,7 @@ jobs:
         with:
           build-root-directory: ./java
           wrapper-directory: ./java
-          arguments: verGJF build
+          arguments: verGJF build --stacktrace --debug
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1
         env:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           build-root-directory: ./java
           wrapper-directory: ./java
-          arguments: verGJF build --stacktrace --debug
+          arguments: verGJF build --stacktrace
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1
         env:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -47,5 +47,5 @@ jobs:
           build-root-directory: ./java
           wrapper-directory: ./java
           arguments: jacocoTestReport coverallsJacoco
-        continue-on-error: true
+        continue-on-error: false
         if: runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/piranha'

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -7,10 +7,6 @@ on:
     branches:
       - master
 
-defaults:
-  run:
-    working-directory: java
-
 jobs:
   build:
     name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"
@@ -40,11 +36,13 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: verGJF build
+        working-directory: java
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
           arguments: jacocoTestReport coverallsJacoco
+        working-directory: java
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/NullAway'
+        if: runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/piranha'

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Build and test using Gradle and Java
         uses: eskatos/gradle-command-action@v1
         with:
+          build-root-directory: ./java
           arguments: verGJF build
-        working-directory: java
       - name: Report jacoco coverage
         uses: eskatos/gradle-command-action@v1
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         with:
+          build-root-directory: ./java
           arguments: jacocoTestReport coverallsJacoco
-        working-directory: java
         continue-on-error: true
         if: runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/piranha'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
         - cd java/
       script:
         - ./gradlew verGJF build
-      after_success:
-        - ./gradlew jacocoTestReport coveralls
       cache:
         directories:
           - $HOME/.gradle

--- a/java/README.md
+++ b/java/README.md
@@ -1,5 +1,7 @@
 # PiranhaJava
 
+[![Coverage Status](https://coveralls.io/repos/github/uber/piranha/badge.svg?branch=master)](https://coveralls.io/github/uber/piranha?branch=master)
+
 ## Installation
 
 ### Overview

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -23,8 +23,8 @@ plugins {
 }
 
 repositories {
-  // to get the google-java-format jar and dependencies
-  jcenter()
+    mavenCentral()
+    google() // For Gradle 4.0+
 }
 
 apply from: "gradle/dependencies.gradle"

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -15,7 +15,16 @@
  */
 
 import net.ltgt.gradle.errorprone.CheckSeverity
+buildscript {
+    repositories {
+        mavenCentral()
+        google() // For Gradle 4.0+
+    }
 
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.0.1'
+    }
+}
 plugins {
   id "com.github.sherter.google-java-format" version "0.7.1"
   id "net.ltgt.errorprone" version "0.6" apply false
@@ -24,7 +33,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    google() // For Gradle 4.0+
 }
 
 apply from: "gradle/dependencies.gradle"

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
     }
 }
 plugins {

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     }
 }
 plugins {
-  id "com.github.sherter.google-java-format" version "0.7.1"
+  id "com.github.sherter.google-java-format" version "0.8"
   id "net.ltgt.errorprone" version "0.6" apply false
   id "com.github.nbaztec.coveralls-jacoco" version "1.2.5" apply false
 }

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -19,6 +19,7 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 plugins {
   id "com.github.sherter.google-java-format" version "0.7.1"
   id "net.ltgt.errorprone" version "0.6" apply false
+  id "com.github.nbaztec.coveralls-jacoco" version "1.2.5" apply false
 }
 
 repositories {

--- a/java/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip

--- a/java/piranha/build.gradle
+++ b/java/piranha/build.gradle
@@ -70,7 +70,9 @@ jacoco {
 
 test {
   maxHeapSize = "1024m"
-  jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+  if (!JavaVersion.current().java9Compatible) {
+    jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
+  }
 }
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")

--- a/java/piranha/build.gradle
+++ b/java/piranha/build.gradle
@@ -20,6 +20,7 @@ plugins {
   id "java"
   // For code coverage:
   id 'jacoco'
+  id 'com.github.nbaztec.coveralls-jacoco'
   // For NullAway, just in case
   id "net.ltgt.errorprone"
 }
@@ -63,6 +64,10 @@ javadoc {
     failOnError = false
 }
 
+jacoco {
+  toolVersion = "0.8.2"
+}
+
 test {
   maxHeapSize = "1024m"
   jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
@@ -76,4 +81,8 @@ jacocoTestReport {
         xml.enabled = true // coveralls plugin depends on xml format report
         html.enabled = true
     }
+}
+
+coverallsJacoco {
+    reportPath = "java/piranha/build/reports/jacoco/test/jacocoTestReport.xml"
 }

--- a/java/piranha/build.gradle
+++ b/java/piranha/build.gradle
@@ -86,5 +86,5 @@ jacocoTestReport {
 }
 
 coverallsJacoco {
-    reportPath = "java/piranha/build/reports/jacoco/test/jacocoTestReport.xml"
+    reportPath = "${project.projectDir}/build/reports/jacoco/test/jacocoTestReport.xml"
 }

--- a/java/sample/build.gradle
+++ b/java/sample/build.gradle
@@ -31,12 +31,12 @@ dependencies {
 tasks.withType(JavaCompile) {
   options.errorprone {
       check("Piranha", CheckSeverity.WARN)
+      option("Piranha:FlagName", "SAMPLE_STALE_FLAG")
+      option("Piranha:IsTreated", "true")
+      option("Piranha:Config", "${project.projectDir}/config/properties.json")
   }
   options.errorprone.errorproneArgs << "-XepPatchChecks:Piranha"
   options.errorprone.errorproneArgs << "-XepPatchLocation:IN_PLACE"
-  options.errorprone.errorproneArgs << "-XepOpt:Piranha:FlagName=SAMPLE_STALE_FLAG"
-  options.errorprone.errorproneArgs << "-XepOpt:Piranha:IsTreated=true"
-  options.errorprone.errorproneArgs << "-XepOpt:Piranha:Config=config/properties.json"
 }
 
 compileJava.doFirst {


### PR DESCRIPTION
Travis CI is about to be sunset for Uber OSS projects, we should switch PiranhaJava and PiranhaSwift CI builds to use GitHub Actions, just as PiranhaJS already does (see also #124). This accounts for the PiranhaJava portion.

This required a number of changes to our Gradle build. Most importantly, a long pending upgrade from Gradle 4.9 to 6.8.3, but also configuration to run the sample project on JDK11, fixes to our code coverage reporting, and an update to our Google Java Format plugin.