### PR TITLE
clean up enum and comma in annotation

### DIFF
--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -1556,16 +1556,11 @@ public class XPFlagCleaner extends BugChecker
   }
 
   private int getLower(CharSequence source, int lower, int index, int flagSize) {
-    while (lower >= 0
-        && source.charAt(lower) != '{'
-        && source.charAt(lower) != '='
-        && source.charAt(lower) != ',') {
+    while (lower >= 0 && source.charAt(lower) != '{' && source.charAt(lower) != ',') {
       lower--;
     }
     // do not remove { or = neither the comma when it is not the last enum
-    if (source.charAt(lower) == '{'
-        || source.charAt(lower) == '='
-        || (index != flagSize - 1 && source.charAt(lower) == ',')) {
+    if (source.charAt(lower) == '{' || (index != flagSize - 1 && source.charAt(lower) == ',')) {
       lower++;
     }
     return lower;

--- a/java/piranha/src/test/java/com/uber/piranha/EnumConstantTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/EnumConstantTest.java
@@ -848,4 +848,236 @@ public class EnumConstantTest {
             "}")
         .doTest();
   }
+
+  /** Test to cleanup an enum in annotation. Should remove the entire line */
+  @Test
+  public void testRemoveEnumFromAnnotationShouldRemoveAnnotation() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "true");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr.addInputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG,",
+            "  STALE_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = TestExperimentName.STALE_FLAG)",
+            " public void annotation_test() {}",
+            "}")
+        .addOutputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " public void annotation_test() {}",
+            "}")
+        .doTest();
+  }
+
+  /**
+   * Test to cleanup the first enum in annotation. Should remove the enum and the comma after it and
+   * keep the annotation and the other enum
+   */
+  @Test
+  public void testRemoveFirstEnumFromAnnotationRemovingCommaAndKeepingOtherEnum() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "true");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr.addInputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG,",
+            "  STALE_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = {TestExperimentName.STALE_FLAG, TestExperimentName.OTHER_FLAG})",
+            " public void annotation_test() {}",
+            "}")
+        .addOutputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = {TestExperimentName.OTHER_FLAG})",
+            " public void annotation_test() {}",
+            "}")
+        .doTest();
+  }
+
+  /**
+   * Test to cleanup the enum in the middle of the annotation. Should remove the enum and the comma
+   * after it and keep the annotation and the other enums
+   */
+  @Test
+  public void testRemoveEnumInTheMiddleFromAnnotationRemovingCommaAndKeepingOthersEnums() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "true");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr.addInputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG,",
+            "  ANOTHER_FLAG,",
+            "  STALE_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = {TestExperimentName.ANOTHER_FLAG, TestExperimentName.STALE_FLAG, TestExperimentName.OTHER_FLAG})",
+            " public void annotation_test() {}",
+            "}")
+        .addOutputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG,",
+            "  ANOTHER_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = {TestExperimentName.ANOTHER_FLAG, TestExperimentName.OTHER_FLAG})",
+            " public void annotation_test() {}",
+            "}")
+        .doTest();
+  }
+
+  /**
+   * Test to cleanup the enum at the end of the annotation. Should remove the enum and the comma
+   * before it and keep the annotation and the other enums
+   */
+  @Test
+  public void testRemoveEnumAtTheEndFromAnnotationRemovingCommaAndKeepingOthersEnums() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "true");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr.addInputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG,",
+            "  ANOTHER_FLAG,",
+            "  STALE_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = {TestExperimentName.ANOTHER_FLAG, TestExperimentName.OTHER_FLAG, TestExperimentName.STALE_FLAG})",
+            " public void annotation_test() {}",
+            "}")
+        .addOutputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG,",
+            "  ANOTHER_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = {TestExperimentName.ANOTHER_FLAG, TestExperimentName.OTHER_FLAG})",
+            " public void annotation_test() {}",
+            "}")
+        .doTest();
+  }
 }

--- a/java/piranha/src/test/java/com/uber/piranha/EnumConstantTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/EnumConstantTest.java
@@ -1022,6 +1022,128 @@ public class EnumConstantTest {
   }
 
   /**
+   * Test to cleanup the enum in the middle of the annotation without space between the annotation.
+   * Should remove the enum and the comma after it and keep the annotation and the other enums
+   */
+  @Test
+  public void
+      testRemoveEnumInTheMiddleWithoutSpacesFromAnnotationRemovingCommaAndKeepingOthersEnums() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "true");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr.addInputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG,",
+            "  ANOTHER_FLAG,",
+            "  STALE_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = {TestExperimentName.ANOTHER_FLAG,TestExperimentName.STALE_FLAG,TestExperimentName.OTHER_FLAG})",
+            " public void annotation_test() {}",
+            "}")
+        .addOutputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG,",
+            "  ANOTHER_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = {TestExperimentName.ANOTHER_FLAG,TestExperimentName.OTHER_FLAG})",
+            " public void annotation_test() {}",
+            "}")
+        .doTest();
+  }
+
+  /**
+   * Test to cleanup the enum in the middle of the annotation separate the enums by new line. Should
+   * remove the enum and the comma after it and keep the annotation and the other enums
+   */
+  @Test
+  public void
+      testRemoveEnumInTheMiddleSeparateByNewLineFromAnnotationRemovingCommaAndKeepingOthersEnums() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "true");
+    b.putFlag("Piranha:Config", "config/properties.json");
+
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+
+    bcr.addInputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG,",
+            "  ANOTHER_FLAG,",
+            "  STALE_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = {TestExperimentName.ANOTHER_FLAG, TestExperimentName.STALE_FLAG,\r\nTestExperimentName.OTHER_FLAG})",
+            " public void annotation_test() {}",
+            "}")
+        .addOutputLines(
+            "TestEnumInAnnotation.java",
+            "package com.uber.piranha;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "class TestEnumInAnnotation {",
+            " enum TestExperimentName {",
+            "  OTHER_FLAG,",
+            "  ANOTHER_FLAG;",
+            " }",
+            " @Retention(RetentionPolicy.RUNTIME)",
+            " @Target({ElementType.METHOD})",
+            " @interface ToggleTesting {",
+            "  TestExperimentName[] treated();",
+            " }",
+            " @ToggleTesting(treated = {TestExperimentName.ANOTHER_FLAG,\r\nTestExperimentName.OTHER_FLAG})",
+            " public void annotation_test() {}",
+            "}")
+        .doTest();
+  }
+
+  /**
    * Test to cleanup the enum at the end of the annotation. Should remove the enum and the comma
    * before it and keep the annotation and the other enums
    */


### PR DESCRIPTION
when there is more than one enum in the annotation and it's being separated by comma piranha is keeping an extra comma after the cleanup.

code to do the cleanup by STALE_FLAG as treated:
`@ToggleTesting(treated = {TestExperimentName.STALE_FLAG, TestExperimentName.OTHER_FLAG})`

current output:
`@ToggleTesting(treated = {, TestExperimentName.OTHER_FLAG})`

expected output
`@ToggleTesting(treated = {TestExperimentName.OTHER_FLAG})`

The enum to be removed could be at the beginning, in the middle or at the end. For the first two cases we should remove the comma that is present after the enum and for the third case we should remove the comma that is present before the enum.
For the scenario when there is only one enum we shouldn't do anything else that what the code is currently doing.