### PR TITLE
Checking for asString in MemberAccessExprSyntax

### DIFF
--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
@@ -111,9 +111,14 @@ class XPFlagCleaner: SyntaxRewriter {
                        name: String, at index: Int) -> Bool {
         if node.argumentList.count > 0,
             let argument = argument(arglist: node.argumentList, index) {
-            if let expr = MemberAccessExprSyntax.init(Syntax(argument.expression)),
-               expr.name.description == name {
-               return true
+            if let expr = MemberAccessExprSyntax.init(Syntax(argument.expression)) {
+                if expr.name.description == name {
+                    return true
+                }
+                if expr.name.description == "asString",
+                   expr.dot.previousToken?.description == name {
+                    return true
+                }
             }
             if let expr = StringLiteralExprSyntax.init(Syntax(argument.expression)) {
                 if name == expr.description.replacingOccurrences(of: "\"", with: "") {

--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -267,6 +267,10 @@ class SwiftExamples {
     private var shouldDoSomething: Bool {
         return false
     }
+    
+    private func testAsString() -> Bool {
+        return false
+    }
 
     func testStringFlag() {
         print("string constant 2")

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -525,6 +525,10 @@ class SwiftExamples {
     private var shouldDoSomething: Bool {
         return cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment)
     }
+    
+    private func testAsString() -> Bool {
+        return cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment.asString)
+    }
 
 
     func testStringFlag() {

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -364,6 +364,10 @@ class SwiftExamples {
     private var shouldDoSomething: Bool {
         return true
     }
+    
+    private func testAsString() -> Bool {
+        return true
+    }
 
     func testStringFlag() {
        print("string constant 1")


### PR DESCRIPTION
**Context:** The following usage ```cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment.asString)``` is not refactored by Piranha.

This PR basically:

1. analyses the MemberAccessExprSyntax description and checks if its == "asString".
2. If it's equal, then it takes into account the previous token's description which in the above case is the experiment identifier that needs to be considered for refactoring.
3. The InputSampleFiles (testfile.swift, control.swift and treated.swift) have been updated accordingly. 