### PR TITLE
[PiranhaSwift] Switch Swift CI to GitHub Actions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,28 @@
+# GitHub CI workflow for PiranhaSwift
+
+name: Swift CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: "PiranhaSwift using ${{ matrix.xcode }} on ${{ matrix.os }}"
+    strategy:
+        matrix:
+          include:
+          - os: macos-latest
+            xcode: Xcode_12.2
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out Piranha sources
+        uses: actions/checkout@v2
+            - name: Build and test
+        run: |
+           cd swift/
+           sh package.sh
+           sh test.sh
+        env:
+           DEVELOPER_DIR: "/Applications/${{ matrix.xcode }}.app/Contents/Developer"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Check out Piranha sources
         uses: actions/checkout@v2
-            - name: Build and test
+      - name: Build and test
         run: |
            cd swift/
            sh package.sh


### PR DESCRIPTION
Travis CI is about to be sunset for Uber OSS projects, we should switch PiranhaJava and PiranhaSwift CI builds to use GitHub Actions, just as PiranhaJS already does (see also #124). This accounts for the PiranhaSwift portion. See #125 for the equivalent PiranhaJava change.