### PR TITLE
User option for - deleting an empty file and replacing 3+ consecutive blank lines with 2.

### DIFF
--- a/polyglot/piranha/Cargo.toml
+++ b/polyglot/piranha/Cargo.toml
@@ -25,6 +25,7 @@ jwalk= "0.6.0"
 clap = { version = "3.1.12", features = ["derive"] }
 log = "0.4.16"
 env_logger = "0.9.0"
+tempdir = "0.3"
 tree-sitter-kotlin = { git = "https://github.com/ketkarameya/tree-sitter-kotlin.git" }
 tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java.git" }
 tree-sitter-swift = { git = "https://github.com/ketkarameya/tree-sitter-swift.git", branch = "add_parser" }

--- a/polyglot/piranha/demo/strings/Sample.strings
+++ b/polyglot/piranha/demo/strings/Sample.strings
@@ -3,3 +3,9 @@
 
 /* This is another key value pair */
 "apple" = "This is an apple.";
+
+/* This is another key value pair */
+"banana" = "This is a banana.";
+
+/* This is another key value pair */
+"melon" = "This is a melon.";

--- a/polyglot/piranha/demo/strings/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/strings/configurations/piranha_arguments.toml
@@ -13,3 +13,4 @@ language = ["strings"]
 substitutions = [
     ["stale_key", "apple"],
 ]
+delete_consecutive_new_lines = true

--- a/polyglot/piranha/src/main.rs
+++ b/polyglot/piranha/src/main.rs
@@ -35,10 +35,10 @@ fn main() {
 
   let args = PiranhaArguments::new(CommandLineArguments::parse());
 
-  let updated_files = execute_piranha(args);
+  let updated_files = execute_piranha(&args);
 
   for source_code_unit in updated_files {
-    source_code_unit.persist();
+    source_code_unit.persist(&args);
   }
 
   info!("Time elapsed - {:?}", now.elapsed().as_secs());

--- a/polyglot/piranha/src/models/piranha_arguments.rs
+++ b/polyglot/piranha/src/models/piranha_arguments.rs
@@ -38,6 +38,11 @@ pub(crate) struct PiranhaArguments {
   language: Language,
   // The language name is file the extension used for files in particular language.
   language_name: String,
+  // User option that determines whether an empty file will be deleted
+  delete_file_if_empty: bool,
+  // User option that determines whether consecutive newline characters will be
+  // replaced with a newline character
+  delete_consecutive_new_lines: bool,
 }
 
 impl PiranhaArguments {
@@ -59,6 +64,12 @@ impl PiranhaArguments {
       path_to_configurations: args.path_to_configurations,
       language_name: String::from(&piranha_args_from_config.language()),
       language: piranha_args_from_config.language().get_language(),
+      delete_file_if_empty: piranha_args_from_config
+        .delete_file_if_empty()
+        .unwrap_or(true),
+      delete_consecutive_new_lines: piranha_args_from_config
+        .delete_consecutive_new_lines()
+        .unwrap_or(true),
     }
   }
 
@@ -81,10 +92,26 @@ impl PiranhaArguments {
   pub(crate) fn language_name(&self) -> &str {
     self.language_name.as_ref()
   }
+
+  pub(crate) fn delete_file_if_empty(&self) -> bool {
+    self.delete_file_if_empty
+  }
+
+  pub(crate) fn delete_consecutive_new_lines(&self) -> bool {
+    self.delete_consecutive_new_lines
+  }
 }
 
 #[cfg(test)]
 impl PiranhaArguments {
+  pub(crate) fn set_delete_file_if_empty(&mut self, value: bool) {
+    self.delete_file_if_empty = value;
+  }
+
+  pub(crate) fn set_delete_consecutive_new_lines(&mut self, value: bool) {
+    self.delete_consecutive_new_lines = value;
+  }
+
   pub(crate) fn dummy() -> Self {
     let language_name = String::from("java");
     PiranhaArguments {
@@ -93,6 +120,24 @@ impl PiranhaArguments {
       path_to_configurations: String::new(),
       language: language_name.get_language(),
       language_name,
+      delete_consecutive_new_lines: false,
+      delete_file_if_empty: false,
     }
+  }
+
+  pub(crate) fn dummy_with_user_opt(delete_file_if_empty: bool, delete_consecutive_new_lines: bool) -> Self {
+    let language_name = String::from("java");
+    let mut args = PiranhaArguments {
+      path_to_code_base: String::new(),
+      input_substitutions: HashMap::new(),
+      path_to_configurations: String::new(),
+      language: language_name.get_language(),
+      language_name,
+      delete_consecutive_new_lines: false,
+      delete_file_if_empty: false,
+    };
+    args.set_delete_consecutive_new_lines(delete_consecutive_new_lines);
+    args.set_delete_file_if_empty(delete_file_if_empty);
+    args
   }
 }

--- a/polyglot/piranha/src/models/piranha_config.rs
+++ b/polyglot/piranha/src/models/piranha_config.rs
@@ -20,6 +20,8 @@ use serde_derive::Deserialize;
 pub(crate) struct PiranhaConfiguration {
   language: Vec<String>,
   substitutions: Vec<Vec<String>>,
+  delete_file_if_empty: Option<bool>,
+  delete_consecutive_new_lines: Option<bool>,
 }
 
 impl PiranhaConfiguration {
@@ -34,4 +36,12 @@ impl PiranhaConfiguration {
   pub(crate) fn language(&self) -> String {
     self.language[0].clone()
   }
+
+    pub(crate) fn delete_file_if_empty(&self) -> Option<bool> {
+        self.delete_file_if_empty
+    }
+
+    pub(crate) fn delete_consecutive_new_lines(&self) -> Option<bool> {
+        self.delete_consecutive_new_lines
+    }
 }

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -53,8 +53,9 @@ impl SourceCodeUnit {
       }
     } else {
       let content = if piranha_arguments.delete_consecutive_new_lines() {
-        let regex = Regex::new(r"\n\s*\n(\s*\n)").unwrap();
-        regex.replace_all(&self.code(), "\n${1}").to_string()
+
+        let regex = Regex::new(r"\n(\s*\n)+(\s*\n)").unwrap();
+        regex.replace_all(&self.code(), "\n${2}").to_string()
       } else {
         self.code()
       };

--- a/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
@@ -1,3 +1,13 @@
+use std::{
+  fs::{self},
+  io,
+};
+
+use itertools::Itertools;
+use tempdir::TempDir;
+
+use crate::models::piranha_arguments::PiranhaArguments;
+
 use {
   super::SourceCodeUnit,
   crate::{
@@ -95,4 +105,99 @@ fn test_apply_edit_negative() {
     ),
     &mut parser,
   );
+}
+
+fn execute_persist_in_temp_folder(
+  source_code: &str, args: &PiranhaArguments,
+  check_predicate: &dyn Fn(&TempDir) -> Result<bool, io::Error>,
+) -> Result<bool, io::Error> {
+  let mut parser = get_parser(String::from("java"));
+  let tmp_dir = TempDir::new("example")?;
+  let file_path = &tmp_dir.path().join("Sample1.java");
+  _ = fs::write(&file_path.as_path(), source_code.to_string());
+  let source_code_unit = SourceCodeUnit::new(
+    &mut parser,
+    source_code.to_string(),
+    &HashMap::new(),
+    &file_path.as_path(),
+  );
+  source_code_unit.persist(args);
+  check_predicate(&tmp_dir)
+}
+
+#[test]
+fn test_persist_delete_file_when_empty() -> Result<(), io::Error> {
+  let args = PiranhaArguments::dummy_with_user_opt(true, true);
+  let source_code = "";
+  fn check(temp_dir: &TempDir) -> Result<bool, io::Error> {
+    let paths = fs::read_dir(temp_dir)?;
+    Ok(paths.count() == 0)
+  }
+  assert!(execute_persist_in_temp_folder(source_code, &args, &check)?);
+  Ok(())
+}
+
+#[test]
+fn test_persist_do_not_delete_file_when_empty() -> Result<(), io::Error> {
+  let args = PiranhaArguments::dummy_with_user_opt(false, true);
+  let source_code = "";
+  fn check(temp_dir: &TempDir) -> Result<bool, io::Error> {
+    let paths = fs::read_dir(temp_dir)?;
+    Ok(paths.count() == 1)
+  }
+
+  assert!(execute_persist_in_temp_folder(source_code, &args, &check)?);
+  Ok(())
+}
+
+#[test]
+fn test_persist_delete_consecutive_lines() -> Result<(), io::Error> {
+  let args = PiranhaArguments::dummy_with_user_opt(true, true);
+  let source_code = "class Test {
+    public void foobar() {
+
+      System.out.println(\"Hello World!\");
+
+
+      System.out.println();
+    }
+  }";
+  fn check(temp_dir: &TempDir) -> Result<bool, io::Error> {
+    let paths = fs::read_dir(temp_dir)?;
+    let path = paths.find_or_first(|_| true).unwrap()?;
+    let expected_str = "class Test {
+    public void foobar() {
+
+      System.out.println(\"Hello World!\");
+
+      System.out.println();
+    }
+  }";
+    let actual_content = fs::read_to_string(path.path().as_path())?;
+    return Ok(actual_content.eq(&expected_str));
+  }
+  assert!(execute_persist_in_temp_folder(source_code, &args, &check)?);
+  Ok(())
+}
+
+#[test]
+fn test_persist_do_not_delete_consecutive_lines() -> Result<(), io::Error> {
+  let args = PiranhaArguments::dummy_with_user_opt(true, false);
+  let source_code = "class Test {
+    public void foobar() {
+
+      System.out.println(\"Hello World!\");
+
+
+      System.out.println();
+    }
+  }";
+  fn check(temp_dir: &TempDir) -> Result<bool, io::Error> {
+    let paths = fs::read_dir(temp_dir)?;
+    let path = paths.find_or_first(|_| true).unwrap()?;
+    let actual_content = fs::read_to_string(path.path().as_path())?;
+    return Ok(actual_content.eq(&actual_content));
+  }
+  assert!(execute_persist_in_temp_folder(source_code, &args, &check)?);
+  Ok(())
 }

--- a/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
@@ -153,10 +153,21 @@ fn test_persist_do_not_delete_file_when_empty() -> Result<(), io::Error> {
 #[test]
 fn test_persist_delete_consecutive_lines() -> Result<(), io::Error> {
   let args = PiranhaArguments::dummy_with_user_opt(true, true);
-  let source_code = "class Test {
+  let source_code_test_1 = "class Test {
     public void foobar() {
 
       System.out.println(\"Hello World!\");
+
+
+      System.out.println();
+    }
+  }";
+  let source_code_test_2 = "class Test {
+    public void foobar() {
+
+      System.out.println(\"Hello World!\");
+
+
 
 
       System.out.println();
@@ -176,7 +187,17 @@ fn test_persist_delete_consecutive_lines() -> Result<(), io::Error> {
     let actual_content = fs::read_to_string(path.path().as_path())?;
     return Ok(actual_content.eq(&expected_str));
   }
-  assert!(execute_persist_in_temp_folder(source_code, &args, &check)?);
+
+  assert!(execute_persist_in_temp_folder(
+    source_code_test_1,
+    &args,
+    &check
+  )?);
+  assert!(execute_persist_in_temp_folder(
+    source_code_test_2,
+    &args,
+    &check
+  )?);
   Ok(())
 }
 

--- a/polyglot/piranha/src/piranha.rs
+++ b/polyglot/piranha/src/piranha.rs
@@ -40,7 +40,7 @@ use crate::{
 use std::collections::VecDeque;
 use tree_sitter::{InputEdit, Node};
 
-pub(crate) fn execute_piranha(args: PiranhaArguments) -> Vec<SourceCodeUnit> {
+pub(crate) fn execute_piranha(args: &PiranhaArguments) -> Vec<SourceCodeUnit> {
   let mut flag_cleaner = FlagCleaner::new(args);
   flag_cleaner.perform_cleanup();
   flag_cleaner.get_updated_files()
@@ -273,8 +273,8 @@ impl FlagCleaner {
   }
 
   /// Instantiate Flag-cleaner
-  fn new(args: PiranhaArguments) -> Self {
-    let graph_rule_store = RuleStore::new(&args);
+  fn new(args: &PiranhaArguments) -> Self {
+    let graph_rule_store = RuleStore::new(args);
     Self {
       rule_store: graph_rule_store,
       path_to_codebase: String::from(args.path_to_code_base()),

--- a/polyglot/piranha/src/tests/mod.rs
+++ b/polyglot/piranha/src/tests/mod.rs
@@ -41,7 +41,7 @@ fn run_test(relative_path_to_tests: &str, n_files_changed: usize) {
     path_to_codebase: format!("{path_to_test_ff}/input/"),
     path_to_configurations: format!("{path_to_test_ff}/configurations/"),
   });
-  let updated_files = execute_piranha(args);
+  let updated_files = execute_piranha(&args);
   assert_eq!(updated_files.len(), n_files_changed);
   let path_to_expected =
     Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("{path_to_test_ff}/expected"));


### PR DESCRIPTION
This PR adds a user option for 
(i) deleting (or not deleting) an file that ends up being empty after Piranha cleanups 
(ii) Allow users to perform regex-replace over the file after Piranha has cleaned it up. 


## Context: 
* For file deletion: 
E.g., When cleaning up `strings` files, the users had a requirement that they didn't want to delete the file if it was empty after piranha cleanup. 

* User specified Regex replace after piranha cleanup : 
We do not want to guarantee the any good formatting after piranha cleanup, because we assume that there are handy formatters like google java format, swift lint, ... However, for some files like `strings` these formatters are not available. So in cases like these, users can replace 3+ consecutive blank lines with two (based on their specific scenario) after piranha cleanup to fix stuff.  The updated demo shows the applicability of this feature.  