### PR TITLE
[PiranhaJava] Remove enum constants with field matching flag value

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -65,6 +65,14 @@ The properties file has the following template:
       },
       ...
     ],
+  "enumProperties":
+    [
+      {
+        "enumName": "TestExperimentName",
+        "argumentIndex": 0
+      },
+      ...
+    ],
   "linkURL": "<provide_your_url>",
   "annotations": ["ToggleTesting"]
 }
@@ -97,6 +105,33 @@ public void some_unit_test() { ... }
 ```
 
 when `IsTreated` is `true`, and will be deleted completely when `IsTreated` is `false`.
+
+An optional top-level field is `enumProperties`.
+Within that, there is an array of JSON objects, having the required fields `enumName` and `argumentIndex`.
+
+What this field does, is if you specify an enum class name, Piranha will remove enum constants that have a constructor with an argument that matches your `FlagName` value, along with their usages.
+
+For example, if your `FlagName` is set to `stale.flag`, and `TestExperimentName` is configured in `enumProperties` with an `argumentIndex` of `0`:
+
+```java
+public enum TestExperimentName {
+  STALE_FLAG("stale.flag"),
+  OTHER_FLAG("other");
+  ...
+}
+```
+
+will be refactored to
+
+
+```java
+public enum TestExperimentName {
+  OTHER_FLAG("other");
+  ...
+}
+```
+
+Additionally, usages of `STALE_FLAG` will be removed as if the enum itself had been passed as the flag to be cleaned by Piranha, rather than the string `"stale.flag"`
 
 Finally, the setting `linkURL` in the properties file is to provide a URL describing the Piranha tooling and any custom configurations associated with the codebase. 
 

--- a/java/README.md
+++ b/java/README.md
@@ -109,7 +109,7 @@ when `IsTreated` is `true`, and will be deleted completely when `IsTreated` is `
 An optional top-level field is `enumProperties`.
 Within that, there is an array of JSON objects, having the required fields `enumName` and `argumentIndex`.
 
-What this field does, is if you specify an enum class name, Piranha will remove enum constants that have a constructor with an argument that matches your `FlagName` value, along with their usages.
+What this field does, is if you specify an enum class name, Piranha will remove enum constants that have a constructor with a string argument that matches your `FlagName` value, along with their usages.
 
 For example, if your `FlagName` is set to `stale.flag`, and `TestExperimentName` is configured in `enumProperties` with an `argumentIndex` of `0`:
 

--- a/java/piranha/config/properties.json
+++ b/java/piranha/config/properties.json
@@ -52,6 +52,12 @@
         "treated" : "false"
     }
   ],
+  "enumProperties": [
+    {
+      "enumName": "TestExperimentName",
+      "argumentIndex": 0
+    }
+  ],
   "cleanupOptions": {
     "tests.clean_by_setters_heuristic.enabled" : true,
     "tests.clean_by_setters_heuristic.ignore_other_flag_sets" : false,

--- a/java/piranha/src/main/java/com/uber/piranha/EnumWithClassSymbol.java
+++ b/java/piranha/src/main/java/com/uber/piranha/EnumWithClassSymbol.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha;
+
+import com.sun.tools.javac.code.Symbol;
+import java.util.Objects;
+
+class EnumWithClassSymbol {
+  private final String enumName;
+  private final Symbol.ClassSymbol enumClass;
+
+  EnumWithClassSymbol(String enumName, Symbol.ClassSymbol enumClass) {
+    this.enumName = enumName;
+    this.enumClass = enumClass;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof EnumWithClassSymbol)) return false;
+    EnumWithClassSymbol enumWithClassSymbol = (EnumWithClassSymbol) o;
+    return enumName.equals(enumWithClassSymbol.enumName)
+        && enumClass.equals(enumWithClassSymbol.enumClass);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enumName, enumClass);
+  }
+}

--- a/java/piranha/src/main/java/com/uber/piranha/PiranhaRuntimeException.java
+++ b/java/piranha/src/main/java/com/uber/piranha/PiranhaRuntimeException.java
@@ -1,0 +1,12 @@
+package com.uber.piranha;
+
+/**
+ * An exception thrown during the execution of the Piranha bug checker. This is a runtime exception
+ * and will crash piranha, as the tool has detected that it will clean up code in an invalid state.
+ */
+public final class PiranhaRuntimeException extends RuntimeException {
+
+  public PiranhaRuntimeException(String message) {
+    super(message);
+  }
+}

--- a/java/piranha/src/main/java/com/uber/piranha/PiranhaRuntimeException.java
+++ b/java/piranha/src/main/java/com/uber/piranha/PiranhaRuntimeException.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.uber.piranha;
 
 /**

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -38,12 +38,14 @@ import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ConditionalExpressionTree;
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.IfTree;
 import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.StatementTree;
@@ -55,17 +57,21 @@ import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
 import com.uber.piranha.config.Config;
 import com.uber.piranha.config.PiranhaConfigurationException;
+import com.uber.piranha.config.PiranhaEnumRecord;
 import com.uber.piranha.config.PiranhaMethodRecord;
 import com.uber.piranha.testannotations.AnnotationArgument;
 import com.uber.piranha.testannotations.ResolvedTestAnnotation;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.lang.model.element.ElementKind;
 
@@ -162,6 +168,10 @@ public class XPFlagCleaner extends BugChecker
 
   @Nullable
   private String treatmentGroupsEnum = null; // FQN of the enum containing the treatment group names
+
+  /** Caches results for enums with matching constructor args */
+  private final Map<EnumWithClassSymbol, Boolean> enumsMatchingConstructorArgsCache =
+      new HashMap<>();
 
   /**
    * when source is refactored, this specifies the end position for the refactoring until the
@@ -323,7 +333,7 @@ public class XPFlagCleaner extends BugChecker
   }
 
   /* Returns the appropriate XP API, if any, as given by the expression */
-  private API getXPAPI(ExpressionTree et) {
+  private API getXPAPI(ExpressionTree et, VisitorState state) {
     et = ASTHelpers.stripParentheses(et);
     Kind k = et.getKind();
     if (k.equals(Tree.Kind.METHOD_INVOCATION)) {
@@ -336,14 +346,16 @@ public class XPFlagCleaner extends BugChecker
       ImmutableCollection<PiranhaMethodRecord> methodRecords =
           this.config.getMethodRecordsForName(methodName);
       if (methodRecords.size() > 0) {
-        return getXPAPI(mit, methodRecords);
+        return getXPAPI(mit, state, methodRecords);
       }
     }
     return API.UNKNOWN;
   }
 
   private API getXPAPI(
-      MethodInvocationTree mit, ImmutableCollection<PiranhaMethodRecord> methodRecordsForName) {
+      MethodInvocationTree mit,
+      VisitorState state,
+      ImmutableCollection<PiranhaMethodRecord> methodRecordsForName) {
     for (PiranhaMethodRecord methodRecord : methodRecordsForName) {
       // when argumentIndex is specified, if mit's argument at argIndex doesn't match xpFlagName,
       // skip to next method property map
@@ -353,7 +365,7 @@ public class XPFlagCleaner extends BugChecker
         if (argumentIndex < mit.getArguments().size()) {
           ExpressionTree argTree = mit.getArguments().get(argumentIndex);
           Symbol argSym = ASTHelpers.getSymbol(argTree);
-          if (!isArgumentMatchesFlagName(argTree, argSym)) {
+          if (!isArgumentMatchesFlagName(argTree, state, argSym)) {
             continue;
           }
         } else {
@@ -385,10 +397,113 @@ public class XPFlagCleaner extends BugChecker
     return API.UNKNOWN;
   }
 
-  private boolean isArgumentMatchesFlagName(ExpressionTree argTree, Symbol argSym) {
+  private boolean isArgumentMatchesFlagName(
+      ExpressionTree argTree, VisitorState state, Symbol argSym) {
     return (isLiteralTreeAndMatchesFlagName(argTree)
         || isVarSymbolAndMatchesFlagName(argSym)
-        || isSymbolAndMatchesFlagName(argSym));
+        || isSymbolAndMatchesFlagName(argSym)
+        || isMatchingEnumFieldValue(argTree, state));
+  }
+
+  /*
+   * Matches on an enum in an expression tree. Covers the following 4 cases:
+   * 1. Unqualified import enum constant (e.g. "STALE_FLAG")
+   * 2. Qualified enum name (e.g. "TestExperimentName.STALE_FLAG")
+   * 3. Unqualified enum constant with method call (e.g. "STALE_FLAG.getKey()")
+   * 4. Qualified enum name with method call (e.g. "TestExperimentName.STALE_FLAG.getKey()")
+   */
+  private boolean isMatchingEnumFieldValue(ExpressionTree argTree, VisitorState state) {
+    // Skip if no enum records are configured, to avoid excessive AST lookups
+    if (!this.config.hasEnumRecords()) {
+      return false;
+    }
+
+    Symbol sym;
+    if (argTree.getKind() == Kind.IDENTIFIER) {
+      // Case 1: Unqualified enum constant (e.g. "STALE_FLAG")
+      sym = ASTHelpers.getSymbol(argTree);
+    } else if (argTree.getKind() == Kind.MEMBER_SELECT) {
+      // Case 2: Qualified enum name (e.g. "TestExperimentName.STALE_FLAG")
+      MemberSelectTree memberTree = (MemberSelectTree) argTree;
+      sym = ASTHelpers.getSymbol(memberTree);
+    } else if (argTree.getKind() == Kind.METHOD_INVOCATION) {
+      // Because the enum constant itself is being removed, we can remove any method called from
+      // that enum constant and not only specific, configured ones
+      MethodInvocationTree methodTree = (MethodInvocationTree) argTree;
+      if (methodTree.getMethodSelect().getKind() != Kind.MEMBER_SELECT) {
+        return false;
+      }
+      MemberSelectTree memberTree = (MemberSelectTree) methodTree.getMethodSelect();
+      if (memberTree.getExpression().getKind() == Kind.IDENTIFIER) {
+        // Case 3: Unqualified enum constant with method call (e.g. "STALE_FLAG.getKey()")
+        IdentifierTree identifier = (IdentifierTree) memberTree.getExpression();
+        sym = ASTHelpers.getSymbol(identifier);
+      } else if (memberTree.getExpression().getKind() == Kind.MEMBER_SELECT) {
+        // Case 4: Qualified enum name with method call (e.g.
+        // "TestExperimentName.STALE_FLAG.getKey()")
+        MemberSelectTree memberTreeExpression = (MemberSelectTree) memberTree.getExpression();
+        sym = ASTHelpers.getSymbol(memberTreeExpression);
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+
+    if (sym.getKind() != ElementKind.ENUM_CONSTANT) {
+      return false;
+    }
+
+    Symbol.ClassSymbol enclosingClass = ASTHelpers.enclosingClass(sym);
+
+    return isEnumConstantMatchingFlagName(sym.getSimpleName().toString(), enclosingClass, state);
+  }
+
+  /**
+   * Finds whether the current enum constant contains the flag string in its constructor arguments.
+   * Must also have a valid configuration record corresponding to this enum in order to return true.
+   *
+   * @param enumName Unqualified enum constant name (e.g. STALE_FLAG)
+   * @param classSymbol Enum class symbol for the corresponding constant
+   * @param state Used to find enum class in AST
+   */
+  public boolean isEnumConstantMatchingFlagName(
+      String enumName, Symbol.ClassSymbol classSymbol, VisitorState state) {
+
+    // Skip any enums that have no configuration
+    ImmutableCollection<PiranhaEnumRecord> enumRecords =
+        this.config.getEnumRecordsForName(classSymbol.getSimpleName().toString());
+    if (enumRecords.isEmpty()) {
+      return false;
+    }
+
+    // Check cached matches
+    EnumWithClassSymbol enumWithClassSymbol = new EnumWithClassSymbol(enumName, classSymbol);
+    if (enumsMatchingConstructorArgsCache.containsKey(enumWithClassSymbol)) {
+      return enumsMatchingConstructorArgsCache.get(enumWithClassSymbol);
+    }
+
+    ClassTree enumClassTree = ASTHelpers.findClass(classSymbol, state);
+    if (enumClassTree == null) {
+      return false;
+    }
+
+    List<? extends ExpressionTree> constructorArguments =
+        enumClassTree
+            .getMembers()
+            .stream()
+            .filter(member -> member.getKind() == Kind.VARIABLE)
+            .map(member -> ((VariableTree) member))
+            .filter(member -> member.getName().toString().equals(enumName))
+            .map(VariableTree::getInitializer)
+            .filter(Objects::nonNull)
+            .filter(initializer -> initializer.getKind() == Kind.NEW_CLASS)
+            .flatMap(enumConstructor -> ((NewClassTree) enumConstructor).getArguments().stream())
+            .collect(Collectors.toList());
+
+    boolean result = enumConstructorArgsContainsFlagName(constructorArguments, enumRecords);
+    enumsMatchingConstructorArgsCache.put(enumWithClassSymbol, result);
+    return result;
   }
 
   /**
@@ -491,7 +606,7 @@ public class XPFlagCleaner extends BugChecker
     }
 
     if (k.equals(Kind.METHOD_INVOCATION)) {
-      API api = getXPAPI(tree);
+      API api = getXPAPI(tree, state);
       if (api.equals(API.IS_TREATED)) {
         return isTreated ? Value.TRUE : Value.FALSE;
       } else if (api.equals(API.IS_CONTROL)) {
@@ -641,6 +756,18 @@ public class XPFlagCleaner extends BugChecker
                 .addFix(SuggestedFix.replace(importTree, "", 0, 1))
                 .build();
           }
+        } else {
+          // Check if this import matches an enum whose field value matches the flag name to remove
+          String enumName = memberSelectTree.getIdentifier().toString();
+          Symbol importSymbol = ASTHelpers.getSymbol(memberSelectTree.getExpression());
+
+          if (importSymbol.getKind().equals(ElementKind.ENUM)
+              && isEnumConstantMatchingFlagName(
+                  enumName, (Symbol.ClassSymbol) importSymbol, visitorState)) {
+            return buildDescription(importTree)
+                .addFix(SuggestedFix.replace(importTree, "", 0, 1))
+                .build();
+          }
         }
       }
     }
@@ -744,7 +871,7 @@ public class XPFlagCleaner extends BugChecker
 
     if (tree.getExpression().getKind().equals(Kind.METHOD_INVOCATION)) {
       MethodInvocationTree mit = (MethodInvocationTree) tree.getExpression();
-      API api = getXPAPI(mit);
+      API api = getXPAPI(mit, state);
       if (api.equals(API.DELETE_METHOD)
           || api.equals(API.SET_TREATED)
           || api.equals(API.SET_CONTROL)) {
@@ -798,36 +925,97 @@ public class XPFlagCleaner extends BugChecker
   @Override
   public Description matchVariable(VariableTree tree, VisitorState state) {
     if (shouldSkip(state)) return Description.NO_MATCH;
-    Symbol sym = FindIdentifiers.findIdent(xpFlagName, state);
+
+    Symbol identifier = FindIdentifiers.findIdent(xpFlagName, state);
+
     // Check if this is the flag definition and remove it.
-    if (sym != null && sym.isEnum() && sym.equals(ASTHelpers.getSymbol(tree))) {
-      xpSym = sym;
-      // Remove the flag symbol. This only works because the error prone patch is applied once
-      // after all files have been analyzed, otherwise targets that use the flag but haven't been
-      // cleaned up would be broken. We use replace with a position adjustment, to get rid of the
-      // trailing "," if present on the parent.
-      String enumAsStr = state.getSourceForNode(state.getPath().getParentPath().getLeaf());
-      String varAsStrWithComma = tree.getName().toString() + ",";
-      if (enumAsStr.contains(varAsStrWithComma)) {
-        return buildDescription(tree).addFix(SuggestedFix.replace(tree, "", 0, 1)).build();
-      } else {
-        // Fallback for single/last enum variable detection
-        return buildDescription(tree).addFix(SuggestedFix.delete(tree)).build();
-      }
-    } else if (sym == null
-        && tree != null
+    if (identifier != null
+        && identifier.isEnum()
+        && identifier.equals(ASTHelpers.getSymbol(tree))) {
+      xpSym = identifier;
+      return removeEnumValue(tree, state, tree.getName().toString());
+    } else if (identifier == null
         && ASTHelpers.getSymbol(tree) != null
         && xpFlagName.equals(ASTHelpers.getSymbol(tree).getConstantValue())) {
       return buildDescription(tree).addFix(SuggestedFix.delete(tree)).build();
     }
+
+    Symbol sym = ASTHelpers.getSymbol(tree);
+
+    // Also checks if this is the flag definition. However, this is for the case where xpFlagName
+    // does not match the enum constant itself, but instead, a String value in the enum constructor
+    // (e.g. STALE_FLAG("stale.flag"), where xpFlagName is "stale.flag")
+    if (sym != null && sym.isEnum() && tree.getInitializer().getKind() == Tree.Kind.NEW_CLASS) {
+      // Enum constructor
+      NewClassTree nct = (NewClassTree) tree.getInitializer();
+      String enumClassName = sym.enclClass().getSimpleName().toString();
+      ImmutableCollection<PiranhaEnumRecord> enumRecords =
+          this.config.getEnumRecordsForName(enumClassName);
+
+      boolean containsFlagName =
+          enumConstructorArgsContainsFlagName(nct.getArguments(), enumRecords);
+      if (containsFlagName) {
+        return removeEnumValue(tree, state, state.getSourceForNode(tree));
+      }
+    }
+
     return Description.NO_MATCH;
   }
 
+  /**
+   * Remove the flag symbol. This only works because the error prone patch is applied once after all
+   * files have been analyzed, otherwise targets that use the flag but haven't been cleaned up would
+   * be broken. We use replace with a position adjustment, to get rid of the trailing "," if present
+   * on the parent.
+   */
+  private Description removeEnumValue(VariableTree tree, VisitorState state, String varName) {
+    String enumAsStr = state.getSourceForNode(state.getPath().getParentPath().getLeaf());
+    String varAsStrWithComma = varName + ",";
+    if (enumAsStr != null && enumAsStr.contains(varAsStrWithComma)) {
+      return buildDescription(tree).addFix(SuggestedFix.replace(tree, "", 0, 1)).build();
+    } else {
+      // Fallback for single/last enum variable detection
+      return buildDescription(tree).addFix(SuggestedFix.delete(tree)).build();
+    }
+  }
+
+  /**
+   * Returns if an enum constructor with arguments, contains the {@link XPFlagCleaner#xpFlagName}
+   * value
+   */
+  private boolean enumConstructorArgsContainsFlagName(
+      List<? extends ExpressionTree> constructorArguments,
+      ImmutableCollection<PiranhaEnumRecord> enumRecordsForName) {
+    for (PiranhaEnumRecord enumRecord : enumRecordsForName) {
+      // when argumentIndex is specified, if the enum's constructor argument at
+      // argIndex doesn't match xpFlagName, skip to next enum property map
+      Optional<Integer> optionalArgumentIdx = enumRecord.getArgumentIdx();
+      if (optionalArgumentIdx.isPresent()) {
+        int argumentIndex = optionalArgumentIdx.get();
+        if (argumentIndex < constructorArguments.size()) {
+          ExpressionTree argument = constructorArguments.get(argumentIndex);
+          if (argument.getKind() == Kind.STRING_LITERAL) {
+            return ((LiteralTree) argument).getValue().equals(xpFlagName);
+          }
+        }
+      } else {
+        // when argumentIndex is not specified, if we find ANY constructor
+        // argument that matches flag name, return a match
+        return constructorArguments
+            .stream()
+            .filter(argument -> argument.getKind() == Kind.STRING_LITERAL)
+            .map(argument -> ((LiteralTree) argument).getValue())
+            .anyMatch(argument -> argument.equals(xpFlagName));
+      }
+    }
+    return false;
+  }
+
   private void recursiveScanTestMethodStats(
-      BlockTree blockTree, TestMethodCounters counters, int depth) {
+      BlockTree blockTree, VisitorState state, TestMethodCounters counters, int depth) {
     for (StatementTree statement : blockTree.getStatements()) {
       if (statement.getKind().equals(Tree.Kind.BLOCK)) {
-        recursiveScanTestMethodStats(blockTree, counters, depth + 1);
+        recursiveScanTestMethodStats(blockTree, state, counters, depth + 1);
       } else if (statement.getKind().equals(Kind.EXPRESSION_STATEMENT)) {
         counters.statements += 1;
         ExpressionTree expr = ((ExpressionStatementTree) statement).getExpression();
@@ -854,7 +1042,7 @@ public class XPFlagCleaner extends BugChecker
             // call is for the
             // flag being passed to Piranha.
             if (!isTreated && depth == 0) {
-              if (getXPAPI(mit).equals(API.SET_TREATED)) {
+              if (getXPAPI(mit, state).equals(API.SET_TREATED)) {
                 counters.topLevelObsoleteSetters += 1;
               }
             }
@@ -864,7 +1052,7 @@ public class XPFlagCleaner extends BugChecker
             // flag in the control
             // condition, while we are setting it to treated everywhere
             if (isTreated && depth == 0) {
-              if (getXPAPI(mit).equals(API.SET_CONTROL)) {
+              if (getXPAPI(mit, state).equals(API.SET_CONTROL)) {
                 counters.topLevelObsoleteSetters += 1;
               }
             }
@@ -903,13 +1091,13 @@ public class XPFlagCleaner extends BugChecker
    * @param tree A method tree that has already been detected as being an unit test method.
    * @return whether the method should be deleted based on the heuristic above.
    */
-  private boolean shouldCleanBySetters(MethodTree tree) {
+  private boolean shouldCleanBySetters(MethodTree tree, VisitorState state) {
     // This assumes that the method was already detected as a unit test and the corresponding
     // heuristic is enabled
     TestMethodCounters counters = new TestMethodCounters();
     // Count statements, all setter calls, and relevant top-level obsolete setters for the current
     // flag
-    recursiveScanTestMethodStats(tree.getBody(), counters, 0);
+    recursiveScanTestMethodStats(tree.getBody(), state, counters, 0);
     if (config.testMethodCleanupSizeLimit() < counters.statements) {
       // Skip, test method too large.
       return false;
@@ -974,7 +1162,7 @@ public class XPFlagCleaner extends BugChecker
       }
     } else if (config.shouldCleanTestMethodsByContent()
         && PiranhaUtils.isUnitTestMethod(tree, state)) {
-      deleteMethod = shouldCleanBySetters(tree);
+      deleteMethod = shouldCleanBySetters(tree, state);
     }
     // Early exit for no changes required:
     if (!deleteMethod && deletableAnnotations.size() == 0 && deletableIdentifiers.size() == 0) {
@@ -1186,7 +1374,7 @@ public class XPFlagCleaner extends BugChecker
 
   /**
    * A small tuple of counters for scanning unit tests to be deleted by the setters heuristic. See
-   * {@link #shouldCleanBySetters(MethodTree)}
+   * {@link #shouldCleanBySetters(MethodTree, VisitorState)}
    */
   private static final class TestMethodCounters {
     public long statements;

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaEnumRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaEnumRecord.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha.config;
+
+import static com.uber.piranha.config.PiranhaRecord.getArgumentIndexFromMap;
+import static com.uber.piranha.config.PiranhaRecord.getValueStringFromMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+/** A class representing an enum configuration record from properties.json */
+public final class PiranhaEnumRecord {
+
+  // Allowed fields for a enum property in the config file.
+  // Entered under the top-level "enumProperties" in properties.json.
+  // By default, enumName and argumentIndex fields are mandatory.
+  private static final String ENUM_NAME_KEY = "enumName";
+  private static final String ARGUMENT_INDEX_KEY = "argumentIndex";
+
+  private final String enumName;
+  private final Optional<Integer> argumentIdx;
+
+  PiranhaEnumRecord(String enumName, Optional<Integer> argumentIdx) {
+    this.enumName = enumName;
+    this.argumentIdx = argumentIdx;
+  }
+
+  public String getEnumName() {
+    return enumName;
+  }
+
+  public Optional<Integer> getArgumentIdx() {
+    return argumentIdx;
+  }
+
+  /**
+   * Parse the entry for a single enum from piranha.json that has been previously decoded into a map
+   *
+   * @param enumPropertyEntry The decoded json entry (as a Map of property names to values)
+   * @param isArgumentIndexOptional Whether argumentIdx should be treated as optional
+   * @return A PiranhaEnumPropertyRecord corresponding to the given map/json record.
+   * @throws PiranhaConfigurationException if there was any issue reading or parsing the
+   *     configuration file.
+   */
+  static PiranhaEnumRecord parseFromJSONPropertyEntryMap(
+      Map<String, Object> enumPropertyEntry, boolean isArgumentIndexOptional)
+      throws PiranhaConfigurationException {
+    String enumName = getValueStringFromMap(enumPropertyEntry, ENUM_NAME_KEY);
+    Integer argumentIndexInteger = getArgumentIndexFromMap(enumPropertyEntry, ARGUMENT_INDEX_KEY);
+    if (enumName == null) {
+      throw new PiranhaConfigurationException(
+          "enumProperty is missing mandatory enumName field. Check:\n" + enumPropertyEntry);
+    } else if (!isArgumentIndexOptional && argumentIndexInteger == null) {
+      throw new PiranhaConfigurationException(
+          "enumProperty did not have argumentIndex. By default, Piranha requires an argument index for flag "
+              + "APIs, to which the flag name/symbol will be passed. This is to avoid over-deletion of all "
+              + "occurrences of a flag API method. If you are sure you want to delete all instances of the "
+              + "method below, consider using Piranha:ArgumentIndexOptional=true to override this behavior. "
+              + "Check:\n"
+              + enumPropertyEntry);
+    } else if (argumentIndexInteger != null && argumentIndexInteger < 0) {
+      throw new PiranhaConfigurationException(
+          "Invalid argumentIndex field. Arguments are zero indexed. Check:\n" + enumPropertyEntry);
+    }
+
+    return new PiranhaEnumRecord(enumName, Optional.ofNullable(argumentIndexInteger));
+  }
+}

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaMethodRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaMethodRecord.java
@@ -1,10 +1,25 @@
+/**
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.uber.piranha.config;
+
+import static com.uber.piranha.config.PiranhaRecord.getArgumentIndexFromMap;
+import static com.uber.piranha.config.PiranhaRecord.getValueStringFromMap;
 
 import com.google.common.collect.ImmutableMap;
 import com.uber.piranha.XPFlagCleaner;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 /** A class representing a method configuration record from properties.json */
 public final class PiranhaMethodRecord {
@@ -77,42 +92,6 @@ public final class PiranhaMethodRecord {
   }
 
   /**
-   * Utility method. Checks whether the value associated to a given map and given key is a non-empty
-   * string.
-   *
-   * @param map - map corresponding to a method property
-   * @param key - key to check the corresponding value
-   * @return String if value is a non-empty string, null otherwise
-   */
-  @Nullable
-  private static String getValueStringFromMap(Map<String, Object> map, String key) {
-    Object value = map.get(key);
-    if (value instanceof String && !value.equals("")) {
-      return String.valueOf(value);
-    }
-    return null;
-  }
-
-  /**
-   * Utility method. Checks whether the argumentIndex key of a method property map is a non-negative
-   * integer.
-   *
-   * @param map - map corresponding to a method property
-   * @return argumentIndex if argument index is a non-negative integer, null otherwise
-   */
-  @Nullable
-  private static Integer getArgumentIndexFromMap(Map<String, Object> map) {
-    Object value = map.get(ARGUMENT_INDEX_KEY);
-    if (value instanceof Long) {
-      int argumentIndex = ((Long) value).intValue();
-      if (argumentIndex >= 0) {
-        return argumentIndex;
-      }
-    }
-    return null;
-  }
-
-  /**
    * Parse the entry for a single method from piranha.json that has been previously decoded into a
    * map
    *
@@ -127,7 +106,7 @@ public final class PiranhaMethodRecord {
       throws PiranhaConfigurationException {
     String methodName = getValueStringFromMap(methodPropertyEntry, METHOD_NAME_KEY);
     String flagType = getValueStringFromMap(methodPropertyEntry, FLAG_TYPE_KEY);
-    Integer argumentIndexInteger = getArgumentIndexFromMap(methodPropertyEntry);
+    Integer argumentIndexInteger = getArgumentIndexFromMap(methodPropertyEntry, ARGUMENT_INDEX_KEY);
     if (methodName == null) {
       throw new PiranhaConfigurationException(
           "methodProperty is missing mandatory methodName field. Check:\n" + methodPropertyEntry);

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaRecord.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha.config;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/** Utility methods used by {@link PiranhaEnumRecord} and {@link PiranhaMethodRecord} classes */
+public class PiranhaRecord {
+  /**
+   * Utility method. Checks whether the value associated to a given map and given key is a non-empty
+   * string.
+   *
+   * @param map - map corresponding to a method property
+   * @param key - key to check the corresponding value
+   * @return String if value is a non-empty string, null otherwise
+   */
+  @Nullable
+  static String getValueStringFromMap(Map<String, Object> map, String key) {
+    Object value = map.get(key);
+    if (value instanceof String && !value.equals("")) {
+      return String.valueOf(value);
+    }
+    return null;
+  }
+
+  /**
+   * Utility method. Checks whether the argumentIndex key of a method property map is a non-negative
+   * integer.
+   *
+   * @param map - map corresponding to a method property
+   * @return argumentIndex if argument index is a non-negative integer, null otherwise
+   */
+  @Nullable
+  static Integer getArgumentIndexFromMap(Map<String, Object> map, String argumentIndexKey) {
+    Object value = map.get(argumentIndexKey);
+    if (value instanceof Long) {
+      int argumentIndex = ((Long) value).intValue();
+      if (argumentIndex >= 0) {
+        return argumentIndex;
+      }
+    }
+    return null;
+  }
+}

--- a/java/piranha/src/test/java/com/uber/piranha/EnumConstantTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/EnumConstantTest.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha;
+
+import static com.uber.piranha.PiranhaTestingHelpers.addExperimentFlagEnumsWithConstructor;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.ErrorProneFlags;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * This test suite tests Piranha logic relating to enum constants with custom constructors with
+ * arguments that match on a flag value
+ *
+ * <p>See: <a href="https://github.com/uber/piranha/issues/141">Issue #141</a>
+ */
+@RunWith(JUnit4.class)
+public class EnumConstantTest {
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  /**
+   * Test to check that Java enum constants are removed when they have a constructor with an
+   * argument that matches the flag value, for an untreated flag
+   *
+   * <p>Also tests flags that use unqualified enum constant usages, and enum method calls
+   */
+  @Test
+  public void testRemoveEnumFieldValueMatchUntreated() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "stale.flag");
+    b.putFlag("Piranha:IsTreated", "false");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr = addExperimentFlagEnumsWithConstructor(bcr, true); // Adds STALE_FLAG, etc enums
+
+    bcr.addInputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG;",
+            "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
+            "class PositiveCaseEnumTest {",
+            "  private XPTest experimentation;",
+            "  public void printFlags() {",
+            "    if (experimentation.isToggleEnabled(STALE_FLAG)) {",
+            "      System.out.println(\"Stale Flag\");",
+            "    }",
+            "    if (experimentation.isToggleDisabled(STALE_FLAG.getKey())) {",
+            "      System.out.println(\"Stale Flag getKey\");",
+            "    }",
+            "    if (experimentation.isToggleEnabled(OTHER_FLAG)) {",
+            "      System.out.println(\"Other Flag\");",
+            "    }",
+            "    if (experimentation.isToggleDisabled(OTHER_FLAG.getKey())) {",
+            "      System.out.println(\"Other Flag getKey\");",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG;",
+            "class PositiveCaseEnumTest {",
+            "  private XPTest experimentation;",
+            "  public void printFlags() {",
+            "    System.out.println(\"Stale Flag getKey\");",
+            "    if (experimentation.isToggleEnabled(OTHER_FLAG)) {",
+            "      System.out.println(\"Other Flag\");",
+            "    }",
+            "    if (experimentation.isToggleDisabled(OTHER_FLAG.getKey())) {",
+            "      System.out.println(\"Other Flag getKey\");",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  /**
+   * Test to check that Java enum constants are removed when they have a constructor with an
+   * argument that matches the flag value, for a treated flag
+   *
+   * <p>Also tests flags that use qualified enum constant usages, and enum method calls
+   */
+  @Test
+  public void testRemoveEnumFieldValueMatchTreated() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "stale.flag");
+    b.putFlag("Piranha:IsTreated", "true");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr = addExperimentFlagEnumsWithConstructor(bcr, true); // Adds STALE_FLAG, etc enums
+
+    bcr.addInputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG;",
+            "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
+            "class PositiveCaseEnumTest {",
+            "  private XPTest experimentation;",
+            "  public void printFlags() {",
+            "    if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {",
+            "      System.out.println(\"Stale Flag\");",
+            "    }",
+            "    if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG.getKey())) {",
+            "      System.out.println(\"Stale Flag getKey\");",
+            "    }",
+            "    if (experimentation.isToggleEnabled(TestExperimentName.OTHER_FLAG)) {",
+            "      System.out.println(\"Other Flag\");",
+            "    }",
+            "    if (experimentation.isToggleEnabled(TestExperimentName.OTHER_FLAG.getKey())) {",
+            "      System.out.println(\"Other Flag getKey\");",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG;",
+            "class PositiveCaseEnumTest {",
+            "  private XPTest experimentation;",
+            "  public void printFlags() {",
+            "    System.out.println(\"Stale Flag\");",
+            "    System.out.println(\"Stale Flag getKey\");",
+            "    if (experimentation.isToggleEnabled(TestExperimentName.OTHER_FLAG)) {",
+            "      System.out.println(\"Other Flag\");",
+            "    }",
+            "    if (experimentation.isToggleEnabled(TestExperimentName.OTHER_FLAG.getKey())) {",
+            "      System.out.println(\"Other Flag getKey\");",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  /**
+   * Test to check that Java enum constants are removed when they have a constructor with an
+   * argument that matches the flag value, for an untreated flag, in test code
+   *
+   * <p>Also tests flags that use unqualified enum constant usages, and enum method calls
+   */
+  @Test
+  public void testRemoveEnumFieldValueMatchTest() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "stale.flag");
+    b.putFlag("Piranha:IsTreated", "false");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr = addExperimentFlagEnumsWithConstructor(bcr, true); // Adds STALE_FLAG, etc enums
+
+    bcr.addInputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG;",
+            "import static com.uber.piranha.TestExperimentName.STALE_FLAG;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_StaleFlag_treated() {",
+            "     experimentation.putToggleEnabled(STALE_FLAG);",
+            "     System.err.println(\"To be removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_StaleFlag_treated_methodCall() {",
+            "     experimentation.putToggleEnabled(STALE_FLAG.getKey());",
+            "     System.err.println(\"To be removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_treated() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_treated_methodCall() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG.getKey());",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "TestClass.java",
+            "package com.uber.piranha;",
+            "import org.junit.Test;",
+            "import static com.uber.piranha.TestExperimentName.OTHER_FLAG;",
+            "class TestClass {",
+            "  private XPTest experimentation;",
+            "  @Test",
+            "  public void test_OtherFlag_treated() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG);",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "  @Test",
+            "  public void test_OtherFlag_treated_methodCall() {",
+            "     experimentation.putToggleEnabled(OTHER_FLAG.getKey());",
+            "     System.err.println(\"Not removed\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/java/piranha/src/test/java/com/uber/piranha/PiranhaTestingHelpers.java
+++ b/java/piranha/src/test/java/com/uber/piranha/PiranhaTestingHelpers.java
@@ -23,4 +23,39 @@ public final class PiranhaTestingHelpers {
       BugCheckerRefactoringTestHelper bcr) throws IOException {
     return bcr.addInput("XPTest.java").expectUnchanged();
   }
+
+  public static BugCheckerRefactoringTestHelper addExperimentFlagEnumsWithConstructor(
+      BugCheckerRefactoringTestHelper bcr, boolean hasEnumConfiguration) {
+    BugCheckerRefactoringTestHelper.ExpectOutput inputLines =
+        bcr.addInputLines(
+            "TestExperimentName.java",
+            "package com.uber.piranha;",
+            "public enum TestExperimentName {",
+            " STALE_FLAG(\"stale.flag\"),",
+            // TODO: Fix needed to handle cleanup of final constant with semicolon
+            " OTHER_FLAG(\"other\");",
+            " private final String key;",
+            " public String getKey() {",
+            "   return key;",
+            " }",
+            " TestExperimentName(final String key) {",
+            "  this.key = key;",
+            " }",
+            "}");
+    return hasEnumConfiguration
+        ? inputLines.addOutputLines(
+            "TestExperimentName.java",
+            "package com.uber.piranha;",
+            "public enum TestExperimentName {",
+            " OTHER_FLAG(\"other\");",
+            " private final String key;",
+            " public String getKey() {",
+            "   return key;",
+            " }",
+            " TestExperimentName(final String key) {",
+            "  this.key = key;",
+            " }",
+            "}")
+        : inputLines.expectUnchanged();
+  }
 }

--- a/java/piranha/src/test/resources/config/properties_test_with_enum_no_match.json
+++ b/java/piranha/src/test/resources/config/properties_test_with_enum_no_match.json
@@ -1,0 +1,15 @@
+{
+  "methodProperties": [
+    {
+      "methodName": "putToggleEnabled",
+      "flagType": "set_treated",
+      "argumentIndex": 0
+    }
+  ],
+  "enumProperties": [
+    {
+      "enumName": "SomeOtherExperimentName",
+      "argumentIndex": 0
+    }
+  ]
+}

--- a/java/piranha/src/test/resources/config/properties_test_with_enum_wrong_arg.json
+++ b/java/piranha/src/test/resources/config/properties_test_with_enum_wrong_arg.json
@@ -1,0 +1,15 @@
+{
+  "methodProperties": [
+    {
+      "methodName": "putToggleEnabled",
+      "flagType": "set_treated",
+      "argumentIndex": 0
+    }
+  ],
+  "enumProperties": [
+    {
+      "enumName": "TestExperimentName",
+      "argumentIndex": 1
+    }
+  ]
+}

--- a/java/piranha/src/test/resources/config/properties_test_without_enum.json
+++ b/java/piranha/src/test/resources/config/properties_test_without_enum.json
@@ -1,0 +1,9 @@
+{
+  "methodProperties": [
+    {
+      "methodName": "putToggleEnabled",
+      "flagType": "set_treated",
+      "argumentIndex": 0
+    }
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/uber/piranha/issues/141

Adds an optional top-level field to the config called `enumProperties`. What this field does, is if the user specifies an enum class name, Piranha will remove enum constants that have a constructor with an argument that matches that `FlagName` value, along with their usages.
