### PR TITLE
[PiranhaSwift] Fix handling of trivia in enum declaration

### DIFF
--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
@@ -680,9 +680,7 @@ class XPFlagCleaner: SyntaxRewriter {
             flagName == string(of: Syntax(firstElement)),
             let indexInParent = indexInParent {
             caseIndex = indexInParent + 1
-            if let leadingTrivia = node.leadingTrivia,
-               let firstLeadingTrivia = leadingTrivia.first,
-               !firstLeadingTrivia.isNewLine {
+            if let leadingTrivia = node.leadingTrivia {
                 previousTrivia = []
                 for i in leadingTrivia {
                     previousTrivia = previousTrivia.appending(i) // saves comment1
@@ -864,16 +862,6 @@ class XPFlagCleaner: SyntaxRewriter {
 
     func deepClean() -> Bool {
         return shouldDeepClean
-    }
-}
-
-
-private extension TriviaPiece {
-    var isNewLine: Bool {
-        guard case TriviaPiece.newlines(_) = self else {
-            return false
-        }
-        return true
     }
 }
 

--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -36,6 +36,18 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     case random_flag //comment8
     case test_experiment1 // comment9
 
+    case random1
+    case random2
+    case random3
+    case random4
+
+    case random6
+
+    case random7
+
+    case random8
+    case random9
+
     var asString: String {
         return String(describing: self)
     }

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -43,6 +43,23 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     case test_experiment // comment 8.3
     case test_experiment1 // comment9
 
+    case random1
+    case random2
+    case test_experiment
+    case random3
+    case random4
+
+    case random6
+
+    case test_experiment
+    case random7
+
+    case random8
+    case test_experiment
+
+    case random9
+
+
     var asString: String {
         return String(describing: self)
     }

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -36,6 +36,18 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     case random_flag //comment8
     case test_experiment1 // comment9
 
+    case random1
+    case random2
+    case random3
+    case random4
+
+    case random6
+
+    case random7
+
+    case random8
+    case random9
+
     var asString: String {
         return String(describing: self)
     }


### PR DESCRIPTION
The current version of PiranhaSwift resulted in refactorings where two flag declarations appear on the same line due to an unnecessary conditional check while handling enums. Deleted the associated code and added tests to cover this scenario. 