### PR TITLE
If else ladder refactoring

### DIFF
--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/IfStmtRewriter.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/IfStmtRewriter.swift
@@ -1,0 +1,110 @@
+//
+//  File.swift
+//  
+//
+//  Created by Chirag Ramani on 13/05/21.
+//
+
+import Foundation
+import SwiftSyntax
+
+/// This SyntaxRewriter dedicatedly operates on the if-else condition and also works on the if-else ladder.
+/// It does the following:
+/// a.) to remove the conditional block that has the false condition because that will never be executed.
+/// b.) If there is a conditional block evaluating to true, then it removes all the following conditions as well as their respective bodies because they will never be executed.
+final class IfElseStmtRewriter: SyntaxRewriter {
+    
+    override func visit(_ node: IfStmtSyntax) -> StmtSyntax {
+        return super.visit(reduce(node))
+    }
+    
+    // MARK: Private
+    
+    private func reduce(_ node: IfStmtSyntax) -> IfStmtSyntax {
+        var updatedNode = reduceFalseTreeIfApplicable(node)
+        updatedNode = reduceTrueTreeIfApplicable(updatedNode)
+        return updatedNode
+    }
+    
+    private func reduceFalseTreeIfApplicable(_ node: IfStmtSyntax) -> IfStmtSyntax {
+        guard node.conditions.count == 1,
+              node.conditions.first?.description.trimmingCharacters(in: .whitespacesAndNewlines) == "false" else {
+            /// Since this doesn't meet the false cleanup criteria, therefore returning.
+            return node
+        }
+        /// Processing else block if present.
+        if let _ = node.elseKeyword,
+           let elseBody = node.elseBody {
+            // Is it an only else condition and there is no if condition.
+            if let expr = CodeBlockSyntax.init(elseBody) {
+                var ifStmt = SyntaxFactory.makeBlankIfStmt()
+                ifStmt = ifStmt.withBody(codeBlockFor(node: node,
+                                                      referenceCodeBlock: expr))
+                return ifStmt
+            }
+            
+            // If condition is present.
+            if let ifOfBody = IfStmtSyntax.init(elseBody) {
+                var ifStmt = SyntaxFactory.makeBlankIfStmt()
+                ifStmt = reduce(ifOfBody)
+                return ifStmt
+            }
+            
+            return node
+        } else {
+            // False conditional and no else body, hence returning a blank statement.
+            return SyntaxFactory.makeBlankIfStmt()
+        }
+    }
+    
+    /// This update the code block with the appropriate leading and trailing trivia.
+    private func codeBlockFor(node: IfStmtSyntax,
+                              referenceCodeBlock codeBlock: CodeBlockSyntax,
+                              previousNode: IfStmtSyntax? = nil) -> CodeBlockSyntax {
+        if node.ifKeyword.previousToken?.tokenKind == .elseKeyword {
+            /// Since there is an existing else block, we would want to have braces and their respective trivia.
+            let leading = SyntaxFactory.makeToken(.leftBrace,
+                                                  presence: .present,
+                                                  leadingTrivia: Trivia.init(pieces: []),
+                                                  trailingTrivia: Trivia.init(pieces: []))
+            
+            let trailing = SyntaxFactory.makeToken(.rightBrace,
+                                                   presence: .present,
+                                                   leadingTrivia: codeBlock.rightBrace.leadingTrivia,
+                                                   trailingTrivia: codeBlock.rightBrace.trailingTrivia)
+            return SyntaxFactory.makeCodeBlock(leftBrace: leading,
+                                               statements: codeBlock.statements,
+                                               rightBrace: trailing)
+        } else {
+            /// Matching the trivia to the if keyword.
+            var statements = codeBlock.statements
+            let firstModified = statements.first?.withLeadingTrivia(node.ifKeyword.leadingTrivia)
+            statements = statements.replacing(childAt: 0, with: firstModified!)
+            let leading = SyntaxFactory.makeToken(.identifier(""),
+                                                  presence: .present,
+                                                  leadingTrivia: Trivia.init(pieces: []),
+                                                  trailingTrivia: Trivia.init(pieces: []))
+            
+            let trailing = SyntaxFactory.makeToken(.identifier(""),
+                                                   presence: .present,
+                                                   leadingTrivia: Trivia.init(pieces: []),
+                                                   trailingTrivia: codeBlock.rightBrace.trailingTrivia)
+            return SyntaxFactory.makeCodeBlock(leftBrace: leading,
+                                               statements: statements,
+                                               rightBrace: trailing)
+        }
+    }
+    
+    // If the condition is true, no other if else condition(s) below this node  will be executed hence the following blocks will be cleaned-up.
+    private func reduceTrueTreeIfApplicable(_ node: IfStmtSyntax) -> IfStmtSyntax {
+        guard node.conditions.count == 1,
+              node.conditions.first?.description.trimmingCharacters(in: .whitespacesAndNewlines) == "true" else {
+            /// Since this doesn't meet the true cleanup criteria, therefore returning.
+            return node
+        }
+        var statement = SyntaxFactory.makeBlankIfStmt()
+        statement = statement.withBody(codeBlockFor(node: node,
+                                              referenceCodeBlock: node.body))
+        return statement
+    }
+}

--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/IfStmtRewriter.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/IfStmtRewriter.swift
@@ -1,9 +1,18 @@
-//
-//  File.swift
-//  
-//
-//  Created by Chirag Ramani on 13/05/21.
-//
+/**
+ *    Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
 import Foundation
 import SwiftSyntax

--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/IfStmtRewriter.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/IfStmtRewriter.swift
@@ -99,8 +99,9 @@ final class IfElseStmtRewriter: SyntaxRewriter {
         } else {
             /// Matching the trivia to the if keyword.
             var statements = codeBlock.statements
-            let firstModified = statements.first?.withLeadingTrivia(node.ifKeyword.leadingTrivia)
-            statements = statements.replacing(childAt: 0, with: firstModified!)
+            if let firstModified = statements.first?.withLeadingTrivia(node.ifKeyword.leadingTrivia) {
+                statements = statements.replacing(childAt: 0, with: firstModified)
+            }
             let leading = SyntaxFactory.makeToken(.identifier(""),
                                                   presence: .present,
                                                   leadingTrivia: Trivia.init(pieces: []),

--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
@@ -247,6 +247,9 @@ class XPFlagCleaner: SyntaxRewriter {
             if booleanNode.booleanLiteral.tokenKind == TokenKind.trueKeyword {
                 return Value.isTrue
             }
+            if case .identifier("true") = booleanNode.booleanLiteral.tokenKind {
+                return Value.isTrue
+            }
             return Value.isFalse
         }
         else if let prefixOperatorNode = PrefixOperatorExprSyntax.init(node) {
@@ -776,13 +779,17 @@ class XPFlagCleaner: SyntaxRewriter {
         return super.visit(node)
     }
 
+    
+    var replacements: [BooleanLiteralExprSyntax] = []
     override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
         let value = evaluate(expression: Syntax(node))
         switch value {
         case Value.isTrue:
-            return visit(SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeTrueKeyword()))
+            let booleanLiteralExpr = SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeToken(.identifier("true"), presence: .present))
+            return visit(booleanLiteralExpr)
         case Value.isFalse:
-            return visit(SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeFalseKeyword()))
+            let booleanLiteralExpr = SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeToken(.identifier("false"), presence: .present))
+            return visit(booleanLiteralExpr)
         case Value.isBot:
             return super.visit(node)
         }

--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
@@ -570,9 +570,13 @@ class XPFlagCleaner: SyntaxRewriter {
         let value = evaluate(expression: Syntax(node))
         switch value {
         case Value.isTrue:
-            return ExprSyntax.init(SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeTrueKeyword()))
+            let booleanLiteralExpr = SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeToken(.identifier("true"),
+                                                                                                                  presence: .present))
+            return ExprSyntax.init(booleanLiteralExpr)
         case Value.isFalse:
-            return ExprSyntax.init(SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeFalseKeyword()))
+            let booleanLiteralExpr = SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeToken(.identifier("false"),
+                                                                                                                  presence: .present))
+            return ExprSyntax.init(booleanLiteralExpr)
         case Value.isBot:
             var result = SyntaxFactory.makeBlankExprList()
             for (index, expr) in node.elements.enumerated() {
@@ -785,10 +789,12 @@ class XPFlagCleaner: SyntaxRewriter {
         let value = evaluate(expression: Syntax(node))
         switch value {
         case Value.isTrue:
-            let booleanLiteralExpr = SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeToken(.identifier("true"), presence: .present))
+            let booleanLiteralExpr = SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeToken(.identifier("true"),
+                                                                                                                  presence: .present))
             return visit(booleanLiteralExpr)
         case Value.isFalse:
-            let booleanLiteralExpr = SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeToken(.identifier("false"), presence: .present))
+            let booleanLiteralExpr = SyntaxFactory.makeBooleanLiteralExpr(booleanLiteral: SyntaxFactory.makeToken(.identifier("false"),
+                                                                                                                  presence: .present))
             return visit(booleanLiteralExpr)
         case Value.isBot:
             return super.visit(node)

--- a/swift/Sources/PiranhaKit/InputCommand/PiranhaCommand.swift
+++ b/swift/Sources/PiranhaKit/InputCommand/PiranhaCommand.swift
@@ -84,7 +84,12 @@ struct CleanupStaleFlagsCommand: ParsableCommand {
             cleaner.setNextPass()
             refactoredOutput = cleaner.visit(parsed)
         }
-        
+
+        let reducers: [SyntaxRewriter] = [IfElseStmtRewriter()]
+        refactoredOutput = reducers.reduce(refactoredOutput,
+                                           { (previousOutput, rewriter) -> Syntax in
+            rewriter.visit(refactoredOutput)
+        })
         // swiftlint:disable:next custom_rules
         print(refactoredOutput, terminator: "")
     }

--- a/swift/test.sh
+++ b/swift/test.sh
@@ -11,7 +11,7 @@ trap "cleanup" INT TERM EXIT
 piranha_exe=artifact/piranha/bin/Piranha
 
 tempfile=mktemp
-swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
+$piranha_exe cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/treated.swift)
 
 if [ "$CHANGES" != "" ]
@@ -22,7 +22,7 @@ then
 fi
 
 
-swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
+$piranha_exe cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/control.swift)
 
 if [ "$CHANGES" != "" ]

--- a/swift/test.sh
+++ b/swift/test.sh
@@ -11,7 +11,7 @@ trap "cleanup" INT TERM EXIT
 piranha_exe=artifact/piranha/bin/Piranha
 
 tempfile=mktemp
-$piranha_exe cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
+swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment --treated > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/treated.swift)
 
 if [ "$CHANGES" != "" ]
@@ -22,7 +22,7 @@ then
 fi
 
 
-$piranha_exe cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
+swift run Piranha cleanup-stale-flags -c properties.json -s tests/InputSampleFiles/testfile.swift -f test_experiment > "$tempfile"
 CHANGES=$(diff -wB $tempfile tests/InputSampleFiles/control.swift)
 
 if [ "$CHANGES" != "" ]

--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -365,4 +365,12 @@ class SwiftExamples {
             print("4")
         }
     }
+    
+    private func ifElseLadder_7() {
+        if x {
+           print("1")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.randomExperiment) || z {
+            print("3")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -323,4 +323,24 @@ class SwiftExamples {
             print("4")
         }
     }
+    
+    private func ifElseLadder_3() {
+        if x {
+            print("1")
+        } else if true {
+            print("2")
+        } else {
+            print("4")
+        }
+    }
+    
+    private func ifElseLadder_4() {
+        if x {
+            print("1")
+        } else if false {
+            print("2")
+        } else {
+            print("4")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -303,4 +303,24 @@ class SwiftExamples {
        someObject.isEnabled = false
        return false
     }
+    
+    private func ifElseLadder_1() {
+        if x {
+            print("1")
+        } else if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment1) {
+            print("3")
+        } else {
+            print("4")
+        }
+    }
+    
+    private func ifElseLadder_2() {
+        if x {
+            print("1")
+        } else if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment1) {
+            print("2")
+        } else {
+            print("4")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -343,4 +343,26 @@ class SwiftExamples {
             print("4")
         }
     }
+    
+    private func ifElseLadder_5() {
+        if x {
+           print("1")
+        } else if y {
+            print("2")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.randomExperiment) || z {
+            print("3")
+        } else {
+            print("4")
+        }
+    }
+    
+    private func ifElseLadder_6() {
+        if x {
+           print("1")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.randomExperiment) || z {
+            print("3")
+        } else {
+            print("4")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -600,4 +600,28 @@ class SwiftExamples {
             print("4")
         }
     }
+    
+    private func ifElseLadder_3() {
+        if x {
+            print("1")
+        } else if true {
+            print("2")
+        } else if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) {
+            print("3")
+        } else {
+            print("4")
+        }
+    }
+    
+    private func ifElseLadder_4() {
+        if x {
+            print("1")
+        } else if false {
+            print("2")
+        } else if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) {
+            print("3")
+        } else {
+            print("4")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -624,4 +624,28 @@ class SwiftExamples {
             print("4")
         }
     }
+    
+    private func ifElseLadder_5() {
+        if x {
+           print("1")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.test_experiment) || y {
+            print("2")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.randomExperiment) || z {
+            print("3")
+        } else {
+            print("4")
+        }
+    }
+    
+    private func ifElseLadder_6() {
+        if x {
+           print("1")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.test_experiment) && y {
+            print("2")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.randomExperiment) || z {
+            print("3")
+        } else {
+            print("4")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -648,4 +648,14 @@ class SwiftExamples {
             print("4")
         }
     }
+    
+    private func ifElseLadder_7() {
+        if x {
+           print("1")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.test_experiment) && someCondition {
+            print("2")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.randomExperiment) || z {
+            print("3")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -576,4 +576,28 @@ class SwiftExamples {
        someObject.isEnabled = cachedExperiments.isTreated(forExperiment: xpName)
        return cachedExperiments.isTreated(forExperiment: xpName)
     }
+    
+    private func ifElseLadder_1() {
+        if x {
+            print("1")
+        } else if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) {
+            print("2")
+        } else if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment1) {
+            print("3")
+        } else {
+            print("4")
+        }
+    }
+    
+    private func ifElseLadder_2() {
+        if x {
+            print("1")
+        } else if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment1) {
+            print("2")
+        } else if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) {
+            print("3")
+        } else {
+            print("4")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -438,4 +438,24 @@ class SwiftExamples {
             print("3")
         }
     }
+    
+    private func ifElseLadder_5() {
+        if x {
+           print("1")
+        } else {
+            print("2")
+        }
+    }
+    
+    private func ifElseLadder_6() {
+        if x {
+           print("1")
+        } else if y {
+            print("2")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.randomExperiment) || z {
+            print("3")
+        } else {
+            print("4")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -458,4 +458,14 @@ class SwiftExamples {
             print("4")
         }
     }
+    
+    private func ifElseLadder_7() {
+        if x {
+           print("1")
+        } else if someCondition {
+            print("2")
+        } else if cachedExperiments.isTreated(ExperimentNamesSwift.randomExperiment) || z {
+            print("3")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -418,4 +418,24 @@ class SwiftExamples {
             print("3")
         }
     }
+    
+    private func ifElseLadder_3() {
+        if x {
+            print("1")
+        } else if true {
+            print("2")
+        } else {
+            print("3")
+        }
+    }
+    
+    private func ifElseLadder_4() {
+        if x {
+            print("1")
+        } else if false {
+            print("2")
+        } else {
+            print("3")
+        }
+    }
 }

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -400,4 +400,22 @@ class SwiftExamples {
        someObject.isEnabled = true
        return true
     }
+    
+    private func ifElseLadder_1() {
+        if x {
+            print("1")
+        } else {
+            print("2")
+        }
+    }
+    
+    private func ifElseLadder_2() {
+        if x {
+            print("1")
+        } else if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment1) {
+            print("2")
+        } else {
+            print("3")
+        }
+    }
 }


### PR DESCRIPTION
**Context**: BooleanLiteral expressions in the if-else conditions should be further refactored by updating the if-else tree, wherever applicable.

**This PR:**
1. This PR adds an IfElseStmtRewriter - that basically consumes the output of the default re-writer and takes this as an opportunity to dedicatedly operate on the if-else condition and also refactor the if-else ladder.
It does the following:
a.) removes the conditional block that has the false condition because that will never be executed and also does the related stitching of the next blocks.
b.) If there is a conditional block evaluating to true, then it removes all the following conditions as well as their respective bodies because they will never be executed along with necessary stitching.
2. As per the above specs, the sample input files(testfile.swift, treated.swift, control.swift) are updated with suitable test cases.

Having independent dedicated reducers will prove to be beneficial as Piranha evolves:
1. The default re-writer focuses on experimentation-related replacements etc.
2. Reducers applied post the above re-writing further refactors as per their utility. This way, new reducers can be added without affecting each other though sequencing in which they will be called will depend on their refactoring strategy. 
3. Also, small scoped independent units are always easier to maintain.