### PR TITLE
Comments handling fixes for enum cases

### DIFF
--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -29,6 +29,9 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     //comment4
     case test_experiment_suffix //comment5
     case test_second_experiment
+    
+    case random_flag //comment6
+    case test_experiment1 // comment7
 
     var asString: String {
         return String(describing: self)

--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -32,6 +32,9 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     
     case random_flag //comment6
     case test_experiment1 // comment7
+    
+    case random_flag //comment8
+    case test_experiment1 // comment9
 
     var asString: String {
         return String(describing: self)

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -36,6 +36,12 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     case random_flag //comment6
     case test_experiment
     case test_experiment1 // comment7
+    
+    case random_flag //comment8
+    // comment 8.1
+    /// comment 8.2
+    case test_experiment // comment 8.3
+    case test_experiment1 // comment9
 
     var asString: String {
         return String(describing: self)

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -32,6 +32,10 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     //comment4
     case test_experiment_suffix //comment5
     case test_second_experiment
+    
+    case random_flag //comment6
+    case test_experiment
+    case test_experiment1 // comment7
 
     var asString: String {
         return String(describing: self)

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -29,6 +29,9 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     //comment4
     case test_experiment_suffix //comment5
     case test_second_experiment
+    
+    case random_flag //comment6
+    case test_experiment1 // comment7
 
     var asString: String {
         return String(describing: self)

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -32,6 +32,9 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     
     case random_flag //comment6
     case test_experiment1 // comment7
+    
+    case random_flag //comment8
+    case test_experiment1 // comment9
 
     var asString: String {
         return String(describing: self)


### PR DESCRIPTION
**Context:**  The below piece of code:
```swift    
    case random_flag //comment6
    case flagToBeRemoved
    case test_experiment1 // comment7
```
is refactored as:
```swift    
    case random_flag //comment6  case test_experiment1 // comment7
```

**The PR** 
1. makes a minor code change to the existing comments handling pieces.
2. As per the new spec, leading single/multiline comment along with same line comment will be considered for refactoring. 

1. For example:

```swift    
    case random_flag //comment6
    case flagToBeRemoved
    case test_experiment1 // comment7
```
is refactored as:
```swift    
    case random_flag //comment6
    case test_experiment1 // comment7
```
2. For example:

```swift    
    case random_flag //comment6
    // comment6.1
    // comment6.2
    case flagToBeRemoved // comment6.3
    case test_experiment1 // comment7
```
is refactored as:
```swift    
     case random_flag //comment6
     case test_experiment1 // comment7
```