### PR TITLE
Adding tests for the paths not covered (According to coverall report)

### DIFF
--- a/java/piranha/src/test/java/com/uber/piranha/ConfigurationTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/ConfigurationTest.java
@@ -14,6 +14,8 @@
 package com.uber.piranha;
 
 import static com.uber.piranha.PiranhaTestingHelpers.addExperimentFlagEnumsWithConstructor;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
@@ -1832,11 +1834,11 @@ public class ConfigurationTest {
     b.putFlag("Piranha:FlagName", "STALE_FLAG");
     b.putFlag("Piranha:IsTreated", "true");
     b.putFlag("Piranha:Config", "src/test/resources/config/invalid/propetiesDoNotExist.json");
-
     expectedEx.expect(PiranhaConfigurationException.class);
     expectedEx.expectMessage(
-        "Error reading config file /Users/ketkara/repositories/open-source/piranha/java/piranha/src/test/resources/config/invalid/propetiesDoNotExist.json : java.io.IOException: Provided config file not found");
-
+        allOf(
+            containsString("Error reading config file"),
+            containsString("Provided config file not found")));
     XPFlagCleaner flagCleaner = new XPFlagCleaner();
     flagCleaner.init(b.build());
   }

--- a/java/piranha/src/test/java/com/uber/piranha/ConfigurationTest.java
+++ b/java/piranha/src/test/java/com/uber/piranha/ConfigurationTest.java
@@ -1825,4 +1825,19 @@ public class ConfigurationTest {
         .addSourceLines("Dummy.java", "package com.uber.piranha;", "class Dummy {", "}")
         .doTest();
   }
+
+  @Test
+  public void test_wrongConfig() {
+    ErrorProneFlags.Builder b = ErrorProneFlags.builder();
+    b.putFlag("Piranha:FlagName", "STALE_FLAG");
+    b.putFlag("Piranha:IsTreated", "true");
+    b.putFlag("Piranha:Config", "src/test/resources/config/invalid/propetiesDoNotExist.json");
+
+    expectedEx.expect(PiranhaConfigurationException.class);
+    expectedEx.expectMessage(
+        "Error reading config file /Users/ketkara/repositories/open-source/piranha/java/piranha/src/test/resources/config/invalid/propetiesDoNotExist.json : java.io.IOException: Provided config file not found");
+
+    XPFlagCleaner flagCleaner = new XPFlagCleaner();
+    flagCleaner.init(b.build());
+  }
 }

--- a/java/piranha/src/test/resources/config/properties_enum_no_arg.json
+++ b/java/piranha/src/test/resources/config/properties_enum_no_arg.json
@@ -1,0 +1,16 @@
+{
+  "methodProperties": [
+
+  ],
+  "linkURL": "<provide_your_url>",
+  "enumProperties": [
+    {
+      "enumName": "TestExperimentNameNoArg"
+    }
+  ],
+  "cleanupOptions": {
+    "tests.clean_by_setters_heuristic.enabled" : true,
+    "tests.clean_by_setters_heuristic.ignore_other_flag_sets" : false,
+    "tests.clean_by_setters_heuristic.lines_limit" : 100
+  }
+}

--- a/java/piranha/src/test/resources/config/properties_unnecessary_instance_method.json
+++ b/java/piranha/src/test/resources/config/properties_unnecessary_instance_method.json
@@ -1,0 +1,74 @@
+{
+  "methodProperties": [
+    {
+      "methodName": "isToggleDisabled",
+      "flagType": "control",
+      "argumentIndex": 0
+    },
+    {
+      "methodName": "isFlagTreated",
+      "flagType": "treated",
+      "returnType": "boolean",
+      "argumentIndex": 0
+    },
+    {
+      "methodName": "isToggleEnabled",
+      "flagType": "treated",
+      "returnType": "boolean",
+      "argumentIndex": 0
+    },
+    {
+      "methodName": "putToggleEnabled",
+      "flagType": "set_treated",
+      "argumentIndex": 0
+    },
+    {
+      "methodName": "putToggleDisabled",
+      "flagType": "set_control",
+      "argumentIndex": 0
+    },
+    {
+      "methodName": "includeEvent",
+      "flagType": "empty",
+      "argumentIndex": 0
+    },
+    {
+      "methodName": "isToggleInGroup",
+      "flagType": "treatmentGroup",
+      "argumentIndex": 0
+    }
+  ],
+  "unnecessaryTestMethodProperties" : [
+    {
+      "methodName": "isTrue",
+      "argumentIndex": 0,
+      "receiverType":"com.uber.piranha.TestObj",
+      "isStatic": "false"
+    }
+  ],
+  "linkURL": "<provide_your_url>",
+  "annotations": [
+    "ToggleTesting",
+    {
+        "name" : "NewToggleTreated",
+        "flag" : "$value",
+        "treated" : "true"
+    },
+    {
+        "name" : "NewToggleControl",
+        "flag" : "$value",
+        "treated" : "false"
+    }
+  ],
+  "enumProperties": [
+    {
+      "enumName": "TestExperimentName",
+      "argumentIndex": 0
+    }
+  ],
+  "cleanupOptions": {
+    "tests.clean_by_setters_heuristic.enabled" : true,
+    "tests.clean_by_setters_heuristic.ignore_other_flag_sets" : false,
+    "tests.clean_by_setters_heuristic.lines_limit" : 100
+  }
+}


### PR DESCRIPTION
The goal of this PR is to improve the code coverage of Piranha. Specifically, it contains new tests for : 
(1) unnecessary method invocation feature for instance method 
(2) Incorrect config file exception 
(3) Disable Unless configured option 
(4) Enum properties when argument index optional is true