### PR TITLE
Allow users to craft identity rewrite rules

### DIFF
--- a/polyglot/piranha/src/models/unit_tests/rule_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/rule_test.rs
@@ -77,7 +77,7 @@ fn test_get_edit_positive_recursive() {
     PathBuf::new().as_path(),
   );
   let node = source_code_unit.root_node();
-  let edit = rule.get_edit(&source_code_unit, &mut rule_store, node, true);
+  let edit = rule.get_edit(&source_code_unit, &mut rule_store, node, true, &None);
   assert!(edit.is_some());
 }
 
@@ -120,7 +120,7 @@ fn test_get_edit_negative_recursive() {
     PathBuf::new().as_path(),
   );
   let node = source_code_unit.root_node();
-  let edit = rule.get_edit(&source_code_unit, &mut rule_store, node, true);
+  let edit = rule.get_edit(&source_code_unit, &mut rule_store, node, true, &None);
   assert!(edit.is_none());
 }
 

--- a/polyglot/piranha/src/piranha.rs
+++ b/polyglot/piranha/src/piranha.rs
@@ -52,8 +52,12 @@ impl SourceCodeUnit {
     &mut self, rule: Rule, rules_store: &mut RuleStore, parser: &mut Parser,
     scope_query: &Option<String>,
   ) {
+    let mut applied_edit_start = None;
     loop {
-      if !self._apply_rule(rule.clone(), rules_store, parser, scope_query) {
+      // We always apply edits from bottom up. 
+      applied_edit_start = self._apply_rule(rule.clone(), rules_store, parser, scope_query, &applied_edit_start);
+
+      if applied_edit_start.is_none() {
         break;
       }
     }
@@ -63,15 +67,15 @@ impl SourceCodeUnit {
   // This is implements the main algorithm of piranha.
   fn _apply_rule(
     &mut self, rule: Rule, rules_store: &mut RuleStore, parser: &mut Parser,
-    scope_query: &Option<String>,
-  ) -> bool {
+    scope_query: &Option<String>, applied_edit_start: &Option<usize>
+  ) -> Option<usize> {
     let scope_node = self.get_scope_node(scope_query, rules_store);
 
-    let mut any_match = false;
+    let mut match_start = None;
 
     // Match the rule "anywhere" inside the scope_node
-    if let Some(edit_1) = rule.get_edit(&self.clone(), rules_store, scope_node, true) {
-      any_match = true;
+    if let Some(edit_1) = rule.get_edit(&self.clone(), rules_store, scope_node, true, applied_edit_start) {
+      match_start = Option::Some(edit_1.replacement_range().start_byte);
       // Apply edit_1
       let applied_ts_edit = self.apply_edit(&edit_1, parser);
 
@@ -128,7 +132,7 @@ impl SourceCodeUnit {
         self.apply_rule(rle, rules_store, parser, &Some(sq.to_string()));
       }
     }
-    any_match
+    match_start
   }
 
   /// Adds the "Method" and "Class" scoped next rules to the queue.

--- a/polyglot/piranha/src/tests/test_piranha_java.rs
+++ b/polyglot/piranha/src/tests/test_piranha_java.rs
@@ -38,3 +38,9 @@ fn test_java_scenarios_control_ff2() {
   initialize();
   run_test(&format!("{}/{}/{}",LANGUAGE, "feature_flag_system_2", "control"), 4);
 }
+
+#[test]
+fn test_java_identity_rule() {
+  initialize();
+  run_test(&format!("{}/{}",LANGUAGE,"identity_rule"), 1);
+}

--- a/polyglot/piranha/test-resources/java/identity_rule/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/identity_rule/configurations/piranha_arguments.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["java"]
+substitutions = []

--- a/polyglot/piranha/test-resources/java/identity_rule/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/java/identity_rule/configurations/rules.toml
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains rules to the specific feature flag API.
+# Before :
+# interface IExp {
+#  @BoolParam(key = "STALE_FLAG", namespace="NS")    
+#  public void isStaleFeature();
+#  @BoolParam(key = "OTHER_FLAG", namespace="NS")
+#  public void isOtherFeature();
+# }
+# After :
+# interface IExp {
+#  @BoolParam(key = "OTHER_FLAG", namespace="NS")
+#  public void isOtherFeature();
+# }
+#
+[[rules]]
+name = "delete_flag_method_declaration_fully_annotated"
+query = """
+(method_declaration) @md
+"""
+replace_node = "md"
+replace = "@md"

--- a/polyglot/piranha/test-resources/java/identity_rule/expected/TestClass.java
+++ b/polyglot/piranha/test-resources/java/identity_rule/expected/TestClass.java
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2022 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+class TestClass {
+
+  public void testMethod(){
+    System.out.println("Hello");
+  }
+
+  public void someMethod(){
+    System.out.println("World");
+  }
+
+  public void fooBar(){
+    System.out.println("!");
+  }
+
+}

--- a/polyglot/piranha/test-resources/java/identity_rule/input/TestClass.java
+++ b/polyglot/piranha/test-resources/java/identity_rule/input/TestClass.java
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2022 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+class TestClass {
+
+  public void testMethod(){
+    System.out.println("Hello");
+  }
+
+  public void someMethod(){
+    System.out.println("World");
+  }
+
+  public void fooBar(){
+    System.out.println("!");
+  }
+
+}


### PR DESCRIPTION
Let's take a scenario where a user wants to performa identity rewrite rule.  In such a scenario, our current logic of finding matches and rewriting gets stuck in an infinite loop. 

Reason: 
Our earlier strategy was : For a rule `r` and compilation unit `cu` , get first match for `r` in `cu` -> rewrite AST -> incrementally re-parse.  Keep repeating this until no match.  This will get stuck in infinite loop if the rule is identity.

Now: 
For a rule `r` and compilation unit `cu` , get first match for `r` in `cu` -> rewrite AST ->  incrementally re-parse  -> incrementally re-parse -> Get next match such that, it occurs before the start of the previous match. 

Note that for "performance" reasons, I return all the matches bottom up with respect to source code line number. Thats why i find next match such that it occurs before previous match. 


I have added a test scenario for it too. 


---------
Identity rewrite rule can be imagined something similar to match-only rule (don't rewrite) . It will match the code, it will update the internal substitution table, but will not do any real change. to the AST.
I will introduce the notion of `match-only` rules in the next PR. I just want to keep changes small and easy for ya'll to review. 

