### PR TITLE
[PiranhaSwift] Expression simplification during equality comparison

### DIFF
--- a/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
+++ b/swift/Sources/PiranhaKit/CleanupStaleFlags/StaleFlagCleaner.swift
@@ -680,9 +680,7 @@ class XPFlagCleaner: SyntaxRewriter {
             flagName == string(of: Syntax(firstElement)),
             let indexInParent = indexInParent {
             caseIndex = indexInParent + 1
-            if let leadingTrivia = node.leadingTrivia,
-               let firstLeadingTrivia = leadingTrivia.first,
-               !firstLeadingTrivia.isNewLine {
+            if let leadingTrivia = node.leadingTrivia {
                 previousTrivia = []
                 for i in leadingTrivia {
                     previousTrivia = previousTrivia.appending(i) // saves comment1
@@ -864,16 +862,6 @@ class XPFlagCleaner: SyntaxRewriter {
 
     func deepClean() -> Bool {
         return shouldDeepClean
-    }
-}
-
-
-private extension TriviaPiece {
-    var isNewLine: Bool {
-        guard case TriviaPiece.newlines(_) = self else {
-            return false
-        }
-        return true
     }
 }
 

--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -36,6 +36,18 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     case random_flag //comment8
     case test_experiment1 // comment9
 
+    case random1
+    case random2
+    case random3
+    case random4
+
+    case random6
+
+    case random7
+
+    case random8
+    case random9
+
     var asString: String {
         return String(describing: self)
     }

--- a/swift/tests/InputSampleFiles/control.swift
+++ b/swift/tests/InputSampleFiles/control.swift
@@ -385,4 +385,23 @@ class SwiftExamples {
             print("3")
         }
     }
+
+    func test_equality() {
+        print("y1")
+        print("y2")
+        print("x3")
+        if false == p1 {
+            print("x4")
+        } else {
+            print("y4")
+        }
+        print("y5")
+        if true == p1 {
+           print("x6")
+        } else {
+           print("y6")
+        }
+
+    }
+
 }

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -43,6 +43,23 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     case test_experiment // comment 8.3
     case test_experiment1 // comment9
 
+    case random1
+    case random2
+    case test_experiment
+    case random3
+    case random4
+
+    case random6
+
+    case test_experiment
+    case random7
+
+    case random8
+    case test_experiment
+
+    case random9
+
+
     var asString: String {
         return String(describing: self)
     }

--- a/swift/tests/InputSampleFiles/testfile.swift
+++ b/swift/tests/InputSampleFiles/testfile.swift
@@ -675,4 +675,44 @@ class SwiftExamples {
             print("3")
         }
     }
+
+    func test_equality() {
+
+        if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) == true {
+            print("x1")
+        } else {
+            print("y1")
+        }
+
+        if true == cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) {
+            print("x2")
+        } else {
+            print("y2")
+        }
+
+        if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) == false {
+            print("x3")
+        } else {
+            print("y3")
+        }
+
+        if cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) == p1 {
+            print("x4")
+        } else {
+            print("y4")
+        }
+
+        if true == (cachedExperiments.isTreated(forExperiment: ExperimentNamesSwift.test_experiment) && true) {
+            print("x5")
+        } else {
+            print("y5")
+        }
+
+        if true == p1 {
+           print("x6")
+        } else {
+           print("y6")
+        }
+    }
+
 }

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -36,6 +36,18 @@ enum ExperimentNamesSwift: String, ExperimentKeying {
     case random_flag //comment8
     case test_experiment1 // comment9
 
+    case random1
+    case random2
+    case random3
+    case random4
+
+    case random6
+
+    case random7
+
+    case random8
+    case random9
+
     var asString: String {
         return String(describing: self)
     }

--- a/swift/tests/InputSampleFiles/treated.swift
+++ b/swift/tests/InputSampleFiles/treated.swift
@@ -480,4 +480,23 @@ class SwiftExamples {
             print("3")
         }
     }
+
+    func test_equality() {
+
+        print("x1")
+        print("x2")
+        print("y3")
+        if true == p1 {
+            print("x4")
+        } else {
+            print("y4")
+        }
+        print("x5")
+        if true == p1 {
+           print("x6")
+        } else {
+           print("y6")
+        }
+    }
+
 }


### PR DESCRIPTION
```
if isTreated(flag) == true {
   // abc
} 
``` 
is refactored as 
``` 
if true == true {
  // abc
}
```

This update fixes this issue and simplifies the code further. 