### PR TITLE
fix #187 - Remove extra comma when deleting sequence item. 

### DIFF
--- a/generic/piranha/Cargo.toml
+++ b/generic/piranha/Cargo.toml
@@ -13,6 +13,7 @@ cc = "1.0.73"
 
 [dependencies]
 tree-sitter = "0.20.6"
+tree-sitter-traversal = "0.1.2"
 json = "0.12.4"
 toml = "0.5.9"
 serde = "1.0.136"

--- a/generic/piranha/src/models/source_code_unit.rs
+++ b/generic/piranha/src/models/source_code_unit.rs
@@ -4,9 +4,10 @@ use std::{
   path::{Path, PathBuf},
 };
 
-use tree_sitter::{InputEdit, Node, Parser, Tree};
+use tree_sitter::{InputEdit, Node, Parser, Range, Tree};
+use tree_sitter_traversal::{traverse, Order};
 
-use crate::utilities::tree_sitter_utilities::get_tree_sitter_edit;
+use crate::utilities::{eq_without_whitespace, tree_sitter_utilities::get_tree_sitter_edit};
 
 use super::edit::Edit;
 
@@ -46,6 +47,12 @@ impl SourceCodeUnit {
     fs::write(&self.path, self.code.as_str()).expect("Unable to Write file");
   }
 
+ 
+  pub(crate) fn apply_edit(&mut self, edit: &Edit, parser: &mut Parser) -> InputEdit {
+    // Get the tree_sitter's input edit representation
+    self._apply_edit(edit.replacement_range(), edit.replacement_string(), parser)
+  }
+
   /// Applies an edit to the source code unit
   /// # Arguments
   /// * `replace_range` - the range of code to be replaced
@@ -56,13 +63,12 @@ impl SourceCodeUnit {
   /// The `edit:InputEdit` performed.
   ///
   /// Note - Causes side effect. - Updates `self.ast` and `self.code`
-  pub(crate) fn apply_edit(&mut self, edit: &Edit, parser: &mut Parser) -> InputEdit {
+  pub(crate) fn _apply_edit(
+    &mut self, range: Range, replacement_string: &str, parser: &mut Parser,
+  ) -> InputEdit {
     // Get the tree_sitter's input edit representation
-    let (new_source_code, ts_edit) = get_tree_sitter_edit(
-      self.code.clone(),
-      edit.replacement_range(),
-      edit.replacement_string(),
-    );
+    let (new_source_code, ts_edit) =
+      get_tree_sitter_edit(self.code.clone(), range, replacement_string);
     // Apply edit to the tree
     self.ast.edit(&ts_edit);
     // Create a new updated tree from the previous tree
@@ -71,7 +77,29 @@ impl SourceCodeUnit {
       .expect("Could not generate new tree!");
     self.ast = new_tree;
     self.code = new_source_code;
+    // Handle errors, like removing extra comma.
+    self.handle_error(parser);
+    if self.ast.root_node().has_error() {
+      panic!("Produced syntactically incorrect source code {}", self.code());
+  }
     ts_edit
+  }
+
+  /// Sometimes our rewrite rules may produce errors (recoverable errors), like failing to remove an extra comma.
+  /// This function, applies the recovery strategies.
+  /// Currently, we only support recovering from extra comma. 
+  fn handle_error(&mut self, parser: &mut Parser) {
+    if self.ast.root_node().has_error() {
+      let c_ast = self.ast.clone();
+      for n in traverse(c_ast.walk(), Order::Post) {
+        // Remove the extra comma
+        if n.is_extra() && eq_without_whitespace(n.utf8_text(self.code().as_bytes()).unwrap(), ",")
+        {
+          self._apply_edit(n.range(), "", parser);
+          break;
+        }
+      }
+    }
   }
 
   // #[cfg(test)] // Rust analyzer FP

--- a/generic/piranha/src/models/source_code_unit.rs
+++ b/generic/piranha/src/models/source_code_unit.rs
@@ -78,7 +78,7 @@ impl SourceCodeUnit {
     self.ast = new_tree;
     self.code = new_source_code;
     // Handle errors, like removing extra comma.
-    self.handle_error(parser);
+    self.remove_additional_comma_from_sequence_list(parser);
     if self.ast.root_node().has_error() {
       panic!("Produced syntactically incorrect source code {}", self.code());
   }
@@ -88,7 +88,7 @@ impl SourceCodeUnit {
   /// Sometimes our rewrite rules may produce errors (recoverable errors), like failing to remove an extra comma.
   /// This function, applies the recovery strategies.
   /// Currently, we only support recovering from extra comma. 
-  fn handle_error(&mut self, parser: &mut Parser) {
+  fn remove_additional_comma_from_sequence_list(&mut self, parser: &mut Parser) {
     if self.ast.root_node().has_error() {
       let c_ast = self.ast.clone();
       for n in traverse(c_ast.walk(), Order::Post) {

--- a/generic/piranha/src/models/unit_tests/source_code_unit_test.rs
+++ b/generic/piranha/src/models/unit_tests/source_code_unit_test.rs
@@ -12,7 +12,7 @@ use {
 #[test]
 fn test_apply_edit_positive() {
   let source_code = "class Test {
-      pub void foobar(){
+      public void foobar(){
         boolean isFlagTreated = true;
         isFlagTreated = true;
         if (isFlagTreated) {
@@ -33,8 +33,8 @@ fn test_apply_edit_positive() {
   let _ = source_code_unit.apply_edit(
     &Edit::new(
       Range {
-        start_byte: 46,
-        end_byte: 75,
+        start_byte: 49,
+        end_byte: 78,
         start_point: tree_sitter::Point { row: 3, column: 9 },
         end_point: tree_sitter::Point { row: 3, column: 38 },
       },
@@ -46,7 +46,7 @@ fn test_apply_edit_positive() {
   );
   assert!(eq_without_whitespace(
     r#"class Test {
-      pub void foobar(){
+      public void foobar(){
         
         isFlagTreated = true;
         if (isFlagTreated) {
@@ -63,7 +63,7 @@ fn test_apply_edit_positive() {
 #[should_panic(expected = "byte index 1000 is out of bounds")]
 fn test_apply_edit_negative() {
   let source_code = "class Test {
-      pub void foobar(){
+      public void foobar(){
         boolean isFlagTreated = true;
         isFlagTreated = false;
         if (isFlagTreated) {

--- a/generic/piranha/src/tests/mod.rs
+++ b/generic/piranha/src/tests/mod.rs
@@ -61,7 +61,6 @@ fn check_result(updated_files: Vec<SourceCodeUnit>, path_to_expected: PathBuf) {
 
     if !eq_without_whitespace(&source_code_unit.code(), &expected_content) {
       all_files_match = false;
-      println!("{}", &source_code_unit.code())
     }
   }
   assert!(all_files_match);

--- a/generic/piranha/src/tests/mod.rs
+++ b/generic/piranha/src/tests/mod.rs
@@ -61,6 +61,7 @@ fn check_result(updated_files: Vec<SourceCodeUnit>, path_to_expected: PathBuf) {
 
     if !eq_without_whitespace(&source_code_unit.code(), &expected_content) {
       all_files_match = false;
+      println!("{}", &source_code_unit.code())
     }
   }
   assert!(all_files_match);

--- a/generic/piranha/test-resources/java/feature_flag_system_1/control/expected/XPFlagCleanerPositiveCases.java
+++ b/generic/piranha/test-resources/java/feature_flag_system_1/control/expected/XPFlagCleanerPositiveCases.java
@@ -22,9 +22,15 @@ import javax.inject.Inject;
 
 class XPFlagCleanerPositiveCases {
 
-  enum TestExperimentName {}
+  enum TestExperimentName {
+    SOME_FLAG,
 
-  enum AnotherTestExperimentName {}
+  }
+
+  enum AnotherTestExperimentName {
+    
+    SOME_OTHER_FLAG
+  }
 
   @Retention(RetentionPolicy.RUNTIME)
   public @interface Autorollout {

--- a/generic/piranha/test-resources/java/feature_flag_system_1/control/input/XPFlagCleanerPositiveCases.java
+++ b/generic/piranha/test-resources/java/feature_flag_system_1/control/input/XPFlagCleanerPositiveCases.java
@@ -23,12 +23,14 @@ import javax.inject.Inject;
 class XPFlagCleanerPositiveCases {
 
   enum TestExperimentName {
+    SOME_FLAG,
     STALE_FLAG
   }
 
   enum AnotherTestExperimentName {
     @Autorollout
-    STALE_FLAG
+    STALE_FLAG,
+    SOME_OTHER_FLAG
   }
 
   @Retention(RetentionPolicy.RUNTIME)

--- a/generic/piranha/test-resources/java/feature_flag_system_1/treated/expected/XPFlagCleanerPositiveCases.java
+++ b/generic/piranha/test-resources/java/feature_flag_system_1/treated/expected/XPFlagCleanerPositiveCases.java
@@ -22,9 +22,13 @@ import javax.inject.Inject;
 
 class XPFlagCleanerPositiveCases {
 
-  enum TestExperimentName {}
+  enum TestExperimentName {
+    SOME_FLAG,
+  }
 
-  enum AnotherTestExperimentName {}
+  enum AnotherTestExperimentName {
+    SOME_OTHER_FLAG
+  }
 
   @Retention(RetentionPolicy.RUNTIME)
   public @interface Autorollout {

--- a/generic/piranha/test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java
+++ b/generic/piranha/test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java
@@ -23,12 +23,15 @@ import javax.inject.Inject;
 class XPFlagCleanerPositiveCases {
 
   enum TestExperimentName {
+
+    SOME_FLAG,
     STALE_FLAG
   }
 
   enum AnotherTestExperimentName {
     @Autorollout
-    STALE_FLAG
+    STALE_FLAG,
+    SOME_OTHER_FLAG
   }
 
   @Retention(RetentionPolicy.RUNTIME)

--- a/generic/piranha/test-resources/kt/feature_flag_system_1/control/expected/XPFlagCleanerCases.kt
+++ b/generic/piranha/test-resources/kt/feature_flag_system_1/control/expected/XPFlagCleanerCases.kt
@@ -18,9 +18,11 @@ import java.lang.annotation.RetentionPolicy
 
 internal class XPFlagCleanerPositiveCases {
     enum class TestExperimentName {
+        SOME_FLAG,
     }
 
     enum class AnotherTestExperimentName {
+        SOME_OTHER_FLAG
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/generic/piranha/test-resources/kt/feature_flag_system_1/control/input/XPFlagCleanerCases.kt
+++ b/generic/piranha/test-resources/kt/feature_flag_system_1/control/input/XPFlagCleanerCases.kt
@@ -18,12 +18,15 @@ import java.lang.annotation.RetentionPolicy
 
 internal class XPFlagCleanerPositiveCases {
     enum class TestExperimentName {
+
+        SOME_FLAG,
         STALE_FLAG
     }
 
     enum class AnotherTestExperimentName {
         @Autorollout
-        STALE_FLAG
+        STALE_FLAG,
+        SOME_OTHER_FLAG
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/generic/piranha/test-resources/kt/feature_flag_system_1/treated/expected/XPFlagCleanerCases.kt
+++ b/generic/piranha/test-resources/kt/feature_flag_system_1/treated/expected/XPFlagCleanerCases.kt
@@ -17,9 +17,11 @@ import java.lang.annotation.RetentionPolicy
 
 internal class XPFlagCleanerPositiveCases {
     enum class TestExperimentName {
+        SOME_FLAG,
     }
 
     enum class AnotherTestExperimentName {
+        SOME_OTHER_FLAG
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/generic/piranha/test-resources/kt/feature_flag_system_1/treated/input/XPFlagCleanerCases.kt
+++ b/generic/piranha/test-resources/kt/feature_flag_system_1/treated/input/XPFlagCleanerCases.kt
@@ -18,12 +18,14 @@ import java.lang.annotation.RetentionPolicy
 
 internal class XPFlagCleanerPositiveCases {
     enum class TestExperimentName {
+        SOME_FLAG,
         STALE_FLAG
     }
 
     enum class AnotherTestExperimentName {
         @Autorollout
-        STALE_FLAG
+        STALE_FLAG,
+        SOME_OTHER_FLAG
     }
 
     @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
At a higher level the problem is that, when we have a a sequence of comma separated items in our grammar (like - arguments, parameters, enum constants), Piranha fails to cleanup the associated `,` resulting in an incorrect tree. 
This PR fixes this problem, by handling the error using a strategy that deletes the extra comma.

Before the PR : 
```
enum XTestExperimentName {
    STALE_FLAG,
    SOME_FLAG
}
```
to 
```
enum XTestExperimentName {
   , SOME_FLAG
}
```
Note this is an incorrect syntax tree. 

After the PR : 
```
enum XTestExperimentName {
    STALE_FLAG,
    SOME_FLAG
}
```
to 
```
enum XTestExperimentName {
   SOME_FLAG
}
```
Note the extra `,` has been removed.