### PR TITLE
Removes extra commas using regex replace in scenarios where tree-sitter does not report precise error

### DIFF
--- a/polyglot/piranha/src/models/edit.rs
+++ b/polyglot/piranha/src/models/edit.rs
@@ -24,6 +24,16 @@ impl Edit {
     }
   }
 
+  #[cfg(test)]
+  pub(crate) fn dummy_edit(replacement_range: Range, replacement_string: String) -> Self {
+    Self::new(
+      replacement_range,
+      replacement_string,
+      Rule::dummy(),
+      HashMap::new(),
+    )
+  }
+
   /// Get the edit's replacement range.
   pub(crate) fn replacement_range(&self) -> Range {
     self.replacement_range

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -120,8 +120,9 @@ impl SourceCodeUnit {
 
   // Tries to remove the extra comma -
   // -->  Remove comma if extra
-  //    --> Check if AST is correct
-  //      ---> No: Undo the change
+  //    --> Check if AST has no errors, to decide if the replacement was successful. 
+  //      --->  if No: Undo the change
+  //      --->  if Yes: Return   
   // Returns true if the comma was successfully removed.
   fn try_to_remove_extra_comma(&mut self, parser: &mut Parser) -> bool {
     let c_ast = self.ast.clone();
@@ -142,7 +143,10 @@ impl SourceCodeUnit {
   }
 
   // Tries to remove the extra comma - 
-  // Applies some Regex Replacements to the source file
+  // Applies three Regex-Replacements strategies to the source file to remove the extra comma. 
+  // *  replace consecutive commas with comma 
+  // *  replace ( `(,` or `[,` ) with just `(` or `[`)
+  // Check if AST has no errors, to decide if the replacement was successful. 
   // Returns true if the comma was successfully removed.
   fn try_to_fix_code_with_regex_replace(&mut self, parser: &mut Parser) -> bool{
     let consecutive_comma_pattern = Regex::new(r",\s*\n*,").unwrap();

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -4,6 +4,7 @@ use std::{
   path::{Path, PathBuf},
 };
 
+use log::info;
 use regex::Regex;
 use tree_sitter::{InputEdit, Node, Parser, Range, Tree};
 use tree_sitter_traversal::{traverse, Order};
@@ -65,7 +66,7 @@ impl SourceCodeUnit {
 
   pub(crate) fn apply_edit(&mut self, edit: &Edit, parser: &mut Parser) -> InputEdit {
     // Get the tree_sitter's input edit representation
-    self._apply_edit(edit.replacement_range(), edit.replacement_string(), parser)
+    self._apply_edit(edit.replacement_range(), edit.replacement_string(), parser, true)
   }
 
   /// Applies an edit to the source code unit
@@ -79,54 +80,105 @@ impl SourceCodeUnit {
   ///
   /// Note - Causes side effect. - Updates `self.ast` and `self.code`
   pub(crate) fn _apply_edit(
-    &mut self, range: Range, replacement_string: &str, parser: &mut Parser,
+    &mut self, range: Range, replacement_string: &str, parser: &mut Parser, handle_error: bool
   ) -> InputEdit {
     // Get the tree_sitter's input edit representation
     let (new_source_code, ts_edit) =
       get_tree_sitter_edit(self.code.clone(), range, replacement_string);
     // Apply edit to the tree
     self.ast.edit(&ts_edit);
-    // Create a new updated tree from the previous tree
-    let new_tree = parser
-      .parse(&new_source_code, Some(&self.ast))
-      .expect("Could not generate new tree!");
-    self.ast = new_tree;
-    self.code = new_source_code;
+    self._replace_file_contents_and_re_parse(&new_source_code, parser, true);
     // Handle errors, like removing extra comma.
-    self.remove_additional_comma_from_sequence_list(parser);
-    if self.ast.root_node().has_error() {
-      panic!(
-        "Produced syntactically incorrect source code {}",
-        self.code()
-      );
+    if self.ast.root_node().has_error() && handle_error {
+      self.fix_syntax_for_comma_separated_expressions(parser);
     }
     ts_edit
+  }
+
+  // Replaces the content of the current file with the new content and re-parses the AST
+  /// # Arguments
+  /// * `replacement_content` - new content of file
+  /// * `parser`
+  /// * `is_current_ast_edited` : have you invoked `edit` on the current AST ?
+  /// Note - Causes side effect. - Updates `self.ast` and `self.code`
+  pub(crate) fn _replace_file_contents_and_re_parse(
+    &mut self, replacement_content: &str, parser: &mut Parser, is_current_ast_edited: bool,
+  ) {
+    let prev_tree = if is_current_ast_edited {
+      Some(&self.ast)
+    } else {
+      None
+    };
+    println!("Replacing file contents");
+    // Create a new updated tree from the previous tree
+    let new_tree = parser
+      .parse(&replacement_content, prev_tree)
+      .expect("Could not generate new tree!");
+    self.ast = new_tree;
+    self.code = replacement_content.to_string();
+  }
+
+  // Tries to remove the extra comma -
+  // -->  Remove comma if extra
+  //    --> Check if AST is correct
+  //      ---> No: Undo the change
+  // Returns true if the comma was successfully removed.
+  fn try_to_remove_extra_comma(&mut self, parser: &mut Parser) -> bool {
+    let c_ast = self.ast.clone();
+    for n in traverse(c_ast.walk(), Order::Post) {
+      // Remove the extra comma
+      if n.is_extra() && eq_without_whitespace(n.utf8_text(self.code().as_bytes()).unwrap(), ",") {
+        let current_version_code = self.code().clone();
+        self._apply_edit(n.range(), "", parser, false);
+        if self.ast.root_node().has_error() {
+          // Undo the edit applied above
+          self._replace_file_contents_and_re_parse(&current_version_code, parser, false);
+        } else {
+          return true;
+        }
+      }
+    }
+    false
+  }
+
+  // Tries to remove the extra comma - 
+  // Applies some Regex Replacements to the source file
+  // Returns true if the comma was successfully removed.
+  fn try_to_fix_code_with_regex_replace(&mut self, parser: &mut Parser) -> bool{
+    let consecutive_comma_pattern = Regex::new(r",\s*\n*,").unwrap();
+    let square_bracket_comma_pattern = Regex::new(r"\[\s*\n*,").unwrap();
+    let round_bracket_comma_pattern = Regex::new(r"\(\s*\n*,").unwrap();
+    let strategies = [(consecutive_comma_pattern, ","), (square_bracket_comma_pattern, "["), (round_bracket_comma_pattern, "(")];
+
+    let mut content = self.code();
+    for (regex_pattern, replacement ) in strategies{
+        if regex_pattern.is_match(&content){
+          content = regex_pattern.replace_all(&content, replacement).to_string();
+          self._replace_file_contents_and_re_parse(&content, parser, false);
+        }
+    }
+    return !self.ast.root_node().has_error();
   }
 
   /// Sometimes our rewrite rules may produce errors (recoverable errors), like failing to remove an extra comma.
   /// This function, applies the recovery strategies.
   /// Currently, we only support recovering from extra comma.
-  fn remove_additional_comma_from_sequence_list(&mut self, parser: &mut Parser) {
-    if self.ast.root_node().has_error() {
-      let c_ast = self.ast.clone();
-      for n in traverse(c_ast.walk(), Order::Post) {
-        // Remove the extra comma
-        if n.is_extra() && eq_without_whitespace(n.utf8_text(self.code().as_bytes()).unwrap(), ",")
-        {
-          self._apply_edit(n.range(), "", parser);
-          break;
-        }
+  fn fix_syntax_for_comma_separated_expressions(&mut self, parser: &mut Parser) {
+    let is_fixed =
+      self.try_to_remove_extra_comma(parser) || self.try_to_fix_code_with_regex_replace(parser);
+
+    if !is_fixed {
+      if traverse(self.ast.walk(), Order::Post).any(|n| n.is_error()) {
+        panic!(
+          "Produced syntactically incorrect source code {}",
+          self.code()
+        );
       }
     }
   }
-
   // #[cfg(test)] // Rust analyzer FP
   pub fn code(&self) -> String {
     String::from(&self.code)
-  }
-  #[cfg(test)] // Rust analyzer FP
-  pub fn path(&self) -> &PathBuf {
-    &self.path
   }
 
   pub(crate) fn substitutions(&self) -> &HashMap<String, String> {

--- a/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
@@ -211,7 +211,6 @@ fn test_persist_do_not_delete_file_when_empty() -> Result<(), io::Error> {
 #[test]
 fn test_persist_delete_consecutive_lines() -> Result<(), io::Error> {
   let args = PiranhaArguments::dummy_with_user_opt(true, true);
-
   let source_code_test_1 = "class Test {
     public void foobar() {
 

--- a/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
@@ -6,17 +6,54 @@ use std::{
 use itertools::Itertools;
 use tempdir::TempDir;
 
-use crate::models::piranha_arguments::PiranhaArguments;
+use tree_sitter::Parser;
 
+use crate::models::piranha_arguments::PiranhaArguments;
 use {
   super::SourceCodeUnit,
   crate::{
-    models::edit::Edit, models::rule::Rule, utilities::eq_without_whitespace,
+    models::edit::Edit, utilities::eq_without_whitespace,
     utilities::tree_sitter_utilities::get_parser,
   },
   std::{collections::HashMap, path::PathBuf},
   tree_sitter::Range,
 };
+
+
+impl SourceCodeUnit {
+  
+  pub(crate) fn path(&self) -> &PathBuf {
+    &self.path
+  }
+
+
+  pub(crate) fn dummy_unit(content: &str, parser: &mut Parser) -> Self{
+    SourceCodeUnit::new(
+      parser,
+      content.to_string(),
+      &HashMap::new(),
+      PathBuf::new().as_path(),
+    )
+  }
+}
+
+fn range(
+  start_byte: usize, end_byte: usize, start_row: usize, start_column: usize, end_row: usize,
+  end_column: usize,
+) -> Range {
+  Range {
+    start_byte,
+    end_byte,
+    start_point: tree_sitter::Point {
+      row: start_row,
+      column: start_column,
+    },
+    end_point: tree_sitter::Point {
+      row: end_row,
+      column: end_column,
+    },
+  }
+}
 
 /// Positive test of an edit being applied  given replacement range  and replacement string.
 #[test]
@@ -33,37 +70,16 @@ fn test_apply_edit_positive() {
 
   let mut parser = get_parser(String::from("java"));
 
-  let mut source_code_unit = SourceCodeUnit::new(
-    &mut parser,
-    source_code.to_string(),
-    &HashMap::new(),
-    PathBuf::new().as_path(),
-  );
+  let mut source_code_unit = SourceCodeUnit::dummy_unit(source_code, &mut parser);
 
   let _ = source_code_unit.apply_edit(
-    &Edit::new(
-      Range {
-        start_byte: 49,
-        end_byte: 78,
-        start_point: tree_sitter::Point { row: 3, column: 9 },
-        end_point: tree_sitter::Point { row: 3, column: 38 },
-      },
-      String::new(),
-      Rule::dummy(),
-      HashMap::new(),
-    ),
+    &Edit::dummy_edit(
+      range(49, 78, 3, 9, 3, 38),
+      String::new()),
     &mut parser,
   );
   assert!(eq_without_whitespace(
-    r#"class Test {
-      public void foobar(){
-        
-        isFlagTreated = true;
-        if (isFlagTreated) {
-          // Do something;
-        }
-      }
-    }"#,
+    &source_code.replace("boolean isFlagTreated = true;", ""),
     &source_code_unit.code()
   ));
 }
@@ -83,30 +99,72 @@ fn test_apply_edit_negative() {
     }";
 
   let mut parser = get_parser(String::from("java"));
-
-  let mut source_code_unit = SourceCodeUnit::new(
-    &mut parser,
-    source_code.to_string(),
-    &HashMap::new(),
-    PathBuf::new().as_path(),
-  );
+  let mut source_code_unit = SourceCodeUnit::dummy_unit(source_code, &mut parser);
 
   let _ = source_code_unit.apply_edit(
-    &Edit::new(
-      Range {
-        start_byte: 1000,
-        end_byte: 10075,
-        start_point: tree_sitter::Point { row: 3, column: 9 },
-        end_point: tree_sitter::Point { row: 3, column: 38 },
-      },
-      String::new(),
-      Rule::dummy(),
-      HashMap::new(),
-    ),
+    &Edit::dummy_edit(range(1000, 2000, 0, 0, 0, 0),
+      String::new()),
     &mut parser,
   );
 }
 
+/// Positive test of an edit being applied  given replacement range  and replacement string.
+/// This scenario checks the logic that removes the comma identified by tree-sitter. 
+#[test]
+fn test_apply_edit_comma_handling_via_grammar() {
+  let source_code = "class Test {
+      @SuppressWarnings(\"NullAway\",\"FooBar\")
+      public void is_valid(@Nullable String s){
+        return s != null && check(s);
+      }
+    }";
+
+  let mut parser = get_parser(String::from("java"));
+
+  let mut source_code_unit = SourceCodeUnit::dummy_unit(source_code, &mut parser);
+
+  let _ = source_code_unit.apply_edit(
+    &Edit::dummy_edit(
+      range(37, 47, 2, 26, 2, 36),
+      String::new()),
+    &mut parser,
+  );
+  println!("{}", &source_code_unit.code());
+  assert!(eq_without_whitespace(
+    &source_code.replace("\"NullAway\",", ""),
+    &source_code_unit.code()
+  ));
+}
+
+
+/// Positive test of an edit being applied  given replacement range  and replacement string.
+/// Currently swift grammar does not always identify extra commas, we use regex replace at this point.
+/// This test scenario checks the regex replacement logic. 
+#[test]
+fn test_apply_edit_comma_handling_via_regex() {
+  let source_code = "class Test {
+    func some_func() {
+      var bike1 = Bike(name: \"BMX Bike\", gear: 2)
+      print(\"Name: \\(bike1.name) and Gear: \\(bike1.gear)\")
+  }
+}";
+
+  let mut parser = get_parser(String::from("swift"));
+
+  let mut source_code_unit = SourceCodeUnit::dummy_unit(source_code, &mut parser);
+
+  let _ = source_code_unit.apply_edit(
+    &Edit::dummy_edit(
+      range(59, 75, 3, 23, 3, 41),
+      String::new()),
+    &mut parser,
+  );
+  println!("{}", &source_code_unit.code());
+  assert!(eq_without_whitespace(
+    &source_code.replace("name: \"BMX Bike\",", ""),
+    &source_code_unit.code()
+  ));
+}
 fn execute_persist_in_temp_folder(
   source_code: &str, args: &PiranhaArguments,
   check_predicate: &dyn Fn(&TempDir) -> Result<bool, io::Error>,
@@ -153,7 +211,9 @@ fn test_persist_do_not_delete_file_when_empty() -> Result<(), io::Error> {
 #[test]
 fn test_persist_delete_consecutive_lines() -> Result<(), io::Error> {
   let args = PiranhaArguments::dummy_with_user_opt(true, true);
+
   let source_code_test_1 = "class Test {
+
     public void foobar() {
 
       System.out.println(\"Hello World!\");
@@ -187,7 +247,6 @@ fn test_persist_delete_consecutive_lines() -> Result<(), io::Error> {
     let actual_content = fs::read_to_string(path.path().as_path())?;
     return Ok(actual_content.eq(&expected_str));
   }
-
   assert!(execute_persist_in_temp_folder(
     source_code_test_1,
     &args,

--- a/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
@@ -213,7 +213,6 @@ fn test_persist_delete_consecutive_lines() -> Result<(), io::Error> {
   let args = PiranhaArguments::dummy_with_user_opt(true, true);
 
   let source_code_test_1 = "class Test {
-
     public void foobar() {
 
       System.out.println(\"Hello World!\");


### PR DESCRIPTION
As you might know, deleting comma is slightly awkward in these systems because it's not part of the abstract grammar (it is part of concrete grammar).  But we do have to delete a comma because I might update argument lists, arrays or parameter lists. 
So our strategy is as follows: 
1. Remove the element from the "comma separated list" like parameter list, args list
2. Parse the tree, and check for "extra" tokens reported by tree-sitter. IF this token is a comma remove it. 
3. Check if the 2. works by  parsing the updated tree, and checking if it is free of errors else undo the change.
4. Now try some regex strategies - > to replace patterns like `,,` with `,` or `(,` with `(`. After applying each regex strategy check if the the tree is free of errors or else undo the change .
5. If nothing works Panic!  - Runtime exception (Goal is to never produce any syntactically incorrect code) 

1, 2, 3 and 5. were implemented earlier.  This PR adds 4. And cleans-up the code.  

I have observed that such fall back regex strategies are applied only for few scenarios that too in more experimental grammars like that of `Swift`.
In most cases, the extra token is always correctly reported. Therefore never has to resort to 4. 

I have added unit-tests too. 
