### PR TITLE
[PiranhaJava] Remove configured test methods

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -115,7 +115,7 @@ when `IsTreated` is `true`, and will be deleted completely when `IsTreated` is `
 
 An optional top-level field is `testMethodProperties`.
 
-Within that, there is an array of JSON objects, having the required fields `methodName` and `argumentIndex`. The both behave the same as the fields with the same name in `methodProperties`.
+Within that, there is an array of JSON objects, having the required fields `methodName` and `argumentIndex`. They both behave the same as the fields with the same name in `methodProperties`.
 
 What this field does, is that if we find one of the `methodProperties` fields inside a method that matches one of the methods in `testMethodProperties`, we remove that method. This is useful for removing `mock()` wrappers or `assert()` calls that are no longer useful after a flag is cleaned up.
 

--- a/java/README.md
+++ b/java/README.md
@@ -65,6 +65,13 @@ The properties file has the following template:
       },
       ...
     ],
+  "testMethodProperties": [
+    {
+      "methodName": "when",
+      "argumentIndex": 0
+    },
+    ...
+  ],
   "enumProperties":
     [
       {
@@ -106,7 +113,13 @@ public void some_unit_test() { ... }
 
 when `IsTreated` is `true`, and will be deleted completely when `IsTreated` is `false`.
 
-An optional top-level field is `enumProperties`.
+An optional top-level field is `testMethodProperties`.
+
+Within that, there is an array of JSON objects, having the required fields `methodName` and `argumentIndex`. The both behave the same as the fields with the same name in `methodProperties`.
+
+What this field does, is that if we find one of the `methodProperties` fields inside a method that matches one of the methods in `testMethodProperties`, we remove that method. This is useful for removing `mock()` wrappers or `assert()` calls that are no longer useful after a flag is cleaned up.
+
+Another optional top-level field is `enumProperties`.
 Within that, there is an array of JSON objects, having the required fields `enumName` and `argumentIndex`.
 
 What this field does, is if you specify an enum class name, Piranha will remove enum constants that have a constructor with a string argument that matches your `FlagName` value, along with their usages.

--- a/java/piranha/config/properties.json
+++ b/java/piranha/config/properties.json
@@ -38,6 +38,20 @@
       "argumentIndex": 0
     }
   ],
+  "testMethodProperties": [
+    {
+      "methodName": "mock",
+      "argumentIndex": 0
+    },
+    {
+      "methodName": "accept",
+      "argumentIndex": 0
+    },
+    {
+      "methodName": "expect",
+      "argumentIndex": 1
+    }
+  ],
   "linkURL": "<provide_your_url>",
   "annotations": [
     "ToggleTesting",

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -58,7 +58,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.uber.piranha.config.Config;
 import com.uber.piranha.config.PiranhaConfigurationException;
 import com.uber.piranha.config.PiranhaEnumRecord;
-import com.uber.piranha.config.PiranhaMethodRecord;
+import com.uber.piranha.config.PiranhaFlagMethodRecord;
 import com.uber.piranha.testannotations.AnnotationArgument;
 import com.uber.piranha.testannotations.ResolvedTestAnnotation;
 import java.util.ArrayList;
@@ -344,7 +344,7 @@ public class XPFlagCleaner extends BugChecker
       }
       MemberSelectTree mst = (MemberSelectTree) mit.getMethodSelect();
       String methodName = mst.getIdentifier().toString();
-      ImmutableCollection<PiranhaMethodRecord> methodRecords =
+      ImmutableCollection<PiranhaFlagMethodRecord> methodRecords =
           this.config.getMethodRecordsForName(methodName);
       if (methodRecords.size() > 0) {
         return getXPAPI(mit, state, methodRecords);
@@ -356,8 +356,8 @@ public class XPFlagCleaner extends BugChecker
   private API getXPAPI(
       MethodInvocationTree mit,
       VisitorState state,
-      ImmutableCollection<PiranhaMethodRecord> methodRecordsForName) {
-    for (PiranhaMethodRecord methodRecord : methodRecordsForName) {
+      ImmutableCollection<PiranhaFlagMethodRecord> methodRecordsForName) {
+    for (PiranhaFlagMethodRecord methodRecord : methodRecordsForName) {
       // when argumentIndex is specified, if mit's argument at argIndex doesn't match xpFlagName,
       // skip to next method property map
       Optional<Integer> optionalArgumentIdx = methodRecord.getArgumentIdx();
@@ -1192,7 +1192,7 @@ public class XPFlagCleaner extends BugChecker
         // only when the flag name matches, and we want to verify that no calls are being made to
         // set
         // unrelated flags (i.e. count them in counters.allSetters).
-        for (PiranhaMethodRecord methodRecord : config.getMethodRecordsForName(methodName)) {
+        for (PiranhaFlagMethodRecord methodRecord : config.getMethodRecordsForName(methodName)) {
           if (methodRecord.getApiType().equals(XPFlagCleaner.API.SET_TREATED)) {
             counters.allSetters += 1;
             // If the test is asking for the flag in treated condition, but we are setting it to

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaFlagMethodRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaFlagMethodRecord.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha.config;
+
+import static com.uber.piranha.config.PiranhaRecord.getArgumentIndexFromMap;
+import static com.uber.piranha.config.PiranhaRecord.getValueStringFromMap;
+
+import com.google.common.collect.ImmutableMap;
+import com.uber.piranha.XPFlagCleaner;
+import java.util.Map;
+import java.util.Optional;
+
+/** A class representing a flag method configuration record from properties.json */
+public final class PiranhaFlagMethodRecord implements PiranhaMethodRecord {
+
+  // Allowed fields for a method property in the config file.
+  // Entered under the top-level "methodProperties" in properties.json.
+  // By default, the flagType, methodName and argumentIndex fields are mandatory.
+  // The returnType and receiverType fields are optional.
+  private static final String FLAG_TYPE_KEY = "flagType";
+  private static final String METHOD_NAME_KEY = "methodName";
+  private static final String ARGUMENT_INDEX_KEY = "argumentIndex";
+  private static final String RETURN_TYPE_STRING = "returnType";
+  private static final String RECEIVER_TYPE_STRING = "receiverType";
+
+  /**
+   * Holds the mapping of flagType string to API. Eg: "treated" -> API.IS_TREATED. Is initialized
+   * once and then accessed without updating.
+   */
+  private static final ImmutableMap<String, XPFlagCleaner.API> flagTypeToAPIMap =
+      initializeFlagTypeToAPIMap();
+
+  private final String methodName;
+  private final XPFlagCleaner.API apiType;
+  private final Optional<Integer> argumentIdx;
+  private final Optional<String> receiverType;
+  private final Optional<String> returnType;
+
+  PiranhaFlagMethodRecord(
+      String methodName,
+      String flagTypeString,
+      Optional<Integer> argumentIdx,
+      Optional<String> receiverType,
+      Optional<String> returnType) {
+    this.methodName = methodName;
+    this.apiType = flagTypeToAPIMap.getOrDefault(flagTypeString, XPFlagCleaner.API.UNKNOWN);
+    this.argumentIdx = argumentIdx;
+    this.receiverType = receiverType;
+    this.returnType = returnType;
+  }
+
+  @Override
+  public String getMethodName() {
+    return methodName;
+  }
+
+  public XPFlagCleaner.API getApiType() {
+    return apiType;
+  }
+
+  @Override
+  public Optional<Integer> getArgumentIdx() {
+    return argumentIdx;
+  }
+
+  @Override
+  public Optional<String> getReceiverType() {
+    return receiverType;
+  }
+
+  @Override
+  public Optional<String> getReturnType() {
+    return returnType;
+  }
+
+  private static ImmutableMap<String, XPFlagCleaner.API> initializeFlagTypeToAPIMap() {
+    ImmutableMap.Builder<String, XPFlagCleaner.API> builder = new ImmutableMap.Builder<>();
+    builder.put("treated", XPFlagCleaner.API.IS_TREATED);
+    builder.put("control", XPFlagCleaner.API.IS_CONTROL);
+    builder.put("set_treated", XPFlagCleaner.API.SET_TREATED);
+    builder.put("set_control", XPFlagCleaner.API.SET_CONTROL);
+    builder.put("empty", XPFlagCleaner.API.DELETE_METHOD);
+    builder.put("treatmentGroup", XPFlagCleaner.API.IS_TREATMENT_GROUP_CHECK);
+    return builder.build();
+  }
+
+  /**
+   * Parse the entry for a single method from piranha.json that has been previously decoded into a
+   * map
+   *
+   * @param methodPropertyEntry The decoded json entry (as a Map of property names to values)
+   * @param isArgumentIndexOptional Whether argumentIdx should be treated as optional
+   * @return A PiranhaFlagMethodRecord corresponding to the given map/json record.
+   * @throws PiranhaConfigurationException if there was any issue reading or parsing the
+   *     configuration file.
+   */
+  static PiranhaFlagMethodRecord parseFromJSONPropertyEntryMap(
+      Map<String, Object> methodPropertyEntry, boolean isArgumentIndexOptional)
+      throws PiranhaConfigurationException {
+    String methodName = getValueStringFromMap(methodPropertyEntry, METHOD_NAME_KEY);
+    String flagType = getValueStringFromMap(methodPropertyEntry, FLAG_TYPE_KEY);
+    Integer argumentIndexInteger = getArgumentIndexFromMap(methodPropertyEntry, ARGUMENT_INDEX_KEY);
+    if (methodName == null) {
+      throw new PiranhaConfigurationException(
+          "methodProperty is missing mandatory methodName field. Check:\n" + methodPropertyEntry);
+    } else if (flagType == null) {
+      throw new PiranhaConfigurationException(
+          "methodProperty is missing mandatory flagType field. Check:\n" + methodPropertyEntry);
+    } else if (!isArgumentIndexOptional && argumentIndexInteger == null) {
+      throw new PiranhaConfigurationException(
+          "methodProperty did not have argumentIndex. By default, Piranha requires an argument index for flag "
+              + "APIs, to which the flag name/symbol will be passed. This is to avoid over-deletion of all "
+              + "occurrences of a flag API method. If you are sure you want to delete all instances of the "
+              + "method below, consider using Piranha:ArgumentIndexOptional=true to override this behavior. "
+              + "Check:\n"
+              + methodPropertyEntry);
+    } else if (argumentIndexInteger != null && argumentIndexInteger < 0) {
+      throw new PiranhaConfigurationException(
+          "Invalid argumentIndex field. Arguments are zero indexed. Check:\n"
+              + methodPropertyEntry);
+    }
+
+    return new PiranhaFlagMethodRecord(
+        methodName,
+        flagType,
+        Optional.ofNullable(argumentIndexInteger),
+        Optional.ofNullable(getValueStringFromMap(methodPropertyEntry, RECEIVER_TYPE_STRING)),
+        Optional.ofNullable(getValueStringFromMap(methodPropertyEntry, RETURN_TYPE_STRING)));
+  }
+}

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaMethodRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaMethodRecord.java
@@ -18,6 +18,7 @@ import static com.uber.piranha.config.PiranhaRecord.getValueStringFromMap;
 
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /** An interface representing a method configuration record from properties.json */
 public interface PiranhaMethodRecord {
@@ -60,6 +61,7 @@ public interface PiranhaMethodRecord {
     return flagType;
   }
 
+  @Nullable
   static Integer parseArgumentIndexFromJSON(
       String propertyName, Map<String, Object> methodPropertyEntry, boolean isArgumentIndexOptional)
       throws PiranhaConfigurationException {

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaMethodRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaMethodRecord.java
@@ -13,10 +13,24 @@
  */
 package com.uber.piranha.config;
 
+import static com.uber.piranha.config.PiranhaRecord.getArgumentIndexFromMap;
+import static com.uber.piranha.config.PiranhaRecord.getValueStringFromMap;
+
+import java.util.Map;
 import java.util.Optional;
 
 /** An interface representing a method configuration record from properties.json */
 public interface PiranhaMethodRecord {
+  // Allowed fields for a method property in the config file.
+  // Entered under the top-level "methodProperties" or "testMethodProperties" in properties.json.
+  // By default, the flagType, methodName and argumentIndex fields are mandatory.
+  // The returnType and receiverType fields are optional.
+  String FLAG_TYPE_KEY = "flagType";
+  String METHOD_NAME_KEY = "methodName";
+  String ARGUMENT_INDEX_KEY = "argumentIndex";
+  String RETURN_TYPE_STRING = "returnType";
+  String RECEIVER_TYPE_STRING = "receiverType";
+
   String getMethodName();
 
   Optional<Integer> getArgumentIdx();
@@ -24,4 +38,46 @@ public interface PiranhaMethodRecord {
   Optional<String> getReceiverType();
 
   Optional<String> getReturnType();
+
+  static String parseMethodNameFromJSON(
+      String propertyName, Map<String, Object> methodPropertyEntry)
+      throws PiranhaConfigurationException {
+    String methodName = getValueStringFromMap(methodPropertyEntry, METHOD_NAME_KEY);
+    if (methodName == null) {
+      throw new PiranhaConfigurationException(
+          propertyName + " is missing mandatory methodName field. Check:\n" + methodPropertyEntry);
+    }
+    return methodName;
+  }
+
+  static String parseFlagTypeFromJSON(String propertyName, Map<String, Object> methodPropertyEntry)
+      throws PiranhaConfigurationException {
+    String flagType = getValueStringFromMap(methodPropertyEntry, FLAG_TYPE_KEY);
+    if (flagType == null) {
+      throw new PiranhaConfigurationException(
+          propertyName + " is missing mandatory flagType field. Check:\n" + methodPropertyEntry);
+    }
+    return flagType;
+  }
+
+  static Integer parseArgumentIndexFromJSON(
+      String propertyName, Map<String, Object> methodPropertyEntry, boolean isArgumentIndexOptional)
+      throws PiranhaConfigurationException {
+    Integer argumentIndexInteger = getArgumentIndexFromMap(methodPropertyEntry, ARGUMENT_INDEX_KEY);
+    if (!isArgumentIndexOptional && argumentIndexInteger == null) {
+      throw new PiranhaConfigurationException(
+          propertyName
+              + " did not have argumentIndex. By default, Piranha requires an argument index for flag "
+              + "APIs, to which the flag name/symbol will be passed. This is to avoid over-deletion of all "
+              + "occurrences of a flag API method. If you are sure you want to delete all instances of the "
+              + "method below, consider using Piranha:ArgumentIndexOptional=true to override this behavior. "
+              + "Check:\n"
+              + methodPropertyEntry);
+    } else if (argumentIndexInteger != null && argumentIndexInteger < 0) {
+      throw new PiranhaConfigurationException(
+          "Invalid argumentIndex field. Arguments are zero indexed. Check:\n"
+              + methodPropertyEntry);
+    }
+    return argumentIndexInteger;
+  }
 }

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaMethodRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaMethodRecord.java
@@ -13,125 +13,15 @@
  */
 package com.uber.piranha.config;
 
-import static com.uber.piranha.config.PiranhaRecord.getArgumentIndexFromMap;
-import static com.uber.piranha.config.PiranhaRecord.getValueStringFromMap;
-
-import com.google.common.collect.ImmutableMap;
-import com.uber.piranha.XPFlagCleaner;
-import java.util.Map;
 import java.util.Optional;
 
-/** A class representing a method configuration record from properties.json */
-public final class PiranhaMethodRecord {
+/** An interface representing a method configuration record from properties.json */
+public interface PiranhaMethodRecord {
+  String getMethodName();
 
-  // Allowed fields for a method property in the config file.
-  // Entered under the top-level "methodProperties" in properties.json.
-  // By default, the flagType, methodName and argumentIndex fields are mandatory.
-  // The returnType and receiverType fields are optional.
-  private static final String FLAG_TYPE_KEY = "flagType";
-  private static final String METHOD_NAME_KEY = "methodName";
-  private static final String ARGUMENT_INDEX_KEY = "argumentIndex";
-  private static final String RETURN_TYPE_STRING = "returnType";
-  private static final String RECEIVER_TYPE_STRING = "receiverType";
+  Optional<Integer> getArgumentIdx();
 
-  /**
-   * Holds the mapping of flagType string to API. Eg: "treated" -> API.IS_TREATED. Is initialized
-   * once and then accessed without updating.
-   */
-  private static final ImmutableMap<String, XPFlagCleaner.API> flagTypeToAPIMap =
-      initializeFlagTypeToAPIMap();
+  Optional<String> getReceiverType();
 
-  private final String methodName;
-  private final XPFlagCleaner.API apiType;
-  private final Optional<Integer> argumentIdx;
-  private final Optional<String> receiverType;
-  private final Optional<String> returnType;
-
-  PiranhaMethodRecord(
-      String methodName,
-      String flagTypeString,
-      Optional<Integer> argumentIdx,
-      Optional<String> receiverType,
-      Optional<String> returnType) {
-    this.methodName = methodName;
-    this.apiType = flagTypeToAPIMap.getOrDefault(flagTypeString, XPFlagCleaner.API.UNKNOWN);
-    this.argumentIdx = argumentIdx;
-    this.receiverType = receiverType;
-    this.returnType = returnType;
-  }
-
-  public String getMethodName() {
-    return methodName;
-  }
-
-  public XPFlagCleaner.API getApiType() {
-    return apiType;
-  }
-
-  public Optional<Integer> getArgumentIdx() {
-    return argumentIdx;
-  }
-
-  public Optional<String> getReceiverType() {
-    return receiverType;
-  }
-
-  public Optional<String> getReturnType() {
-    return returnType;
-  }
-
-  private static ImmutableMap<String, XPFlagCleaner.API> initializeFlagTypeToAPIMap() {
-    ImmutableMap.Builder<String, XPFlagCleaner.API> builder = new ImmutableMap.Builder<>();
-    builder.put("treated", XPFlagCleaner.API.IS_TREATED);
-    builder.put("control", XPFlagCleaner.API.IS_CONTROL);
-    builder.put("set_treated", XPFlagCleaner.API.SET_TREATED);
-    builder.put("set_control", XPFlagCleaner.API.SET_CONTROL);
-    builder.put("empty", XPFlagCleaner.API.DELETE_METHOD);
-    builder.put("treatmentGroup", XPFlagCleaner.API.IS_TREATMENT_GROUP_CHECK);
-    return builder.build();
-  }
-
-  /**
-   * Parse the entry for a single method from piranha.json that has been previously decoded into a
-   * map
-   *
-   * @param methodPropertyEntry The decoded json entry (as a Map of property names to values)
-   * @param isArgumentIndexOptional Whether argumentIdx should be treated as optional
-   * @return A PiranhaMethodRecord corresponding to the given map/json record.
-   * @throws PiranhaConfigurationException if there was any issue reading or parsing the
-   *     configuration file.
-   */
-  static PiranhaMethodRecord parseFromJSONPropertyEntryMap(
-      Map<String, Object> methodPropertyEntry, boolean isArgumentIndexOptional)
-      throws PiranhaConfigurationException {
-    String methodName = getValueStringFromMap(methodPropertyEntry, METHOD_NAME_KEY);
-    String flagType = getValueStringFromMap(methodPropertyEntry, FLAG_TYPE_KEY);
-    Integer argumentIndexInteger = getArgumentIndexFromMap(methodPropertyEntry, ARGUMENT_INDEX_KEY);
-    if (methodName == null) {
-      throw new PiranhaConfigurationException(
-          "methodProperty is missing mandatory methodName field. Check:\n" + methodPropertyEntry);
-    } else if (flagType == null) {
-      throw new PiranhaConfigurationException(
-          "methodProperty is missing mandatory flagType field. Check:\n" + methodPropertyEntry);
-    } else if (!isArgumentIndexOptional && argumentIndexInteger == null) {
-      throw new PiranhaConfigurationException(
-          "methodProperty did not have argumentIndex. By default, Piranha requires an argument index for flag "
-              + "APIs, to which the flag name/symbol will be passed. This is to avoid over-deletion of all "
-              + "occurrences of a flag API method. If you are sure you want to delete all instances of the "
-              + "method below, consider using Piranha:ArgumentIndexOptional=true to override this behavior. "
-              + "Check:\n"
-              + methodPropertyEntry);
-    } else if (argumentIndexInteger != null && argumentIndexInteger.intValue() < 0) {
-      throw new PiranhaConfigurationException(
-          "Invalid argumentIndex field. Arguments are zero indexed. Check:\n"
-              + methodPropertyEntry);
-    }
-
-    return new PiranhaMethodRecord(
-        methodName,
-        flagType,
-        Optional.ofNullable(argumentIndexInteger),
-        Optional.ofNullable(getValueStringFromMap(methodPropertyEntry, RECEIVER_TYPE_STRING)),
-        Optional.ofNullable(getValueStringFromMap(methodPropertyEntry, RETURN_TYPE_STRING)));
-  }
+  Optional<String> getReturnType();
 }

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaRecord.java
@@ -16,7 +16,10 @@ package com.uber.piranha.config;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-/** Utility methods used by {@link PiranhaEnumRecord} and {@link PiranhaMethodRecord} classes */
+/**
+ * Utility methods used by {@link PiranhaEnumRecord}, {@link PiranhaFlagMethodRecord}, and {@link
+ * PiranhaTestMethodRecord} classes
+ */
 public class PiranhaRecord {
   /**
    * Utility method. Checks whether the value associated to a given map and given key is a non-empty

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaTestMethodRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaTestMethodRecord.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha.config;
+
+import static com.uber.piranha.config.PiranhaRecord.getArgumentIndexFromMap;
+import static com.uber.piranha.config.PiranhaRecord.getValueStringFromMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+/** A class representing a test method configuration record from properties.json */
+public final class PiranhaTestMethodRecord implements PiranhaMethodRecord {
+
+  // Allowed fields for a test method property in the config file.
+  // Entered under the top-level "testMethodProperties" in properties.json.
+  // By default, methodName and argumentIndex fields are mandatory.
+  // The returnType and receiverType fields are optional.
+  private static final String METHOD_NAME_KEY = "methodName";
+  private static final String ARGUMENT_INDEX_KEY = "argumentIndex";
+  private static final String RETURN_TYPE_STRING = "returnType";
+  private static final String RECEIVER_TYPE_STRING = "receiverType";
+
+  private final String methodName;
+  private final Optional<Integer> argumentIdx;
+  private final Optional<String> receiverType;
+  private final Optional<String> returnType;
+
+  PiranhaTestMethodRecord(
+      String methodName,
+      Optional<Integer> argumentIdx,
+      Optional<String> receiverType,
+      Optional<String> returnType) {
+    this.methodName = methodName;
+    this.argumentIdx = argumentIdx;
+    this.receiverType = receiverType;
+    this.returnType = returnType;
+  }
+
+  @Override
+  public String getMethodName() {
+    return methodName;
+  }
+
+  @Override
+  public Optional<Integer> getArgumentIdx() {
+    return argumentIdx;
+  }
+
+  @Override
+  public Optional<String> getReceiverType() {
+    return receiverType;
+  }
+
+  @Override
+  public Optional<String> getReturnType() {
+    return returnType;
+  }
+
+  /**
+   * Parse the entry for a single method from piranha.json that has been previously decoded into a
+   * map
+   *
+   * @param methodPropertyEntry The decoded json entry (as a Map of property names to values)
+   * @param isArgumentIndexOptional Whether argumentIdx should be treated as optional
+   * @return A PiranhaTestMethodRecord corresponding to the given map/json record.
+   * @throws PiranhaConfigurationException if there was any issue reading or parsing the
+   *     configuration file.
+   */
+  static PiranhaTestMethodRecord parseFromJSONPropertyEntryMap(
+      Map<String, Object> methodPropertyEntry, boolean isArgumentIndexOptional)
+      throws PiranhaConfigurationException {
+    String methodName = getValueStringFromMap(methodPropertyEntry, METHOD_NAME_KEY);
+    Integer argumentIndexInteger = getArgumentIndexFromMap(methodPropertyEntry, ARGUMENT_INDEX_KEY);
+    if (methodName == null) {
+      throw new PiranhaConfigurationException(
+          "testMethodProperty is missing mandatory methodName field. Check:\n"
+              + methodPropertyEntry);
+    } else if (!isArgumentIndexOptional && argumentIndexInteger == null) {
+      throw new PiranhaConfigurationException(
+          "testMethodProperty did not have argumentIndex. By default, Piranha requires an argument index for flag "
+              + "APIs, to which the flag name/symbol will be passed. This is to avoid over-deletion of all "
+              + "occurrences of a flag API method. If you are sure you want to delete all instances of the "
+              + "method below, consider using Piranha:ArgumentIndexOptional=true to override this behavior. "
+              + "Check:\n"
+              + methodPropertyEntry);
+    } else if (argumentIndexInteger != null && argumentIndexInteger < 0) {
+      throw new PiranhaConfigurationException(
+          "Invalid argumentIndex field. Arguments are zero indexed. Check:\n"
+              + methodPropertyEntry);
+    }
+
+    return new PiranhaTestMethodRecord(
+        methodName,
+        Optional.ofNullable(argumentIndexInteger),
+        Optional.ofNullable(getValueStringFromMap(methodPropertyEntry, RECEIVER_TYPE_STRING)),
+        Optional.ofNullable(getValueStringFromMap(methodPropertyEntry, RETURN_TYPE_STRING)));
+  }
+}

--- a/java/piranha/src/main/java/com/uber/piranha/config/PiranhaTestMethodRecord.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/PiranhaTestMethodRecord.java
@@ -13,7 +13,8 @@
  */
 package com.uber.piranha.config;
 
-import static com.uber.piranha.config.PiranhaRecord.getArgumentIndexFromMap;
+import static com.uber.piranha.config.PiranhaMethodRecord.parseArgumentIndexFromJSON;
+import static com.uber.piranha.config.PiranhaMethodRecord.parseMethodNameFromJSON;
 import static com.uber.piranha.config.PiranhaRecord.getValueStringFromMap;
 
 import java.util.Map;
@@ -21,15 +22,8 @@ import java.util.Optional;
 
 /** A class representing a test method configuration record from properties.json */
 public final class PiranhaTestMethodRecord implements PiranhaMethodRecord {
-
-  // Allowed fields for a test method property in the config file.
-  // Entered under the top-level "testMethodProperties" in properties.json.
-  // By default, methodName and argumentIndex fields are mandatory.
-  // The returnType and receiverType fields are optional.
-  private static final String METHOD_NAME_KEY = "methodName";
-  private static final String ARGUMENT_INDEX_KEY = "argumentIndex";
-  private static final String RETURN_TYPE_STRING = "returnType";
-  private static final String RECEIVER_TYPE_STRING = "receiverType";
+  // Used for generating exception messages
+  private static final String PROPERTY_NAME = "testMethodProperty";
 
   private final String methodName;
   private final Optional<Integer> argumentIdx;
@@ -80,30 +74,17 @@ public final class PiranhaTestMethodRecord implements PiranhaMethodRecord {
   static PiranhaTestMethodRecord parseFromJSONPropertyEntryMap(
       Map<String, Object> methodPropertyEntry, boolean isArgumentIndexOptional)
       throws PiranhaConfigurationException {
-    String methodName = getValueStringFromMap(methodPropertyEntry, METHOD_NAME_KEY);
-    Integer argumentIndexInteger = getArgumentIndexFromMap(methodPropertyEntry, ARGUMENT_INDEX_KEY);
-    if (methodName == null) {
-      throw new PiranhaConfigurationException(
-          "testMethodProperty is missing mandatory methodName field. Check:\n"
-              + methodPropertyEntry);
-    } else if (!isArgumentIndexOptional && argumentIndexInteger == null) {
-      throw new PiranhaConfigurationException(
-          "testMethodProperty did not have argumentIndex. By default, Piranha requires an argument index for flag "
-              + "APIs, to which the flag name/symbol will be passed. This is to avoid over-deletion of all "
-              + "occurrences of a flag API method. If you are sure you want to delete all instances of the "
-              + "method below, consider using Piranha:ArgumentIndexOptional=true to override this behavior. "
-              + "Check:\n"
-              + methodPropertyEntry);
-    } else if (argumentIndexInteger != null && argumentIndexInteger < 0) {
-      throw new PiranhaConfigurationException(
-          "Invalid argumentIndex field. Arguments are zero indexed. Check:\n"
-              + methodPropertyEntry);
-    }
+
+    String methodName = parseMethodNameFromJSON(PROPERTY_NAME, methodPropertyEntry);
+    Integer argumentIndexInteger =
+        parseArgumentIndexFromJSON(PROPERTY_NAME, methodPropertyEntry, isArgumentIndexOptional);
+    String receiverType = getValueStringFromMap(methodPropertyEntry, RECEIVER_TYPE_STRING);
+    String returnType = getValueStringFromMap(methodPropertyEntry, RETURN_TYPE_STRING);
 
     return new PiranhaTestMethodRecord(
         methodName,
         Optional.ofNullable(argumentIndexInteger),
-        Optional.ofNullable(getValueStringFromMap(methodPropertyEntry, RECEIVER_TYPE_STRING)),
-        Optional.ofNullable(getValueStringFromMap(methodPropertyEntry, RETURN_TYPE_STRING)));
+        Optional.ofNullable(receiverType),
+        Optional.ofNullable(returnType));
   }
 }

--- a/java/piranha/src/test/resources/com/uber/piranha/TestMethods.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/TestMethods.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha;
+
+class MockObject {
+  public boolean thenReturn(boolean bool) {
+    return bool;
+  }
+}
+
+class TestMethods {
+  public static boolean mockable() {
+    return false;
+  }
+
+  public static MockObject mock(Object thingToMock) {
+    return new MockObject();
+  }
+
+  public static MockObject keepMe(Object thingToMock) {
+    return new MockObject();
+  }
+
+  public static MockObject expect(Object thingToMock) {
+    return new MockObject();
+  }
+
+  public static MockObject expect(boolean value, Object thingToMock) {
+    return new MockObject();
+  }
+}


### PR DESCRIPTION
Fixes #47 

This development allows the user of Piranha to specify a list of methods
where if a dynamic flag evaluation is in a certain argument position, we
remove that method.

This is useful for cleaning up `mock()` wrapper methods or `assert()`
methods in test code that are useless after a feature flag is removed.

Limitations:
  - This does not remove unused imports for the test methods because we
    have to account for cases of the test methods that will not be
    removed.