### PR TITLE
Scoped label replacements

### DIFF
--- a/swift/test.sh
+++ b/swift/test.sh
@@ -11,7 +11,7 @@ trap "cleanup" INT TERM EXIT
 piranha_exe=artifact/piranha/bin/Piranha
 
 tempfile=mktemp
-swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
+$piranha_exe cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/treated.swift)
 
 if [ "$CHANGES" != "" ]
@@ -22,7 +22,7 @@ then
 fi
 
 
-swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
+$piranha_exe cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/control.swift)
 
 if [ "$CHANGES" != "" ]

--- a/swift/test.sh
+++ b/swift/test.sh
@@ -11,7 +11,7 @@ trap "cleanup" INT TERM EXIT
 piranha_exe=artifact/piranha/bin/Piranha
 
 tempfile=mktemp
-$piranha_exe cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
+swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/treated.swift)
 
 if [ "$CHANGES" != "" ]
@@ -22,7 +22,7 @@ then
 fi
 
 
-$piranha_exe cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
+swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/control.swift)
 
 if [ "$CHANGES" != "" ]

--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -289,4 +289,18 @@ class SwiftExamples {
         .loyalty_credits_purchase_addon_explicit_layout,
         .loyalty_stack_view_migration
     ]
+    
+    private func labelledNameAccess() -> Bool {
+       return false
+    }
+    
+    private func labelledNameAccess_nested() -> Bool {
+        
+        func test() -> Bool {
+            let xpName = ExperimentNamesSwift.test_experiment1
+            return cachedExperiments.isTreated(forExperiment: xpName)
+        }
+       someObject.isEnabled = false
+       return false
+    }
 }

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -560,4 +560,20 @@ class SwiftExamples {
         .loyalty_credits_purchase_addon_explicit_layout,
         .loyalty_stack_view_migration
     ]
+    
+    private func labelledNameAccess() -> Bool {
+       let xpName = ExperimentNamesSwift.test_experiment
+       return cachedExperiments.isTreated(forExperiment: xpName)
+    }
+    
+    private func labelledNameAccess_nested() -> Bool {
+       let xpName = ExperimentNamesSwift.test_experiment
+        
+        func test() -> Bool {
+            let xpName = ExperimentNamesSwift.test_experiment1
+            return cachedExperiments.isTreated(forExperiment: xpName)
+        }
+       someObject.isEnabled = cachedExperiments.isTreated(forExperiment: xpName)
+       return cachedExperiments.isTreated(forExperiment: xpName)
+    }
 }

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -386,4 +386,18 @@ class SwiftExamples {
         .loyalty_credits_purchase_addon_explicit_layout,
         .loyalty_stack_view_migration
     ]
+    
+    private func labelledNameAccess() -> Bool {
+       return true
+    }
+    
+    private func labelledNameAccess_nested() -> Bool {
+        
+        func test() -> Bool {
+            let xpName = ExperimentNamesSwift.test_experiment1
+            return cachedExperiments.isTreated(forExperiment: xpName)
+        }
+       someObject.isEnabled = true
+       return true
+    }
 }


### PR DESCRIPTION
**Context:**
```swift
let xpName = ExperimentNames.someStaleFlag
return cachedExperiments.isTreated(forExperiment: xpName)
````
is not considered for refactoring. 

**This PR:**
1. Adds support to enable refactoring for the above and related use-cases.
2. It also considers scope into account. For ex, a local scope variable value(if accessible) should override the higher scope variable value. This makes sure that as FuncDeclSyntax nodes are being entered/existed, the scope resolution provides enough context to fill in the suitable values (considering the closest context to avoid ambiguities).
3. As per the above scope based rules, the sample input files(testfile.swift, treated.swift, control.swift) are updated with suitable test-cases.
