### PR TITLE
Initial changes to support matching method invocations passed as an arg

### DIFF
--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -397,7 +397,7 @@ public class XPFlagCleaner extends BugChecker
         !methodRecord.getArgumentIdx().isPresent()
             || argument(
                     methodRecord.getArgumentIdx().get(),
-                    (arg, st) -> isArgumentMatchesFlagName(arg, state))
+                    (arg, st) -> isArgumentMatchesFlagName(arg, methodRecord, state))
                 .matches(mit, state);
     if (!argumentMatchesFlagName) {
       return false;
@@ -443,8 +443,14 @@ public class XPFlagCleaner extends BugChecker
     return API.UNKNOWN;
   }
 
-  private boolean isArgumentMatchesFlagName(ExpressionTree arg, VisitorState state) {
+  private boolean isArgumentMatchesFlagName(
+      ExpressionTree arg, MethodRecord methodRecord, VisitorState state) {
     Symbol argSym = ASTHelpers.getSymbol(arg);
+    if (methodRecord.getMethodName().contains("$"))
+      return arg instanceof MethodInvocationTree
+          && config
+              .getMethodName((MethodInvocationTree) arg)
+              .equals(methodRecord.getMethodName().split("\\$")[1]);
     return isLiteralTreeAndMatchesFlagName(arg)
         || isVarSymbolAndMatchesFlagName(argSym)
         || isSymbolAndMatchesFlagName(argSym)

--- a/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
+++ b/java/piranha/src/main/java/com/uber/piranha/XPFlagCleaner.java
@@ -444,7 +444,7 @@ public class XPFlagCleaner extends BugChecker
     return API.UNKNOWN;
   }
 
-  // If the cleanup option is provided as 'flag_method_name', this method will check
+  // If the cleanup option 'flag_method_name' is provided, this method will check
   // if the argument is a method invocation matches the provided flag method name.
   private boolean isArgumentMatchesFlagMethod(ExpressionTree arg) {
     return arg instanceof MethodInvocationTree

--- a/java/piranha/src/main/java/com/uber/piranha/config/Config.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/Config.java
@@ -165,6 +165,8 @@ public final class Config {
       if (mstExpr instanceof MethodInvocationTree) {
         MethodInvocationTree chainedMIT = (MethodInvocationTree) mstExpr;
         String chainedMethodName = getMethodName(chainedMIT) + "." + methodName;
+        // This ensures that we only match instance method invocations like
+        // abc.stale_flag().getValue() and not stale_flag().getValue()
         if (chainedMIT.getMethodSelect() instanceof MemberSelectTree
             && Matchers.instanceMethod().anyClass().matches(chainedMIT, state)
             && configMethodProperties.containsKey(chainedMethodName))
@@ -174,9 +176,6 @@ public final class Config {
 
     return ImmutableSet.of();
   }
-
-  // This ensures that we only match instance method invocations like
-  // abc.stale_flag().getValue() and not stale_flag().getValue()
 
   /**
    * Returns name of the method invocation

--- a/java/piranha/src/main/java/com/uber/piranha/config/Config.java
+++ b/java/piranha/src/main/java/com/uber/piranha/config/Config.java
@@ -138,13 +138,22 @@ public final class Config {
 
   /**
    * Return all configuration method records matching the name of the given method invocation tree.
-   * If the cleanup option "allow_method_chain" is set to true, returns all configurations method
+   *
+   * <p>If the cleanup option "allow_method_chain" is set to true, returns all configurations method
    * record matching the name of the given method invocation and its receiver method invocation. For
    * instance, the invocation `exp.stale_flag().getValue()` will match the method record with name
    * as "stale_flag.getValue". Note: This method only supports matching a method chain of length 2
    * Moreover, it only matches chained invocations where the nested invocation is an instance method
    * invocation (with a receiver). For instance, abc.stale_flag().getValue() and not
    * stale_flag().getValue().
+   *
+   * <p>If the cleanup option "allow_matching_method_invocation_as_argument" is set to true, returns
+   * all configurations method record matching the name of the given method invocation and its
+   * argument which is also a method invocation. For instance, the invocation `cp.put(x.staleFlag(),
+   * true)` will match the method record with name as "put$0$stale_flag". The syntax for matching an
+   * method invocation with another method invocation passed as argument is
+   * [wrapper_method_name]$[arg_index]$[method_inv_name_passed_as_argument]. Note: This method only
+   * supports matching at most one argument.
    *
    * @param mit Method invocation AST
    * @param state visitor state

--- a/java/piranha/src/test/java/com/uber/piranha/CorePiranhaTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/CorePiranhaTest.java
@@ -1157,6 +1157,29 @@ public class CorePiranhaTest {
         .doTest();
   }
 
+  @Test
+  public void testMethodTestDoNotallowArgMatchingAndMethodChain() throws IOException {
+    String staleFlag = "stale_flag";
+    String isTreated = "true";
+    String srcProp =
+        "src/test/resources/config/properties_method_chain_not_allow_arg_matching_and_method_chain.json";
+    transformAndCreateNewPropertyFile(
+        srcProp, trgtProp, staleFlag, Boolean.parseBoolean(isTreated));
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", staleFlag);
+    b.putFlag("Piranha:IsTreated", isTreated);
+    b.putFlag("Piranha:ArgumentIndexOptional", "true");
+    b.putFlag("Piranha:Config", trgtProp);
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = addMockAPIToNameSpace(bcr);
+    bcr.addInput("XPMethodChainCases.java")
+        .addOutput("XPMethodChainCasesDoNotallowArgMatchingAndMethodChain.java")
+        .allowBreakingChanges()
+        .doTest();
+  }
+
   @After
   public void cleanup() throws IOException {
     Files.deleteIfExists(Paths.get(trgtProp));

--- a/java/piranha/src/test/java/com/uber/piranha/CorePiranhaTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/CorePiranhaTest.java
@@ -1049,7 +1049,7 @@ public class CorePiranhaTest {
     String newContent =
         Files.readAllLines(Paths.get(srcProp))
             .stream()
-            .map(x -> x.replace("[flagName]", flagNameCamelCase))
+            .map(x -> x.replace("[flagMethodName]", flagNameCamelCase))
             .map(x -> x.replace("[notIsTreated]", String.valueOf(!isTreated)))
             .collect(joining("\n"));
     Path trgt = Paths.get(trgtProp);

--- a/java/piranha/src/test/java/com/uber/piranha/CorePiranhaTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/CorePiranhaTest.java
@@ -1134,6 +1134,29 @@ public class CorePiranhaTest {
         .doTest();
   }
 
+  @Test
+  public void testMethodTestDoNotAllowsMatchingArgMethodInvc() throws IOException {
+    String staleFlag = "stale_flag";
+    String isTreated = "true";
+    String srcProp =
+        "src/test/resources/config/properties_method_chain_not_allow_arg_method_invc.json";
+    transformAndCreateNewPropertyFile(
+        srcProp, trgtProp, staleFlag, Boolean.parseBoolean(isTreated));
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", staleFlag);
+    b.putFlag("Piranha:IsTreated", isTreated);
+    b.putFlag("Piranha:ArgumentIndexOptional", "true");
+    b.putFlag("Piranha:Config", trgtProp);
+    BugCheckerRefactoringTestHelper bcr =
+        BugCheckerRefactoringTestHelper.newInstance(new XPFlagCleaner(b.build()), getClass());
+    bcr = bcr.setArgs("-d", temporaryFolder.getRoot().getAbsolutePath());
+    bcr = addMockAPIToNameSpace(bcr);
+    bcr.addInput("XPMethodChainCases.java")
+        .addOutput("XPMethodChainCasesTreatmentDoNotAllowMatchingArgMethodInvc.java")
+        .allowBreakingChanges()
+        .doTest();
+  }
+
   @After
   public void cleanup() throws IOException {
     Files.deleteIfExists(Paths.get(trgtProp));

--- a/java/piranha/src/test/java/com/uber/piranha/CorePiranhaTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/CorePiranhaTest.java
@@ -1116,7 +1116,7 @@ public class CorePiranhaTest {
   public void testMethodTestDoNotAllowsChainFlag() throws IOException {
     String staleFlag = "stale_flag";
     String isTreated = "false";
-    String srcProp = "src/test/resources/config/properties_method_chain_not_allow_chained.json";
+    String srcProp = "src/test/resources/config/properties_no_method_chain.json";
     transformAndCreateNewPropertyFile(
         srcProp, trgtProp, staleFlag, Boolean.parseBoolean(isTreated));
     ErrorProneFlags.Builder b = ErrorProneFlags.builder();
@@ -1138,8 +1138,7 @@ public class CorePiranhaTest {
   public void testMethodTestDoNotAllowsMatchingArgMethodInvc() throws IOException {
     String staleFlag = "stale_flag";
     String isTreated = "true";
-    String srcProp =
-        "src/test/resources/config/properties_method_chain_not_allow_arg_method_invc.json";
+    String srcProp = "src/test/resources/config/properties_no_flag_method_name.json";
     transformAndCreateNewPropertyFile(
         srcProp, trgtProp, staleFlag, Boolean.parseBoolean(isTreated));
     ErrorProneFlags.Builder b = ErrorProneFlags.builder();
@@ -1162,7 +1161,7 @@ public class CorePiranhaTest {
     String staleFlag = "stale_flag";
     String isTreated = "true";
     String srcProp =
-        "src/test/resources/config/properties_method_chain_not_allow_arg_matching_and_method_chain.json";
+        "src/test/resources/config/properties_no_flag_method_name_no_method_chain.json";
     transformAndCreateNewPropertyFile(
         srcProp, trgtProp, staleFlag, Boolean.parseBoolean(isTreated));
     ErrorProneFlags.Builder b = ErrorProneFlags.builder();

--- a/java/piranha/src/test/resources/com/uber/piranha/XPMethodChainCases.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPMethodChainCases.java
@@ -67,11 +67,11 @@ class XPMethodChainCases {
 
     System.out.println("done!");
     // Matches API
-    cp.put("", "stale_flag", true);
-    cp.put("", "stale_flag", false);
+    cp.put(sp.staleFlag(), true);
+    cp.put(sp.staleFlag(), false);
     // Do not match API
-    cp.put("", "other_flag", true);
-    cp.put("", "other_flag", false);
+    cp.put(sp.otherFlag(), true);
+    cp.put(sp.otherFlag(), false);
   }
 
   class TestMethodChainTest {

--- a/java/piranha/src/test/resources/com/uber/piranha/XPMethodChainCasesControl.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPMethodChainCasesControl.java
@@ -55,8 +55,8 @@ class XPMethodChainCases {
 
     System.out.println("done!");
 
-    cp.put("", "other_flag", true);
-    cp.put("", "other_flag", false);
+    cp.put(sp.otherFlag(), true);
+    cp.put(sp.otherFlag(), false);
   }
 
   class TestMethodChainTest {

--- a/java/piranha/src/test/resources/com/uber/piranha/XPMethodChainCasesDoNotallowArgMatchingAndMethodChain.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPMethodChainCasesDoNotallowArgMatchingAndMethodChain.java
@@ -6,10 +6,6 @@ class XPMethodChainCases {
     @BoolParam(key = "other_flag")
     BoolParameter otherFlag();
 
-    // Annotation and the abstract method should be removed
-    @BoolParam(key = "stale_flag")
-    BoolParameter staleFlag();
-
     static SomeParam create(Parameter cp) {
       return null;
     }
@@ -76,15 +72,8 @@ class XPMethodChainCases {
   }
 
   class TestMethodChainTest {
-    // Matches annotation
-    @PVal(ns = "", key = "stale_flag", val = "true")
-    public void testSomethingTreated() {
-      System.out.println();
-    }
 
-    // Matches annotation
-    @PVal(ns = "", key = "stale_flag", val = "false")
-    public void testSomethingControl() {
+    public void testSomethingTreated() {
       System.out.println();
     }
 

--- a/java/piranha/src/test/resources/com/uber/piranha/XPMethodChainCasesTreatment.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPMethodChainCasesTreatment.java
@@ -54,8 +54,8 @@ class XPMethodChainCases {
 
     System.out.println("done!");
 
-    cp.put("", "other_flag", true);
-    cp.put("", "other_flag", false);
+    cp.put(sp.otherFlag(), true);
+    cp.put(sp.otherFlag(), false);
   }
 
   class TestMethodChainTest {

--- a/java/piranha/src/test/resources/com/uber/piranha/XPMethodChainCasesTreatmentDoNotAllowMatchingArgMethodInvc.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/XPMethodChainCasesTreatmentDoNotAllowMatchingArgMethodInvc.java
@@ -14,7 +14,7 @@ class XPMethodChainCases {
   public BoolParameter staleFlag() {
     return null;
   }
-  // should not match instance method where nested invocation is not a member select tree.
+
   public void testDontMatchNonInstanceNested() {
     // Does not Match
     if (staleFlag().getValue()) {
@@ -24,56 +24,48 @@ class XPMethodChainCases {
 
   public static void foobar(Parameter cp) {
     SomeParam sp = SomeParam.create(cp);
-    // Matches API
-    if (sp.staleFlag().getValue()) {
-      System.out.println("!");
-    }
-    // Matches API
-    if (!sp.staleFlag().getValue()) {
-      System.out.println("!!!");
-    }
+
+    System.out.println("!");
     // Does not match API
     if (sp.otherFlag().getValue()) {
       System.out.println("!!!");
     }
-    if (sp.otherFlag().getValue() && sp.staleFlag().getValue()) {
+    if (sp.otherFlag().getValue()) {
       System.out.println("!!!");
     }
-    if (sp.otherFlag().getValue() || sp.staleFlag().getValue()) {
-      System.out.println("!!!");
-    }
+
+    System.out.println("!!!");
+
     SomeParamRev spr = SomeParamRev.create(cp);
-    // Does not match API- is reverse order
     if (spr.getValue().staleFlag()) {
       System.out.println("!!!!");
     }
-    // Does not match API- matches partially
     if (spr.getValue() != null) {
       System.out.println("!!!!!");
     }
     SomeOtherInterface sot = SomeOtherInterface.create(cp);
-    // Does not match API- matches partially
     if (sot.staleFlag() != null) {
       System.out.println("!!");
     }
-    // Does not Match - static method invocation
+
     if (StaticMthds.staleFlag().getValue()) {
       System.out.print("!!");
     }
 
     System.out.println("done!");
-    // Matches API
-    // Do not match API
+    cp.put(sp.staleFlag(), true);
+    cp.put(sp.staleFlag(), false);
     cp.put(sp.otherFlag(), true);
     cp.put(sp.otherFlag(), false);
   }
 
   class TestMethodChainTest {
 
-    public void testSomethingControl() {
+    public void testSomethingTreated() {
       System.out.println();
     }
 
+    // Does not match annotation
     @PVal(ns = "", key = "other_flag", val = "false")
     public void testSomethingOther() {
       System.out.println();

--- a/java/piranha/src/test/resources/com/uber/piranha/mock/Parameter.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/mock/Parameter.java
@@ -3,4 +3,6 @@ package com.uber.piranha;
 public class Parameter {
 
   public void put(BoolParameter p, boolean b) {}
+
+  public void put(boolean b, BoolParameter p) {}
 }

--- a/java/piranha/src/test/resources/com/uber/piranha/mock/Parameter.java
+++ b/java/piranha/src/test/resources/com/uber/piranha/mock/Parameter.java
@@ -2,5 +2,5 @@ package com.uber.piranha;
 
 public class Parameter {
 
-  public void put(String a, String flag, boolean b) {};
+  public void put(BoolParameter p, boolean b) {}
 }

--- a/java/piranha/src/test/resources/config/properties_method_chain.json
+++ b/java/piranha/src/test/resources/config/properties_method_chain.json
@@ -6,7 +6,7 @@
       "returnType": "boolean"
     },
     {
-      "methodName": "put$[flagName]",
+      "methodName": "put",
       "flagType": "empty",
       "argumentIndex" : 0
     }
@@ -25,6 +25,6 @@
   ],
   "cleanupOptions": {
     "allow_method_chain" : true,
-    "allow_matching_method_invocation_as_argument" : true
+    "flag_method_name" : "[flagName]"
   }
 }

--- a/java/piranha/src/test/resources/config/properties_method_chain.json
+++ b/java/piranha/src/test/resources/config/properties_method_chain.json
@@ -6,8 +6,9 @@
       "returnType": "boolean"
     },
     {
-      "methodName": "put$0$[flagName]",
-      "flagType": "empty"
+      "methodName": "put$[flagName]",
+      "flagType": "empty",
+      "argumentIndex" : 0
     }
   ],
   "annotations": [

--- a/java/piranha/src/test/resources/config/properties_method_chain.json
+++ b/java/piranha/src/test/resources/config/properties_method_chain.json
@@ -6,9 +6,8 @@
       "returnType": "boolean"
     },
     {
-      "methodName": "put",
-      "flagType": "empty",
-      "argumentIndex": 1
+      "methodName": "put$0$[flagName]",
+      "flagType": "empty"
     }
   ],
   "annotations": [
@@ -24,6 +23,7 @@
     }
   ],
   "cleanupOptions": {
-    "allow_method_chain" : true
+    "allow_method_chain" : true,
+    "allow_matching_method_invocation_as_argument" : true
   }
 }

--- a/java/piranha/src/test/resources/config/properties_method_chain.json
+++ b/java/piranha/src/test/resources/config/properties_method_chain.json
@@ -1,7 +1,7 @@
 {
   "methodProperties": [
     {
-      "methodName": "[flagName].getValue",
+      "methodName": "[flagMethodName].getValue",
       "flagType": "treated",
       "returnType": "boolean"
     },
@@ -25,6 +25,6 @@
   ],
   "cleanupOptions": {
     "allow_method_chain" : true,
-    "flag_method_name" : "[flagName]"
+    "flag_method_name" : "[flagMethodName]"
   }
 }

--- a/java/piranha/src/test/resources/config/properties_method_chain_not_allow_arg_matching_and_method_chain.json
+++ b/java/piranha/src/test/resources/config/properties_method_chain_not_allow_arg_matching_and_method_chain.json
@@ -25,6 +25,6 @@
   ],
   "cleanupOptions": {
     "allow_method_chain" : false,
-    "allow_matching_method_invocation_as_argument" : true
+    "allow_matching_method_invocation_as_argument" : false
   }
 }

--- a/java/piranha/src/test/resources/config/properties_method_chain_not_allow_arg_method_invc.json
+++ b/java/piranha/src/test/resources/config/properties_method_chain_not_allow_arg_method_invc.json
@@ -6,8 +6,9 @@
       "returnType": "boolean"
     },
     {
-      "methodName": "put$0$[flagName]",
-      "flagType": "empty"
+      "methodName": "put$[flagName]",
+      "flagType": "empty",
+      "argumentIndex" : 0
     }
   ],
   "annotations": [

--- a/java/piranha/src/test/resources/config/properties_method_chain_not_allow_arg_method_invc.json
+++ b/java/piranha/src/test/resources/config/properties_method_chain_not_allow_arg_method_invc.json
@@ -23,7 +23,7 @@
     }
   ],
   "cleanupOptions": {
-    "allow_method_chain" : false,
-    "allow_matching_method_invocation_as_argument" : true
+    "allow_method_chain" : true,
+    "allow_matching_method_invocation_as_argument" : false
   }
 }

--- a/java/piranha/src/test/resources/config/properties_no_flag_method_name.json
+++ b/java/piranha/src/test/resources/config/properties_no_flag_method_name.json
@@ -6,7 +6,7 @@
       "returnType": "boolean"
     },
     {
-      "methodName": "put$[flagName]",
+      "methodName": "put",
       "flagType": "empty",
       "argumentIndex" : 0
     }
@@ -24,7 +24,6 @@
     }
   ],
   "cleanupOptions": {
-    "allow_method_chain" : false,
-    "allow_matching_method_invocation_as_argument" : true
+    "allow_method_chain" : true
   }
 }

--- a/java/piranha/src/test/resources/config/properties_no_flag_method_name.json
+++ b/java/piranha/src/test/resources/config/properties_no_flag_method_name.json
@@ -1,7 +1,7 @@
 {
   "methodProperties": [
     {
-      "methodName": "[flagName].getValue",
+      "methodName": "[flagMethodName].getValue",
       "flagType": "treated",
       "returnType": "boolean"
     },

--- a/java/piranha/src/test/resources/config/properties_no_flag_method_name_no_method_chain.json
+++ b/java/piranha/src/test/resources/config/properties_no_flag_method_name_no_method_chain.json
@@ -6,7 +6,7 @@
       "returnType": "boolean"
     },
     {
-      "methodName": "put$[flagName]",
+      "methodName": "put",
       "flagType": "empty",
       "argumentIndex" : 0
     }
@@ -24,7 +24,6 @@
     }
   ],
   "cleanupOptions": {
-    "allow_method_chain" : false,
-    "allow_matching_method_invocation_as_argument" : false
+    "allow_method_chain" : false
   }
 }

--- a/java/piranha/src/test/resources/config/properties_no_flag_method_name_no_method_chain.json
+++ b/java/piranha/src/test/resources/config/properties_no_flag_method_name_no_method_chain.json
@@ -1,7 +1,7 @@
 {
   "methodProperties": [
     {
-      "methodName": "[flagName].getValue",
+      "methodName": "[flagMethodName].getValue",
       "flagType": "treated",
       "returnType": "boolean"
     },

--- a/java/piranha/src/test/resources/config/properties_no_method_chain.json
+++ b/java/piranha/src/test/resources/config/properties_no_method_chain.json
@@ -6,7 +6,7 @@
       "returnType": "boolean"
     },
     {
-      "methodName": "put$[flagName]",
+      "methodName": "put",
       "flagType": "empty",
       "argumentIndex" : 0
     }
@@ -24,7 +24,7 @@
     }
   ],
   "cleanupOptions": {
-    "allow_method_chain" : true,
-    "allow_matching_method_invocation_as_argument" : false
+    "allow_method_chain" : false,
+    "flag_method_name" : "[flagName]"
   }
 }

--- a/java/piranha/src/test/resources/config/properties_no_method_chain.json
+++ b/java/piranha/src/test/resources/config/properties_no_method_chain.json
@@ -1,7 +1,7 @@
 {
   "methodProperties": [
     {
-      "methodName": "[flagName].getValue",
+      "methodName": "[flagMethodName].getValue",
       "flagType": "treated",
       "returnType": "boolean"
     },
@@ -25,6 +25,6 @@
   ],
   "cleanupOptions": {
     "allow_method_chain" : false,
-    "flag_method_name" : "[flagName]"
+    "flag_method_name" : "[flagMethodName]"
   }
 }


### PR DESCRIPTION
This PR adds a feature for matching method invocations that are passed as arguments in the XP APIs. 
This feature can be turned on and turned off by toggling the cleanup option `allow_matching_method_invocation_as_argument`. 
The general syntax for matching an method invocation with another method invocation passed as argument is <wrapper_method_name>$<arg_index>$<method_inv_name_passed_as_argument>.