### PR TITLE
[PiranhaJava] Deleting statements containing specific Mockito API patterns 

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: macos-11
     strategy:
         matrix:
-          xcode: ['13.0']
+          xcode: ['13.1']
     name: "PiranhaSwift using ${{ matrix.xcode }} on ${{ matrix.os }}"
     steps:
       - name: Check out Piranha sources
         uses: actions/checkout@v2
       - name: Set Xcode ${{ matrix.xcode }}
         run: |
-         sudo xcode-select -s /Applications/Xcode_13.0_beta.app
+         sudo xcode-select -s /Applications/Xcode_13.1.app
          xcodebuild -version
          swift --version
          swift package --version

--- a/java/piranha/build.gradle
+++ b/java/piranha/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
     testCompile deps.test.junit4
     testCompile deps.test.daggerAnnotations
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.1.0'
     testCompile(deps.build.errorProneTestHelpers) {
         exclude group: "junit", module: "junit"
     }


### PR DESCRIPTION
* This addresses the (i) of issue #104  
* Made use of the Matchers API (the mini predicate DSL) provided by Error prone 
* Currently I have added support only for the Mockito's `when(...).then*()` pattern. 