### PR TITLE
[PiranhaJava] Make code coverage step on Java CI optional

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -47,5 +47,5 @@ jobs:
           build-root-directory: ./java
           wrapper-directory: ./java
           arguments: jacocoTestReport coverallsJacoco
-        continue-on-error: false
+        continue-on-error: true
         if: runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/piranha'


### PR DESCRIPTION
Because code coverage reporting requies access to the
`COVERALLS_REPO_TOKEN` GitHub secret from the `uber/piranha`
repo, it will actually fail for PRs started from a branch on
a different fork (e.g. `[my_username]/piranha`). For this reason,
a failure to report coverage should *not* block landing PRs.

In the future, we might want to revisit this and see if there is
a safe way to run coverage reporting for PRs merged from other
forks, but this isn't high priority for us right now, as ongoing
coverage reporting on master should catch any significant regressions.

For authors inside Uber, pushing to a branch on `uber/piranha` and
creating the PR from there is still recommended, as that ensures
that coverage info will be available.