### PR TITLE
Reorganize the code a bit so that Piranha can be used as a binary and as library

### DIFF
--- a/polyglot/piranha/Cargo.toml
+++ b/polyglot/piranha/Cargo.toml
@@ -8,6 +8,14 @@ include = [
     "src/"
 ]
 
+[[bin]]
+name = "polyglot_piranha"
+path = "src/main.rs"
+
+[lib]
+name = "polyglot_piranha"
+path = "src/lib.rs"
+
 [build-dependencies]
 cc = "1.0.73"
 

--- a/polyglot/piranha/src/cleanup_rules/swift/scope_config.toml
+++ b/polyglot/piranha/src/cleanup_rules/swift/scope_config.toml
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+[[scopes]]
+name = "Class"
+[[scopes.rules]]
+matcher =  """
+(class_declaration name: (_) @cls_name) @class
+"""
+generator = """(
+(class_declaration name: (_) @name) @cs
+(#eq? @name "@cls_name")              
+)"""
+
+
+[[scopes]]
+name = "File"
+[[scopes.rules]]
+matcher =  """
+(source_file) @source_file
+"""
+generator = """(source_file) @sf"""

--- a/polyglot/piranha/src/lib.rs
+++ b/polyglot/piranha/src/lib.rs
@@ -11,7 +11,10 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use models::{piranha_arguments::PiranhaArguments, source_code_unit::SourceCodeUnit, piranha_output::PiranhaOutputSummary};
+use models::{
+  piranha_arguments::PiranhaArguments, piranha_output::PiranhaOutputSummary,
+  source_code_unit::SourceCodeUnit,
+};
 
 mod config;
 pub mod models;
@@ -28,7 +31,8 @@ use log::info;
 use regex::Regex;
 use tree_sitter::{Parser, Range};
 
-use crate::{models::{rule_store::RuleStore,},
+use crate::{
+  models::rule_store::RuleStore,
   utilities::{read_file, tree_sitter_utilities::get_match_and_replace_range},
 };
 
@@ -47,7 +51,9 @@ use tree_sitter::Node;
 
 /// Executes piranha for the given configuration
 /// Returns (List of updated piranha files, Map of matches found for each file, map of rewrites performed in each file)
-pub fn execute_piranha(configuration: &PiranhaArguments, should_rewrite_files : bool) -> Vec<PiranhaOutputSummary> {
+pub fn execute_piranha(
+  configuration: &PiranhaArguments, should_rewrite_files: bool,
+) -> Vec<PiranhaOutputSummary> {
   let mut flag_cleaner = FlagCleaner::new(configuration);
   flag_cleaner.perform_cleanup();
 
@@ -56,11 +62,15 @@ pub fn execute_piranha(configuration: &PiranhaArguments, should_rewrite_files : 
   if should_rewrite_files {
     for scu in source_code_units {
       scu.persist(&configuration);
-    }  
+    }
   }
-  
+
   // flag_cleaner.relevant_files
-  flag_cleaner.get_updated_files().iter().map(|f|PiranhaOutputSummary::new(f)).collect_vec()
+  flag_cleaner
+    .get_updated_files()
+    .iter()
+    .map(|f| PiranhaOutputSummary::new(f))
+    .collect_vec()
 }
 
 impl SourceCodeUnit {
@@ -294,7 +304,7 @@ struct FlagCleaner {
 }
 
 impl FlagCleaner {
-   fn get_updated_files(&self) -> Vec<SourceCodeUnit> {
+  fn get_updated_files(&self) -> Vec<SourceCodeUnit> {
     self
       .relevant_files
       .values()
@@ -304,7 +314,7 @@ impl FlagCleaner {
   }
 
   /// Performs cleanup related to stale flags
-    fn perform_cleanup(&mut self) {
+  fn perform_cleanup(&mut self) {
     // Setup the parser for the specific language
     let mut parser = Parser::new();
     parser
@@ -385,7 +395,7 @@ impl FlagCleaner {
   }
 
   /// Instantiate Flag-cleaner
-fn new(args: &PiranhaArguments) -> Self {
+  fn new(args: &PiranhaArguments) -> Self {
     let graph_rule_store = RuleStore::new(args);
     Self {
       rule_store: graph_rule_store,

--- a/polyglot/piranha/src/lib.rs
+++ b/polyglot/piranha/src/lib.rs
@@ -11,6 +11,15 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+use models::{piranha_arguments::PiranhaArguments, source_code_unit::SourceCodeUnit, piranha_output::PiranhaOutputSummary};
+
+mod config;
+pub mod models;
+// pub mod piranha;
+#[cfg(test)]
+mod tests;
+pub mod utilities;
+
 use std::{collections::HashMap, path::PathBuf};
 
 use colored::Colorize;
@@ -20,10 +29,7 @@ use log::info;
 use regex::Regex;
 use tree_sitter::{Parser, Range};
 
-use crate::{
-  models::{piranha_arguments::PiranhaArguments,
-    piranha_output::PiranhaOutputSummary, rule_store::RuleStore, source_code_unit::SourceCodeUnit,
-  },
+use crate::{models::{rule_store::RuleStore,},
   utilities::{read_file, tree_sitter_utilities::get_match_and_replace_range},
 };
 
@@ -42,7 +48,7 @@ use tree_sitter::Node;
 
 /// Executes piranha for the given configuration
 /// Returns (List of updated piranha files, Map of matches found for each file, map of rewrites performed in each file)
-pub(crate) fn execute_piranha(configuration: &PiranhaArguments) -> (Vec<SourceCodeUnit>, Vec<PiranhaOutputSummary>) {
+pub fn execute_piranha(configuration: &PiranhaArguments) -> (Vec<SourceCodeUnit>, Vec<PiranhaOutputSummary>) {
   let mut flag_cleaner = FlagCleaner::new(configuration);
   flag_cleaner.perform_cleanup();
   // flag_cleaner.relevant_files
@@ -270,7 +276,7 @@ impl SourceCodeUnit {
 }
 
 // Maintains the state of Piranha and the updated content of files in the source code.
-struct FlagCleaner {
+pub(crate) struct FlagCleaner {
   // Maintains Piranha's state
   rule_store: RuleStore,
   // Path to source code folder
@@ -280,7 +286,7 @@ struct FlagCleaner {
 }
 
 impl FlagCleaner {
-  fn get_updated_files(&self) -> Vec<SourceCodeUnit> {
+   fn get_updated_files(&self) -> Vec<SourceCodeUnit> {
     self
       .relevant_files
       .values()
@@ -290,7 +296,7 @@ impl FlagCleaner {
   }
 
   /// Performs cleanup related to stale flags
-  fn perform_cleanup(&mut self) {
+    fn perform_cleanup(&mut self) {
     // Setup the parser for the specific language
     let mut parser = Parser::new();
     parser
@@ -371,7 +377,7 @@ impl FlagCleaner {
   }
 
   /// Instantiate Flag-cleaner
-  fn new(args: &PiranhaArguments) -> Self {
+fn new(args: &PiranhaArguments) -> Self {
     let graph_rule_store = RuleStore::new(args);
     Self {
       rule_store: graph_rule_store,

--- a/polyglot/piranha/src/lib.rs
+++ b/polyglot/piranha/src/lib.rs
@@ -123,7 +123,7 @@ impl SourceCodeUnit {
         query_again = true;
 
         // Add all the (code_snippet, tag) mapping to the substitution table.
-        self.add_to_substitutions(edit.matches());
+        self.add_to_substitutions(edit.matches(), rule_store);
 
         // Apply edit_1
         let applied_ts_edit = self.apply_edit(&edit, parser);
@@ -151,7 +151,7 @@ impl SourceCodeUnit {
         // Note that, here we DO NOT invoke the `_apply_edit` method and only update the `substitutions`
         // By NOT invoking this we simulate the application of an identity rule
         //
-        self.add_to_substitutions(m.matches());
+        self.add_to_substitutions(m.matches(), rule_store);
 
         self.propagate((m.range(), m.range()), rule.clone(), rule_store, parser);
       }
@@ -225,7 +225,7 @@ impl SourceCodeUnit {
         (current_match_range, current_replace_range) = get_match_and_replace_range(applied_edit);
         current_rule = edit.matched_rule();
         // Add the (tag, code_snippet) mapping to substitution table.
-        self.add_to_substitutions(edit.matches());
+        self.add_to_substitutions(edit.matches(), rules_store);
       } else {
         // No more parents found for cleanup
         break;
@@ -338,7 +338,7 @@ impl FlagCleaner {
             SourceCodeUnit::new(
               &mut parser,
               content,
-              &self.rule_store.input_substitutions(),
+              &self.rule_store.default_substitutions(),
               path.as_path(),
             )
           })

--- a/polyglot/piranha/src/main.rs
+++ b/polyglot/piranha/src/main.rs
@@ -12,29 +12,19 @@ Copyright (c) 2022 Uber Technologies, Inc.
 */
 
 //! Defines the entry-point for Piranha.
-use std::{fs, time::Instant};
+use std::{fs::{self}, time::Instant};
 
-use crate::{
-  models::piranha_arguments::PiranhaArguments, piranha::execute_piranha,
-  utilities::initialize_logger,
+use polyglot_piranha::{
+  models::piranha_arguments::PiranhaArguments,
+  models::piranha_output::PiranhaOutputSummary, utilities::initialize_logger, execute_piranha,
 };
-use clap::StructOpt;
-use config::CommandLineArguments;
 use log::info;
-use models::piranha_output::PiranhaOutputSummary;
-
-mod config;
-mod models;
-mod piranha;
-#[cfg(test)]
-mod tests;
-mod utilities;
 
 fn main() {
   let now = Instant::now();
   initialize_logger(false);
 
-  let args = PiranhaArguments::new(CommandLineArguments::parse());
+  let args = PiranhaArguments::from_command_line();
 
   let (source_code_units, piranha_output_summaries) = execute_piranha(&args);
 

--- a/polyglot/piranha/src/main.rs
+++ b/polyglot/piranha/src/main.rs
@@ -12,7 +12,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 */
 
 //! Defines the entry-point for Piranha.
-use std::{fs::{self}, time::Instant};
+use std::{fs, time::Instant};
 
 use polyglot_piranha::{
   models::piranha_arguments::PiranhaArguments,
@@ -26,11 +26,7 @@ fn main() {
 
   let args = PiranhaArguments::from_command_line();
 
-  let (source_code_units, piranha_output_summaries) = execute_piranha(&args);
-
-  for scu in source_code_units {
-    scu.persist(&args);
-  }
+  let piranha_output_summaries = execute_piranha(&args, true);
 
   if args.path_to_output_summaries().is_some() {
     write_output_summary(

--- a/polyglot/piranha/src/main.rs
+++ b/polyglot/piranha/src/main.rs
@@ -14,11 +14,11 @@ Copyright (c) 2022 Uber Technologies, Inc.
 //! Defines the entry-point for Piranha.
 use std::{fs, time::Instant};
 
-use polyglot_piranha::{
-  models::piranha_arguments::PiranhaArguments,
-  models::piranha_output::PiranhaOutputSummary, utilities::initialize_logger, execute_piranha,
-};
 use log::info;
+use polyglot_piranha::{
+  execute_piranha, models::piranha_arguments::PiranhaArguments,
+  models::piranha_output::PiranhaOutputSummary, utilities::initialize_logger,
+};
 
 fn main() {
   let now = Instant::now();

--- a/polyglot/piranha/src/models/constraint.rs
+++ b/polyglot/piranha/src/models/constraint.rs
@@ -35,22 +35,19 @@ impl Constraint {
     &self, node: Node, source_code_unit: SourceCodeUnit, rule_store: &mut RuleStore,
     substitutions: &HashMap<String, String>,
   ) -> bool {
-
     let mut current_node = node;
     // This ensures that the below while loop considers the current node too when checking for constraints.
     // It does not make sense to check for constraint if current node is a "leaf" node.
     if node.child_count() > 0 {
-       current_node = node.child(0).unwrap();
+      current_node = node.child(0).unwrap();
     }
     // Get the scope_node of the constraint (`scope.matcher`)
     let mut matched_matcher = false;
     while let Some(parent) = current_node.parent() {
       let query_str = &self.matcher(substitutions);
-      if let Some(p_match) = parent.get_match_for_query(
-        &source_code_unit.code(),
-        rule_store.query(query_str),
-        false,
-      ) {
+      if let Some(p_match) =
+        parent.get_match_for_query(&source_code_unit.code(), rule_store.query(query_str), false)
+      {
         matched_matcher = true;
         let scope_node = get_node_for_range(
           source_code_unit.root_node(),

--- a/polyglot/piranha/src/models/edit.rs
+++ b/polyglot/piranha/src/models/edit.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use serde_derive::{Serialize};
+use serde_derive::Serialize;
 use tree_sitter::Range;
 
-use super::{matches::Match};
+use super::matches::Match;
 
 #[derive(Serialize, Debug, Clone)]
 pub(crate) struct Edit {
@@ -13,13 +13,10 @@ pub(crate) struct Edit {
   replacement_string: String,
   // The rule used for creating this match-replace
   matched_rule: String,
-  
 }
 
 impl Edit {
-  pub(crate) fn new(
-    p_match: Match, replacement_string: String, matched_rule: String,
-  ) -> Self {
+  pub(crate) fn new(p_match: Match, replacement_string: String, matched_rule: String) -> Self {
     Self {
       p_match,
       replacement_string,

--- a/polyglot/piranha/src/models/matches.rs
+++ b/polyglot/piranha/src/models/matches.rs
@@ -41,7 +41,7 @@ impl Match {
 }
 
 /// This method serializes the `tree_sitter::Range` struct. Originally, it does not derive serde::Serialize
-/// So in this method, we cast `Range` to a local type `LocalRange` and serialize this casted object. 
+/// So in this method, we cast `Range` to a local type `LocalRange` and serialize this casted object.
 /// Note `LocalRange` derives serialize.
 fn ser_range<S: Serializer>(range: &Range, serializer: S) -> Result<S::Ok, S::Error> {
   let local_range = LocalRange {

--- a/polyglot/piranha/src/models/mod.rs
+++ b/polyglot/piranha/src/models/mod.rs
@@ -14,7 +14,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 pub(crate) mod constraint;
 pub(crate) mod edit;
 pub(crate) mod outgoing_edges;
-pub(crate) mod piranha_arguments;
+pub mod piranha_arguments;
 pub(crate) mod piranha_config;
 pub(crate) mod rule;
 pub(crate) mod rule_graph;
@@ -22,4 +22,4 @@ pub(crate) mod rule_store;
 pub(crate) mod scopes;
 pub(crate) mod source_code_unit;
 pub(crate) mod matches;
-pub(crate) mod piranha_output;
+pub mod piranha_output;

--- a/polyglot/piranha/src/models/mod.rs
+++ b/polyglot/piranha/src/models/mod.rs
@@ -13,13 +13,13 @@ Copyright (c) 2022 Uber Technologies, Inc.
 
 pub(crate) mod constraint;
 pub(crate) mod edit;
+pub(crate) mod matches;
 pub(crate) mod outgoing_edges;
 pub mod piranha_arguments;
 pub(crate) mod piranha_config;
+pub mod piranha_output;
 pub(crate) mod rule;
 pub(crate) mod rule_graph;
 pub(crate) mod rule_store;
 pub(crate) mod scopes;
 pub(crate) mod source_code_unit;
-pub(crate) mod matches;
-pub mod piranha_output;

--- a/polyglot/piranha/src/models/piranha_arguments.rs
+++ b/polyglot/piranha/src/models/piranha_arguments.rs
@@ -46,6 +46,10 @@ pub struct PiranhaArguments {
   // User option that determines whether consecutive newline characters will be
   // replaced with a newline character
   delete_consecutive_new_lines: bool,
+  // User option that determines the prefix used for tag names that should be considered 
+  /// global i.e. if a global tag is found when rewriting a source code unit
+  /// All source code units from this point will have access to this global tag. 
+  global_tag_prefix: Option<String>,
 }
 
 impl PiranhaArguments {
@@ -78,6 +82,7 @@ impl PiranhaArguments {
       delete_consecutive_new_lines: piranha_args_from_config
         .delete_consecutive_new_lines()
         .unwrap_or(false),
+      global_tag_prefix: piranha_args_from_config.global_tag_prefix(),
     }
   }
 
@@ -110,7 +115,17 @@ impl PiranhaArguments {
   }
 
   pub fn path_to_output_summaries(&self) -> Option<&String> {
-    self.path_to_output_summaries.as_ref()
+        self.path_to_output_summaries.as_ref()
+    }
+  
+  /// Returns default Global prefix tag as "GLOBAL_TAG."
+  /// i.e. it expects global tag names to lok like 
+  /// @GLOBAL_TAG.class_name
+  pub(crate) fn global_tag_prefix(&self) -> &str {
+    if let Some(t) = &self.global_tag_prefix{
+      return t.as_str();
+    }
+    return "GLOBAL_TAG."
   }
 }
 
@@ -135,6 +150,7 @@ impl PiranhaArguments {
       language_name,
       delete_consecutive_new_lines: false,
       delete_file_if_empty: false,
+      global_tag_prefix: None
     }
   }
 
@@ -151,6 +167,7 @@ impl PiranhaArguments {
       language_name,
       delete_consecutive_new_lines: false,
       delete_file_if_empty: false,
+      global_tag_prefix: None
     };
     args.set_delete_consecutive_new_lines(delete_consecutive_new_lines);
     args.set_delete_file_if_empty(delete_file_if_empty);

--- a/polyglot/piranha/src/models/piranha_arguments.rs
+++ b/polyglot/piranha/src/models/piranha_arguments.rs
@@ -35,8 +35,8 @@ pub struct PiranhaArguments {
   input_substitutions: HashMap<String, String>,
   /// Folder containing the API specific rules
   path_to_configurations: String,
-  /// File to which the output summary should be written 
-  path_to_output_summaries : Option<String>,
+  /// File to which the output summary should be written
+  path_to_output_summaries: Option<String>,
   /// Tree-sitter language model
   language: Language,
   // The language name is file the extension used for files in particular language.
@@ -49,11 +49,9 @@ pub struct PiranhaArguments {
 }
 
 impl PiranhaArguments {
-
   pub fn from_command_line() -> Self {
     Self::new(CommandLineArguments::parse())
   }
-
 
   pub(crate) fn new(args: CommandLineArguments) -> Self {
     let path_to_piranha_argument_file =
@@ -112,8 +110,8 @@ impl PiranhaArguments {
   }
 
   pub fn path_to_output_summaries(&self) -> Option<&String> {
-        self.path_to_output_summaries.as_ref()
-    }
+    self.path_to_output_summaries.as_ref()
+  }
 }
 
 #[cfg(test)]
@@ -140,7 +138,9 @@ impl PiranhaArguments {
     }
   }
 
-  pub(crate) fn dummy_with_user_opt(delete_file_if_empty: bool, delete_consecutive_new_lines: bool) -> Self {
+  pub(crate) fn dummy_with_user_opt(
+    delete_file_if_empty: bool, delete_consecutive_new_lines: bool,
+  ) -> Self {
     let language_name = String::from("java");
     let mut args = PiranhaArguments {
       path_to_code_base: String::new(),

--- a/polyglot/piranha/src/models/piranha_arguments.rs
+++ b/polyglot/piranha/src/models/piranha_arguments.rs
@@ -13,6 +13,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 
 use std::{collections::HashMap, path::PathBuf};
 
+use clap::Parser;
 use colored::Colorize;
 use log::info;
 use tree_sitter::Language;
@@ -25,7 +26,7 @@ use crate::{
 
 #[derive(Clone)]
 /// Captures the processed Piranha arguments (Piranha-Configuration) parsed from `path_to_feature_flag_rules`.
-pub(crate) struct PiranhaArguments {
+pub struct PiranhaArguments {
   /// Path to source code folder.
   path_to_code_base: String,
   // Input arguments provided to Piranha, mapped to tag names -
@@ -48,6 +49,12 @@ pub(crate) struct PiranhaArguments {
 }
 
 impl PiranhaArguments {
+
+  pub fn from_command_line() -> Self {
+    Self::new(CommandLineArguments::parse())
+  }
+
+
   pub(crate) fn new(args: CommandLineArguments) -> Self {
     let path_to_piranha_argument_file =
       PathBuf::from(args.path_to_configurations.as_str()).join("piranha_arguments.toml");
@@ -104,7 +111,7 @@ impl PiranhaArguments {
     self.delete_consecutive_new_lines
   }
 
-    pub(crate) fn path_to_output_summaries(&self) -> Option<&String> {
+  pub fn path_to_output_summaries(&self) -> Option<&String> {
         self.path_to_output_summaries.as_ref()
     }
 }

--- a/polyglot/piranha/src/models/piranha_config.rs
+++ b/polyglot/piranha/src/models/piranha_config.rs
@@ -22,6 +22,7 @@ pub(crate) struct PiranhaConfiguration {
   substitutions: Vec<Vec<String>>,
   delete_file_if_empty: Option<bool>,
   delete_consecutive_new_lines: Option<bool>,
+  global_tag_prefix: Option<String>,
 }
 
 impl PiranhaConfiguration {
@@ -41,7 +42,11 @@ impl PiranhaConfiguration {
     self.delete_file_if_empty
   }
 
-  pub(crate) fn delete_consecutive_new_lines(&self) -> Option<bool> {
-    self.delete_consecutive_new_lines
+    pub(crate) fn delete_consecutive_new_lines(&self) -> Option<bool> {
+        self.delete_consecutive_new_lines
+    }
+
+  pub(crate) fn global_tag_prefix(&self) -> Option<String> {
+      self.global_tag_prefix.clone()
   }
 }

--- a/polyglot/piranha/src/models/piranha_config.rs
+++ b/polyglot/piranha/src/models/piranha_config.rs
@@ -37,11 +37,11 @@ impl PiranhaConfiguration {
     self.language[0].clone()
   }
 
-    pub(crate) fn delete_file_if_empty(&self) -> Option<bool> {
-        self.delete_file_if_empty
-    }
+  pub(crate) fn delete_file_if_empty(&self) -> Option<bool> {
+    self.delete_file_if_empty
+  }
 
-    pub(crate) fn delete_consecutive_new_lines(&self) -> Option<bool> {
-        self.delete_consecutive_new_lines
-    }
+  pub(crate) fn delete_consecutive_new_lines(&self) -> Option<bool> {
+    self.delete_consecutive_new_lines
+  }
 }

--- a/polyglot/piranha/src/models/piranha_output.rs
+++ b/polyglot/piranha/src/models/piranha_output.rs
@@ -1,3 +1,5 @@
+use std::path::{PathBuf};
+
 use itertools::Itertools;
 use serde_derive::Serialize;
 
@@ -36,4 +38,12 @@ impl PiranhaOutputSummary {
   pub(crate) fn rewrites(&self) -> &[Edit] {
     self.rewrites.as_ref()
   }
+
+    pub fn path(&self) -> PathBuf {
+        PathBuf::from(self.path.as_str())
+    }
+
+    pub fn content(&self) -> &str {
+        self.content.as_ref()
+    }
 }

--- a/polyglot/piranha/src/models/piranha_output.rs
+++ b/polyglot/piranha/src/models/piranha_output.rs
@@ -4,7 +4,7 @@ use serde_derive::Serialize;
 use super::{edit::Edit, matches::Match, source_code_unit::SourceCodeUnit};
 
 #[derive(Serialize, Debug, Clone, Default)]
-pub(crate) struct PiranhaOutputSummary {
+pub struct PiranhaOutputSummary {
   path: String,
   content: String,
   matches: Vec<(String, Match)>,

--- a/polyglot/piranha/src/models/piranha_output.rs
+++ b/polyglot/piranha/src/models/piranha_output.rs
@@ -1,4 +1,4 @@
-use std::path::{PathBuf};
+use std::path::PathBuf;
 
 use itertools::Itertools;
 use serde_derive::Serialize;
@@ -16,19 +16,13 @@ pub struct PiranhaOutputSummary {
 impl PiranhaOutputSummary {
   pub(crate) fn new(source_code_unit: &SourceCodeUnit) -> PiranhaOutputSummary {
     return PiranhaOutputSummary {
-      path: String::from(
-        source_code_unit
-          .path()
-          .as_os_str()
-          .to_str()
-          .unwrap(),
-      ),
+      path: String::from(source_code_unit.path().as_os_str().to_str().unwrap()),
       content: source_code_unit.code(),
       matches: source_code_unit.matches().iter().cloned().collect_vec(),
       rewrites: source_code_unit.rewrites().iter().cloned().collect_vec(),
     };
   }
-  
+
   #[cfg(test)]
   pub(crate) fn matches(&self) -> &[(String, Match)] {
     self.matches.as_ref()
@@ -39,11 +33,11 @@ impl PiranhaOutputSummary {
     self.rewrites.as_ref()
   }
 
-    pub fn path(&self) -> PathBuf {
-        PathBuf::from(self.path.as_str())
-    }
+  pub fn path(&self) -> PathBuf {
+    PathBuf::from(self.path.as_str())
+  }
 
-    pub fn content(&self) -> &str {
-        self.content.as_ref()
-    }
+  pub fn content(&self) -> &str {
+    self.content.as_ref()
+  }
 }

--- a/polyglot/piranha/src/models/rule.rs
+++ b/polyglot/piranha/src/models/rule.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 
 use colored::Colorize;
 use serde_derive::Deserialize;
-use tree_sitter::{Node};
+use tree_sitter::Node;
 
 use crate::utilities::{
   tree_sitter_utilities::{get_context, get_node_for_range, substitute_tags, PiranhaHelpers},
@@ -23,7 +23,8 @@ use crate::utilities::{
 };
 
 use super::{
-  constraint::Constraint, edit::Edit, rule_store::RuleStore, source_code_unit::SourceCodeUnit, matches::Match,
+  constraint::Constraint, edit::Edit, matches::Match, rule_store::RuleStore,
+  source_code_unit::SourceCodeUnit,
 };
 
 static FEATURE_FLAG_API_GROUP: &str = "Feature-flag API cleanup";
@@ -64,7 +65,7 @@ impl Rule {
     self.query.is_none() && self.replace.is_none()
   }
 
-  // Checks if a rule is `match-only` i.e. it has a query but no replace. 
+  // Checks if a rule is `match-only` i.e. it has a query but no replace.
   pub(crate) fn is_match_only_rule(&self) -> bool {
     self.query.is_some() && self.replace.is_none()
   }
@@ -147,21 +148,21 @@ impl Rule {
   }
 
   pub(crate) fn replace_node(&self) -> String {
-    if let Some(rn) = &self.replace_node{
+    if let Some(rn) = &self.replace_node {
       return rn.to_string();
     }
     panic!("No replace_node pattern!")
   }
 
   pub(crate) fn query(&self) -> String {
-    if let Some(q) = &self.query{
+    if let Some(q) = &self.query {
       return q.to_string();
     }
     panic!("No query pattern!")
   }
 
   pub(crate) fn replace(&self) -> String {
-    if let Some(rp) = &self.replace{
+    if let Some(rp) = &self.replace {
       return rp.to_string();
     }
     panic!("No replace pattern!")
@@ -245,12 +246,16 @@ impl Rule {
   ) -> Vec<Match> {
     let mut output: Vec<Match> = vec![];
     // Get all matches for the query in the given scope `node`.
-    let replace_node_tag = if self.is_match_only_rule() || self.is_dummy_rule() { None } else {Some(self.replace_node())};
+    let replace_node_tag = if self.is_match_only_rule() || self.is_dummy_rule() {
+      None
+    } else {
+      Some(self.replace_node())
+    };
     let all_query_matches = node.get_all_matches_for_query(
       source_code_unit.code(),
       rule_store.query(&self.query()),
       recursive,
-      replace_node_tag
+      replace_node_tag,
     );
 
     // Return the first match that satisfies constraint of the rule
@@ -260,7 +265,7 @@ impl Rule {
         p_match.range().start_byte,
         p_match.range().end_byte,
       );
-      
+
       if matched_node.satisfies_constraint(
         source_code_unit.clone(),
         self,
@@ -273,7 +278,6 @@ impl Rule {
     output
   }
 
-
   /// Gets the first match for the rule in `self`
   pub(crate) fn get_edit(
     &self, source_code_unit: &SourceCodeUnit, rule_store: &mut RuleStore, node: Node,
@@ -281,14 +285,12 @@ impl Rule {
   ) -> Option<Edit> {
     // Get all matches for the query in the given scope `node`.
 
-    return self.get_matches(source_code_unit, rule_store, node, recursive)
-      .first().map(|p_match| {
+    return self
+      .get_matches(source_code_unit, rule_store, node, recursive)
+      .first()
+      .map(|p_match| {
         let replacement = substitute_tags(self.replace(), p_match.matches()).replace("\\n", "\n");
-        return Edit::new(
-          p_match.clone(),
-          replacement,
-          self.name()
-        );
+        return Edit::new(p_match.clone(), replacement, self.name());
       });
   }
 

--- a/polyglot/piranha/src/models/rule.rs
+++ b/polyglot/piranha/src/models/rule.rs
@@ -102,7 +102,9 @@ impl Rule {
       let mut updated_rule = self.clone();
       if !updated_rule.holes().is_empty() {
         updated_rule.update_query(substitutions);
-        updated_rule.update_replace(substitutions);
+        if !updated_rule.is_match_only_rule(){
+          updated_rule.update_replace(substitutions);
+        }
       }
       Ok(updated_rule)
     }

--- a/polyglot/piranha/src/models/rule_graph.rs
+++ b/polyglot/piranha/src/models/rule_graph.rs
@@ -30,11 +30,11 @@ impl RuleGraph {
         .get(val)
         .map(|v| vec![v.name()])
         .unwrap_or_else(|| {
-          if rules_by_group.contains_key(val){
+          if rules_by_group.contains_key(val) {
             return rules_by_group[val].clone();
           }
           return vec![];
-      })
+        })
     };
 
     let mut graph = HashMap::new();

--- a/polyglot/piranha/src/models/rule_store.rs
+++ b/polyglot/piranha/src/models/rule_store.rs
@@ -89,9 +89,7 @@ impl RuleStore {
   ) {
     if let Ok(mut r) = rule.try_instantiate(tag_captures) {
       if !self.global_rules.iter().any(|r| {
-        r.name().eq(&rule.name())
-          && r.replace().eq(&rule.replace())
-          && r.query().eq(&rule.query())
+        r.name().eq(&rule.name()) && r.replace().eq(&rule.replace()) && r.query().eq(&rule.query())
       }) {
         r.add_grep_heuristics_for_global_rules(tag_captures);
         #[rustfmt::skip]
@@ -123,7 +121,9 @@ impl RuleStore {
       // If the to_rule_name is a dummy rule, skip it and rather return it's next rules.
       if to_rule_name.is_dummy_rule() {
         // Call this method recursively on the dummy node
-        for (next_next_rules_scope, next_next_rules) in self.get_next(&to_rule_name.name(), tag_matches) {
+        for (next_next_rules_scope, next_next_rules) in
+          self.get_next(&to_rule_name.name(), tag_matches)
+        {
           for next_next_rule in next_next_rules {
             // Group the next rules based on the scope
             next_rules.collect(

--- a/polyglot/piranha/src/models/rule_store.rs
+++ b/polyglot/piranha/src/models/rule_store.rs
@@ -44,6 +44,8 @@ pub(crate) struct RuleStore {
   scopes: Vec<ScopeGenerator>,
   // Command line arguments passed to piranha
   piranha_args: PiranhaArguments,
+  // Command line arguments passed to piranha
+  global_tags: HashMap<String, String>,
 }
 
 impl RuleStore {
@@ -57,6 +59,7 @@ impl RuleStore {
       global_rules: vec![],
       scopes,
       piranha_args: args.clone(),
+      global_tags: HashMap::new(),
     };
 
     for (_, rule) in rule_store.rules_by_name.clone() {
@@ -79,8 +82,10 @@ impl RuleStore {
     self.piranha_args.language_name()
   }
 
-  pub(crate) fn input_substitutions(&self) -> HashMap<String, String> {
-    self.piranha_args.input_substitutions().clone()
+  pub(crate) fn default_substitutions(&self) -> HashMap<String, String> {
+    let mut default_subs = self.piranha_args.input_substitutions().clone();
+    default_subs.extend(self.global_tags().clone());
+    return default_subs;
   }
 
   /// Add a new global rule, along with grep heuristics (If it doesn't already exist)
@@ -153,6 +158,19 @@ impl RuleStore {
       .map(|scope| scope.rules())
       .unwrap_or_else(Vec::new)
   }
+
+  pub(crate) fn global_tags(&self) -> &HashMap<String, String> {
+    &self.global_tags
+  }
+
+  pub(crate) fn add_global_tags(&mut self, new_entries: &HashMap<String, String>) {
+    let global_substitutions: HashMap<String, String> = new_entries
+      .iter()
+      .filter(|e| e.0.starts_with(self.piranha_args.global_tag_prefix()))
+      .map(|(a, b)| (a.to_string(), b.to_string()))
+      .collect();
+    let _ = &self.global_tags.extend(global_substitutions.clone());
+  }
 }
 
 #[cfg(test)]
@@ -165,6 +183,7 @@ impl RuleStore {
       global_rules: vec![],
       piranha_args: PiranhaArguments::dummy(),
       scopes: vec![],
+      global_tags: HashMap::new(),
     }
   }
 
@@ -176,6 +195,7 @@ impl RuleStore {
       global_rules: vec![],
       piranha_args: PiranhaArguments::dummy(),
       scopes,
+      global_tags : HashMap::new()
     }
   }
 }

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -47,14 +47,14 @@ impl SourceCodeUnit {
     }
   }
 
-  pub fn root_node(&self) -> Node<'_> {
+  pub(crate) fn root_node(&self) -> Node<'_> {
     self.ast.root_node()
   }
 
   /// Writes the current contents of `code` to the file system.
   /// Based on the user's specifications, this function will delete a file if empty
   /// and replace three consecutive newline characters with two.
-  pub(crate) fn persist(&self, piranha_arguments: &PiranhaArguments) {
+  pub fn persist(&self, piranha_arguments: &PiranhaArguments) {
     if self.code.as_str().is_empty() {
       if piranha_arguments.delete_file_if_empty() {
         _ = fs::remove_file(&self.path).expect("Unable to Delete file");
@@ -186,7 +186,7 @@ impl SourceCodeUnit {
     }
   }
   // #[cfg(test)] // Rust analyzer FP
-  pub fn code(&self) -> String {
+  pub(crate) fn code(&self) -> String {
     String::from(&self.code)
   }
 

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -10,7 +10,9 @@ use tree_sitter_traversal::{traverse, Order};
 
 use crate::utilities::{eq_without_whitespace, tree_sitter_utilities::get_tree_sitter_edit};
 
-use super::{edit::Edit, matches::Match, piranha_arguments::PiranhaArguments};
+
+use super::{edit::Edit, piranha_arguments::PiranhaArguments, matches::Match, rule_store::RuleStore};
+
 
 // Maintains the updated source code content and AST of the file
 #[derive(Clone)]
@@ -200,8 +202,9 @@ impl SourceCodeUnit {
     &self.substitutions
   }
 
-  pub(crate) fn add_to_substitutions(&mut self, new_entries: &HashMap<String, String>) {
+  pub(crate) fn add_to_substitutions(&mut self, new_entries: &HashMap<String, String>, rule_store: &mut RuleStore) {
     let _ = &self.substitutions.extend(new_entries.clone());
+    rule_store.add_global_tags(new_entries);
   }
 
   pub(crate) fn rewrites(&self) -> &[Edit] {

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -10,7 +10,7 @@ use tree_sitter_traversal::{traverse, Order};
 
 use crate::utilities::{eq_without_whitespace, tree_sitter_utilities::get_tree_sitter_edit};
 
-use super::{edit::Edit, piranha_arguments::PiranhaArguments, matches::Match};
+use super::{edit::Edit, matches::Match, piranha_arguments::PiranhaArguments};
 
 // Maintains the updated source code content and AST of the file
 #[derive(Clone)]
@@ -27,9 +27,7 @@ pub(crate) struct SourceCodeUnit {
   // Rewrites applied to this source code unit
   rewrites: Vec<Edit>,
   // Matches for the read_only rules in this source code unit
-  matches: Vec<(String, Match)>
-
-
+  matches: Vec<(String, Match)>,
 }
 
 impl SourceCodeUnit {
@@ -43,7 +41,7 @@ impl SourceCodeUnit {
       substitutions: substitutions.clone(),
       path: path.to_path_buf(),
       rewrites: Vec::new(),
-      matches: Vec::new()
+      matches: Vec::new(),
     }
   }
 
@@ -61,7 +59,6 @@ impl SourceCodeUnit {
       }
     } else {
       let content = if piranha_arguments.delete_consecutive_new_lines() {
-
         let regex = Regex::new(r"\n(\s*\n)+(\s*\n)").unwrap();
         regex.replace_all(&self.code(), "\n${2}").to_string()
       } else {
@@ -73,7 +70,12 @@ impl SourceCodeUnit {
 
   pub(crate) fn apply_edit(&mut self, edit: &Edit, parser: &mut Parser) -> InputEdit {
     // Get the tree_sitter's input edit representation
-    self._apply_edit(edit.replacement_range(), edit.replacement_string(), parser, true)
+    self._apply_edit(
+      edit.replacement_range(),
+      edit.replacement_string(),
+      parser,
+      true,
+    )
   }
 
   /// Applies an edit to the source code unit
@@ -87,7 +89,7 @@ impl SourceCodeUnit {
   ///
   /// Note - Causes side effect. - Updates `self.ast` and `self.code`
   pub(crate) fn _apply_edit(
-    &mut self, range: Range, replacement_string: &str, parser: &mut Parser, handle_error: bool
+    &mut self, range: Range, replacement_string: &str, parser: &mut Parser, handle_error: bool,
   ) -> InputEdit {
     // Get the tree_sitter's input edit representation
     let (new_source_code, ts_edit) =
@@ -127,9 +129,9 @@ impl SourceCodeUnit {
 
   // Tries to remove the extra comma -
   // -->  Remove comma if extra
-  //    --> Check if AST has no errors, to decide if the replacement was successful. 
+  //    --> Check if AST has no errors, to decide if the replacement was successful.
   //      --->  if No: Undo the change
-  //      --->  if Yes: Return   
+  //      --->  if Yes: Return
   // Returns true if the comma was successfully removed.
   fn try_to_remove_extra_comma(&mut self, parser: &mut Parser) -> bool {
     let c_ast = self.ast.clone();
@@ -149,24 +151,28 @@ impl SourceCodeUnit {
     false
   }
 
-  // Tries to remove the extra comma - 
-  // Applies three Regex-Replacements strategies to the source file to remove the extra comma. 
-  // *  replace consecutive commas with comma 
+  // Tries to remove the extra comma -
+  // Applies three Regex-Replacements strategies to the source file to remove the extra comma.
+  // *  replace consecutive commas with comma
   // *  replace ( `(,` or `[,` ) with just `(` or `[`)
-  // Check if AST has no errors, to decide if the replacement was successful. 
+  // Check if AST has no errors, to decide if the replacement was successful.
   // Returns true if the comma was successfully removed.
-  fn try_to_fix_code_with_regex_replace(&mut self, parser: &mut Parser) -> bool{
+  fn try_to_fix_code_with_regex_replace(&mut self, parser: &mut Parser) -> bool {
     let consecutive_comma_pattern = Regex::new(r",\s*\n*,").unwrap();
     let square_bracket_comma_pattern = Regex::new(r"\[\s*\n*,").unwrap();
     let round_bracket_comma_pattern = Regex::new(r"\(\s*\n*,").unwrap();
-    let strategies = [(consecutive_comma_pattern, ","), (square_bracket_comma_pattern, "["), (round_bracket_comma_pattern, "(")];
+    let strategies = [
+      (consecutive_comma_pattern, ","),
+      (square_bracket_comma_pattern, "["),
+      (round_bracket_comma_pattern, "("),
+    ];
 
     let mut content = self.code();
-    for (regex_pattern, replacement ) in strategies{
-        if regex_pattern.is_match(&content){
-          content = regex_pattern.replace_all(&content, replacement).to_string();
-          self._replace_file_contents_and_re_parse(&content, parser, false);
-        }
+    for (regex_pattern, replacement) in strategies {
+      if regex_pattern.is_match(&content) {
+        content = regex_pattern.replace_all(&content, replacement).to_string();
+        self._replace_file_contents_and_re_parse(&content, parser, false);
+      }
     }
     return !self.ast.root_node().has_error();
   }
@@ -198,25 +204,25 @@ impl SourceCodeUnit {
     let _ = &self.substitutions.extend(new_entries.clone());
   }
 
-    pub(crate) fn rewrites(&self) -> &[Edit] {
-        self.rewrites.as_ref()
-    }
+  pub(crate) fn rewrites(&self) -> &[Edit] {
+    self.rewrites.as_ref()
+  }
 
-    pub(crate) fn path(&self) -> &PathBuf {
-      &self.path
-    }
+  pub(crate) fn path(&self) -> &PathBuf {
+    &self.path
+  }
 
-    pub(crate) fn rewrites_mut(&mut self) -> &mut Vec<Edit> {
-        &mut self.rewrites
-    }
+  pub(crate) fn rewrites_mut(&mut self) -> &mut Vec<Edit> {
+    &mut self.rewrites
+  }
 
-    pub(crate) fn matches(&self) -> &[(String, Match)] {
-        self.matches.as_ref()
-    }
+  pub(crate) fn matches(&self) -> &[(String, Match)] {
+    self.matches.as_ref()
+  }
 
-    pub(crate) fn matches_mut(&mut self) -> &mut Vec<(String, Match)> {
-        &mut self.matches
-    }
+  pub(crate) fn matches_mut(&mut self) -> &mut Vec<(String, Match)> {
+    &mut self.matches
+  }
 }
 
 #[cfg(test)]

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -14,7 +14,7 @@ use super::{edit::Edit, piranha_arguments::PiranhaArguments, matches::Match};
 
 // Maintains the updated source code content and AST of the file
 #[derive(Clone)]
-pub struct SourceCodeUnit {
+pub(crate) struct SourceCodeUnit {
   // The tree representing the file
   ast: Tree,
   // The content of a file
@@ -54,7 +54,7 @@ impl SourceCodeUnit {
   /// Writes the current contents of `code` to the file system.
   /// Based on the user's specifications, this function will delete a file if empty
   /// and replace three consecutive newline characters with two.
-  pub fn persist(&self, piranha_arguments: &PiranhaArguments) {
+  pub(crate) fn persist(&self, piranha_arguments: &PiranhaArguments) {
     if self.code.as_str().is_empty() {
       if piranha_arguments.delete_file_if_empty() {
         _ = fs::remove_file(&self.path).expect("Unable to Delete file");

--- a/polyglot/piranha/src/models/unit_tests/scopes_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/scopes_test.rs
@@ -159,11 +159,5 @@ fn test_get_scope_query_negative() {
     PathBuf::new().as_path(),
   );
 
-  let _ = ScopeGenerator::get_scope_query(
-    source_code_unit,
-    "Method",
-    133,
-    134,
-    &mut rule_store,
-  );
+  let _ = ScopeGenerator::get_scope_query(source_code_unit, "Method", 133, 134, &mut rule_store);
 }

--- a/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
@@ -19,10 +19,8 @@ use {
   tree_sitter::Range,
 };
 
-
 impl SourceCodeUnit {
-  
-  pub(crate) fn dummy_unit(content: &str, parser: &mut Parser) -> Self{
+  pub(crate) fn dummy_unit(content: &str, parser: &mut Parser) -> Self {
     SourceCodeUnit::new(
       parser,
       content.to_string(),
@@ -68,9 +66,7 @@ fn test_apply_edit_positive() {
   let mut source_code_unit = SourceCodeUnit::dummy_unit(source_code, &mut parser);
 
   let _ = source_code_unit.apply_edit(
-    &Edit::dummy_edit(
-      range(49, 78, 3, 9, 3, 38),
-      String::new()),
+    &Edit::dummy_edit(range(49, 78, 3, 9, 3, 38), String::new()),
     &mut parser,
   );
   assert!(eq_without_whitespace(
@@ -97,14 +93,13 @@ fn test_apply_edit_negative() {
   let mut source_code_unit = SourceCodeUnit::dummy_unit(source_code, &mut parser);
 
   let _ = source_code_unit.apply_edit(
-    &Edit::dummy_edit(range(1000, 2000, 0, 0, 0, 0),
-      String::new()),
+    &Edit::dummy_edit(range(1000, 2000, 0, 0, 0, 0), String::new()),
     &mut parser,
   );
 }
 
 /// Positive test of an edit being applied  given replacement range  and replacement string.
-/// This scenario checks the logic that removes the comma identified by tree-sitter. 
+/// This scenario checks the logic that removes the comma identified by tree-sitter.
 #[test]
 fn test_apply_edit_comma_handling_via_grammar() {
   let source_code = "class Test {
@@ -119,9 +114,7 @@ fn test_apply_edit_comma_handling_via_grammar() {
   let mut source_code_unit = SourceCodeUnit::dummy_unit(source_code, &mut parser);
 
   let _ = source_code_unit.apply_edit(
-    &Edit::dummy_edit(
-      range(37, 47, 2, 26, 2, 36),
-      String::new()),
+    &Edit::dummy_edit(range(37, 47, 2, 26, 2, 36), String::new()),
     &mut parser,
   );
   println!("{}", &source_code_unit.code());
@@ -131,10 +124,9 @@ fn test_apply_edit_comma_handling_via_grammar() {
   ));
 }
 
-
 /// Positive test of an edit being applied  given replacement range  and replacement string.
 /// Currently swift grammar does not always identify extra commas, we use regex replace at this point.
-/// This test scenario checks the regex replacement logic. 
+/// This test scenario checks the regex replacement logic.
 #[test]
 fn test_apply_edit_comma_handling_via_regex() {
   let source_code = "class Test {
@@ -149,9 +141,7 @@ fn test_apply_edit_comma_handling_via_regex() {
   let mut source_code_unit = SourceCodeUnit::dummy_unit(source_code, &mut parser);
 
   let _ = source_code_unit.apply_edit(
-    &Edit::dummy_edit(
-      range(59, 75, 3, 23, 3, 41),
-      String::new()),
+    &Edit::dummy_edit(range(59, 75, 3, 23, 3, 41), String::new()),
     &mut parser,
   );
   println!("{}", &source_code_unit.code());

--- a/polyglot/piranha/src/tests/mod.rs
+++ b/polyglot/piranha/src/tests/mod.rs
@@ -24,6 +24,8 @@ mod test_piranha_kt;
 
 mod test_piranha_strings;
 
+mod test_piranha_swift;
+
 use std::sync::Once;
 
 static INIT: Once = Once::new();

--- a/polyglot/piranha/src/tests/mod.rs
+++ b/polyglot/piranha/src/tests/mod.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 
 use crate::config::CommandLineArguments;
 use crate::models::piranha_arguments::PiranhaArguments;
-use crate::models::source_code_unit::SourceCodeUnit;
+use crate::models::piranha_output::PiranhaOutputSummary;
 use crate::execute_piranha;
 use crate::utilities::{eq_without_whitespace, find_file, initialize_logger, read_file};
 
@@ -44,7 +44,7 @@ fn run_match_test(relative_path_to_tests: &str, number_of_matches: usize) {
     path_to_configurations: format!("{path_to_test_ff}/configurations/"),
     path_to_output_summary: None
   });
-  let (_updated_files, output_summaries) = execute_piranha(&args);
+  let output_summaries = execute_piranha(&args, false);
   
   assert_eq!(output_summaries.iter().flat_map(|os|os.matches().iter()).count(), number_of_matches);
 }
@@ -60,18 +60,18 @@ fn run_rewrite_test(relative_path_to_tests: &str, n_files_changed: usize) {
     path_to_configurations: format!("{path_to_test_ff}/configurations/"),
     path_to_output_summary: None
   });
-  let (updated_files, output_summaries) = execute_piranha(&args);
+  let output_summaries = execute_piranha(&args, false);
   // Checks if there are any rewrites performed for the file
   assert!(output_summaries.iter().flat_map(|os|os.rewrites().iter()).count() > 0);
 
-  assert_eq!(updated_files.len(), n_files_changed);
+  assert_eq!(output_summaries.len(), n_files_changed);
   let path_to_expected =
     Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("{path_to_test_ff}/expected"));
-  check_result(updated_files, path_to_expected);
+  check_result(output_summaries, path_to_expected);
 }
 
 /// Checks if the file updates returned by piranha are as expected.
-fn check_result(updated_files: Vec<SourceCodeUnit>, path_to_expected: PathBuf) {
+fn check_result(updated_files: Vec<PiranhaOutputSummary>, path_to_expected: PathBuf) {
   let mut all_files_match = true;
 
   for source_code_unit in &updated_files {
@@ -83,9 +83,9 @@ fn check_result(updated_files: Vec<SourceCodeUnit>, path_to_expected: PathBuf) {
     let expected_file_path = find_file(&path_to_expected, updated_file_name);
     let expected_content = read_file(&expected_file_path).unwrap();
 
-    if !eq_without_whitespace(&source_code_unit.code(), &expected_content) {
+    if !eq_without_whitespace(&source_code_unit.content(), &expected_content) {
       all_files_match = false;
-      println!("{}", &source_code_unit.code());
+      println!("{}", &source_code_unit.content());
     }
   }
   assert!(all_files_match);

--- a/polyglot/piranha/src/tests/mod.rs
+++ b/polyglot/piranha/src/tests/mod.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use crate::config::CommandLineArguments;
 use crate::models::piranha_arguments::PiranhaArguments;
 use crate::models::source_code_unit::SourceCodeUnit;
-use crate::piranha::execute_piranha;
+use crate::execute_piranha;
 use crate::utilities::{eq_without_whitespace, find_file, initialize_logger, read_file};
 
 mod test_piranha_java;

--- a/polyglot/piranha/src/tests/mod.rs
+++ b/polyglot/piranha/src/tests/mod.rs
@@ -14,9 +14,9 @@ Copyright (c) 2022 Uber Technologies, Inc.
 use std::path::{Path, PathBuf};
 
 use crate::config::CommandLineArguments;
+use crate::execute_piranha;
 use crate::models::piranha_arguments::PiranhaArguments;
 use crate::models::piranha_output::PiranhaOutputSummary;
-use crate::execute_piranha;
 use crate::utilities::{eq_without_whitespace, find_file, initialize_logger, read_file};
 
 mod test_piranha_java;
@@ -34,23 +34,29 @@ fn initialize() {
   });
 }
 
-// Runs a piranha over the target `<relative_path_to_tests>/input` (using configurations `<relative_path_to_tests>/configuration`) 
-// and checks if the number of matches == `number_of_matches`. 
+// Runs a piranha over the target `<relative_path_to_tests>/input` (using configurations `<relative_path_to_tests>/configuration`)
+// and checks if the number of matches == `number_of_matches`.
 fn run_match_test(relative_path_to_tests: &str, number_of_matches: usize) {
   let path_to_test_ff = format!("test-resources/{relative_path_to_tests}");
 
   let args = PiranhaArguments::new(CommandLineArguments {
     path_to_codebase: format!("{path_to_test_ff}/input/"),
     path_to_configurations: format!("{path_to_test_ff}/configurations/"),
-    path_to_output_summary: None
+    path_to_output_summary: None,
   });
   let output_summaries = execute_piranha(&args, false);
-  
-  assert_eq!(output_summaries.iter().flat_map(|os|os.matches().iter()).count(), number_of_matches);
+
+  assert_eq!(
+    output_summaries
+      .iter()
+      .flat_map(|os| os.matches().iter())
+      .count(),
+    number_of_matches
+  );
 }
 
-// Runs a piranha over the target `<relative_path_to_tests>/input` (using configurations `<relative_path_to_tests>/configuration`) 
-// and checks if the output of piranha is same as `<relative_path_to_tests>/expected`. 
+// Runs a piranha over the target `<relative_path_to_tests>/input` (using configurations `<relative_path_to_tests>/configuration`)
+// and checks if the output of piranha is same as `<relative_path_to_tests>/expected`.
 // It also asserts the number of changed files in the expected output.
 fn run_rewrite_test(relative_path_to_tests: &str, n_files_changed: usize) {
   let path_to_test_ff = format!("test-resources/{relative_path_to_tests}");
@@ -58,11 +64,17 @@ fn run_rewrite_test(relative_path_to_tests: &str, n_files_changed: usize) {
   let args = PiranhaArguments::new(CommandLineArguments {
     path_to_codebase: format!("{path_to_test_ff}/input/"),
     path_to_configurations: format!("{path_to_test_ff}/configurations/"),
-    path_to_output_summary: None
+    path_to_output_summary: None,
   });
   let output_summaries = execute_piranha(&args, false);
   // Checks if there are any rewrites performed for the file
-  assert!(output_summaries.iter().flat_map(|os|os.rewrites().iter()).count() > 0);
+  assert!(
+    output_summaries
+      .iter()
+      .flat_map(|os| os.rewrites().iter())
+      .count()
+      > 0
+  );
 
   assert_eq!(output_summaries.len(), n_files_changed);
   let path_to_expected =

--- a/polyglot/piranha/src/tests/test_piranha_java.rs
+++ b/polyglot/piranha/src/tests/test_piranha_java.rs
@@ -11,44 +11,55 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use super::{initialize, run_rewrite_test, run_match_test};
+use super::{initialize, run_match_test, run_rewrite_test};
 
 static LANGUAGE: &str = "java";
 
 #[test]
 fn test_java_scenarios_treated_ff1() {
   initialize();
-  run_rewrite_test(&format!("{}/{}/{}",LANGUAGE, "feature_flag_system_1", "treated"), 2);
+  run_rewrite_test(
+    &format!("{}/{}/{}", LANGUAGE, "feature_flag_system_1", "treated"),
+    2,
+  );
 }
 
 #[test]
 fn test_java_scenarios_treated_ff2() {
   initialize();
-  run_rewrite_test(&format!("{}/{}/{}",LANGUAGE, "feature_flag_system_2", "treated"), 4);
+  run_rewrite_test(
+    &format!("{}/{}/{}", LANGUAGE, "feature_flag_system_2", "treated"),
+    4,
+  );
 }
 
 #[test]
 fn test_java_scenarios_control_ff1() {
   initialize();
-  run_rewrite_test(&format!("{}/{}/{}",LANGUAGE, "feature_flag_system_1", "control"), 2);
+  run_rewrite_test(
+    &format!("{}/{}/{}", LANGUAGE, "feature_flag_system_1", "control"),
+    2,
+  );
 }
 
 #[test]
 fn test_java_scenarios_control_ff2() {
   initialize();
-  run_rewrite_test(&format!("{}/{}/{}",LANGUAGE, "feature_flag_system_2", "control"), 4);
+  run_rewrite_test(
+    &format!("{}/{}/{}", LANGUAGE, "feature_flag_system_2", "control"),
+    4,
+  );
 }
 
 #[test]
 fn test_java_scenarios_find_and_propagate() {
   initialize();
-  run_rewrite_test(&format!("{}/{}",LANGUAGE, "find_and_propagate"), 2);
+  run_rewrite_test(&format!("{}/{}", LANGUAGE, "find_and_propagate"), 2);
 }
-
 
 // run_match_test
 #[test]
 fn test_java_match_only() {
   initialize();
-  run_match_test(&format!("{}/{}",LANGUAGE, "structural_find"), 20);
+  run_match_test(&format!("{}/{}", LANGUAGE, "structural_find"), 20);
 }

--- a/polyglot/piranha/src/tests/test_piranha_kt.rs
+++ b/polyglot/piranha/src/tests/test_piranha_kt.rs
@@ -18,24 +18,35 @@ static LANGUAGE: &str = "kt";
 #[test]
 fn test_kotlin_scenarios_treated_ff1() {
   initialize();
-  run_rewrite_test(&format!("{}/{}/{}",LANGUAGE, "feature_flag_system_1", "treated"), 2);
-  
+  run_rewrite_test(
+    &format!("{}/{}/{}", LANGUAGE, "feature_flag_system_1", "treated"),
+    2,
+  );
 }
 
 #[test]
 fn test_kotlin_scenarios_treated_ff2() {
   initialize();
-  run_rewrite_test(&format!("{}/{}/{}",LANGUAGE, "feature_flag_system_2", "treated"), 4);
+  run_rewrite_test(
+    &format!("{}/{}/{}", LANGUAGE, "feature_flag_system_2", "treated"),
+    4,
+  );
 }
 
 #[test]
 fn test_kotlin_scenarios_control_ff1() {
   initialize();
-  run_rewrite_test(&format!("{}/{}/{}",LANGUAGE, "feature_flag_system_1", "control"), 2);
+  run_rewrite_test(
+    &format!("{}/{}/{}", LANGUAGE, "feature_flag_system_1", "control"),
+    2,
+  );
 }
 
 #[test]
 fn test_kotlin_scenarios_control_ff2() {
   initialize();
-  run_rewrite_test(&format!("{}/{}/{}",LANGUAGE, "feature_flag_system_2", "control"), 4);
+  run_rewrite_test(
+    &format!("{}/{}/{}", LANGUAGE, "feature_flag_system_2", "control"),
+    4,
+  );
 }

--- a/polyglot/piranha/src/tests/test_piranha_strings.rs
+++ b/polyglot/piranha/src/tests/test_piranha_strings.rs
@@ -18,12 +18,11 @@ static LANGUAGE: &str = "strings";
 #[test]
 fn test_strings_scenario_rules_with_holes() {
   initialize();
-  run_rewrite_test(&format!("{}/{}",LANGUAGE, "rules_with_holes"), 2);
+  run_rewrite_test(&format!("{}/{}", LANGUAGE, "rules_with_holes"), 2);
 }
-
 
 #[test]
 fn test_strings_scenario_rules_with_no_holes() {
   initialize();
-  run_rewrite_test(&format!("{}/{}",LANGUAGE, "rules_with_no_holes"), 2);
+  run_rewrite_test(&format!("{}/{}", LANGUAGE, "rules_with_no_holes"), 2);
 }

--- a/polyglot/piranha/src/tests/test_piranha_swift.rs
+++ b/polyglot/piranha/src/tests/test_piranha_swift.rs
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2022 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+use super::{initialize, run_rewrite_test};
+
+static LANGUAGE: &str = "swift";
+
+// Tests cascading file delete based on enum and type alias. 
+// This scenario is "derived" from plugin cleanup.
+// This cleanup requires the concept of global tags
+#[test]
+fn test_cascading_delete_file() {
+  initialize();
+  run_rewrite_test(&format!("{}/{}",LANGUAGE, "cascade_file_delete"), 3);
+}
+
+
+// Tests cascading file delete based on enum and type alias. 
+// This scenario is "derived" from plugin cleanup.
+// Checks custom global_tags
+#[test]
+fn test_cascading_delete_file_custom_global_tag() {
+  initialize();
+  run_rewrite_test(&format!("{}/{}",LANGUAGE, "cascade_file_delete_custom_global_tag"), 3);
+}

--- a/polyglot/piranha/src/utilities/mod.rs
+++ b/polyglot/piranha/src/utilities/mod.rs
@@ -66,7 +66,7 @@ impl<T: Hash + Eq, U> MapOfVec<T, U> for HashMap<T, Vec<U>> {
 }
 
 /// Initialize logger.
-pub(crate) fn initialize_logger(is_test: bool) {
+pub fn initialize_logger(is_test: bool) {
   let log_file = OpenOptions::new()
     .write(true)
     .create(true) // Create a log file if it doesn't exists

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -115,8 +115,11 @@ impl PiranhaHelpers for Node<'_> {
   fn get_match_for_query(
     &self, source_code: &str, query: &Query, recursive: bool,
   ) -> Option<Match> {
-    if let Some(m) = self.get_all_matches_for_query(source_code.to_string(), query, recursive, None).first(){
-        return Some(m.clone());
+    if let Some(m) = self
+      .get_all_matches_for_query(source_code.to_string(), query, recursive, None)
+      .first()
+    {
+      return Some(m.clone());
     }
     None
   }
@@ -131,7 +134,6 @@ impl PiranhaHelpers for Node<'_> {
     // corresponding to the same tag.
     let mut output = vec![];
     for (captured_node_range, query_matches) in query_capture_groups {
-       
       // This ensures that each query pattern in rule.query matches the same node.
       if query_matches.len() != query.pattern_count() {
         continue;

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -100,7 +100,7 @@ impl PiranhaHelpers for Node<'_> {
     let updated_substitutions = &substitutions
       .clone()
       .into_iter()
-      .chain(rule_store.input_substitutions())
+      .chain(rule_store.default_substitutions())
       .collect();
     rule.constraints().iter().all(|constraint| {
       constraint.is_satisfied(

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete/configurations/edges.toml
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete/configurations/edges.toml
@@ -1,0 +1,26 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+from = "delete_switch_entry"
+scope = "Class"
+to = ["delete_enum_entry"]
+
+[[edges]]
+from = "delete_enum_entry"
+scope = "Global"
+to = ["read_only_detect_type_alias"]
+
+
+[[edges]]
+from = "read_only_detect_type_alias"
+scope = "Global"
+to = ["delete_factory_class_inherits_relevant_type_alias"]

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete/configurations/piranha_arguments.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["swift"]
+substitutions = [
+    ["stale_flag_name", "Premium-Icon"],
+]

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete/configurations/rules.toml
@@ -1,0 +1,71 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Matchs an enum entry named `GLOBAL_TAG.enum_entry_name`
+[[rules]]
+name = "delete_enum_entry"
+query = """
+(
+class_declaration name: (type_identifier) @enum_declaration_name
+	(enum_class_body (enum_entry name: (simple_identifier) @name)  @ee)
+(#eq? @name "@GLOBAL_TAG.enum_entry_name")
+)"""
+replace_node = "ee"
+replace = ""
+holes = ["GLOBAL_TAG.enum_entry_name"]
+
+# Matches a switch case that returns the "stale_flag_name" string literal.
+[[rules]]
+name = "delete_switch_entry"
+query = """
+(
+(switch_entry (switch_pattern (pattern (simple_identifier)@GLOBAL_TAG.enum_entry_name) @pattern)
+(statements (control_transfer_statement (line_string_literal (line_str_text) @flag_name)))
+) @entry
+
+(#eq? @flag_name "@stale_flag_name")
+)
+"""
+replace_node = "entry"
+replace = ""
+holes = ["stale_flag_name"]
+
+
+# Looks for type aliases using `enum_declaration_name`
+[[rules]] 
+name = "read_only_detect_type_alias"
+query = """
+((typealias_declaration name: (type_identifier)@inherits_plugin_switch 
+	(user_type (type_arguments name : (user_type (type_identifier)@type_arg))))@tdn
+(#eq? @type_arg "@enum_declaration_name")
+)
+"""
+holes = [ "enum_declaration_name"]
+
+# Deletes factory calss that uses the GLOBAL_TAG.enum_entry_name and inherits the relevant type alias.
+[[rules]]
+name = "delete_factory_class_inherits_relevant_type_alias"
+query = """
+(
+(source_file
+((class_declaration name: (type_identifier)
+    (inheritance_specifier inherits_from: (user_type (type_identifier)@container ))
+        body: (class_body (function_declaration 
+            body: (function_body (statements (call_expression (call_expression
+                (call_suffix (value_arguments (value_argument 
+                    value: (prefix_expression target: (simple_identifier) @name))))))))))))) @source_file
+(#eq? @name "@GLOBAL_TAG.enum_entry_name")
+(#eq? @container "@inherits_plugin_switch")
+)
+"""
+replace_node = "source_file"
+replace = ""
+holes = ["GLOBAL_TAG.enum_entry_name", "inherits_plugin_switch"]

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete/expected/Experiment.swift
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete/expected/Experiment.swift
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Experiment
+
+public enum SomePluginSwitch: PluginSwitch {
+    case defaultIcon
+
+    case defaultTitle
+    case premiumTitle
+
+
+
+    public var generatedExperimentKey: String {
+        switch self {
+        case .defaultIcon: return "Default-Icon"
+
+        case .defaultTitle: return "Default-Title"
+        case .premiumTitle: return "Premium-Title"
+        }
+    }
+}

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete/expected/SomeProtocols.swift
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete/expected/SomeProtocols.swift
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public typealias SomePluginFactory = PluginFactory<SomePluginSwitch>

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete/input/Experiment.swift
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete/input/Experiment.swift
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Experiment
+
+public enum SomePluginSwitch: PluginSwitch {
+    case defaultIcon
+    case premiumIcon
+    case defaultTitle
+    case premiumTitle
+
+
+
+    public var generatedExperimentKey: String {
+        switch self {
+        case .defaultIcon: return "Default-Icon"
+        case .premiumIcon: return "Premium-Icon"
+        case .defaultTitle: return "Default-Title"
+        case .premiumTitle: return "Premium-Title"
+        }
+    }
+}

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete/input/Factory.swift
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete/input/Factory.swift
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public final class SomeFactory: SomePluginFactory {
+    // MARK: - Initializer
+    public init(cachedExperiments: CachedExperimenting) {
+        super.init(pluginSwitch: .premiumIcon) { context in
+            handler(cachedExperiments: cachedExperiments, context: context)
+        }
+    }
+}

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete/input/SomeProtocols.swift
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete/input/SomeProtocols.swift
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public typealias SomePluginFactory = PluginFactory<SomePluginSwitch>

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/configurations/edges.toml
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/configurations/edges.toml
@@ -1,0 +1,26 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+from = "delete_switch_entry"
+scope = "Class"
+to = ["delete_enum_entry"]
+
+[[edges]]
+from = "delete_enum_entry"
+scope = "Global"
+to = ["read_only_detect_type_alias"]
+
+
+[[edges]]
+from = "read_only_detect_type_alias"
+scope = "Global"
+to = ["delete_factory_class_inherits_relevant_type_alias"]

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/configurations/piranha_arguments.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["swift"]
+substitutions = [
+    ["stale_flag_name", "Premium-Icon"],
+]
+global_tag_prefix = "universal_tag."

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/configurations/rules.toml
@@ -1,0 +1,71 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Matchs an enum entry named `universal_tag.enum_entry_name`
+[[rules]]
+name = "delete_enum_entry"
+query = """
+(
+class_declaration name: (type_identifier) @enum_declaration_name
+	(enum_class_body (enum_entry name: (simple_identifier) @name)  @ee)
+(#eq? @name "@universal_tag.enum_entry_name")
+)"""
+replace_node = "ee"
+replace = ""
+holes = ["universal_tag.enum_entry_name"]
+
+# Matches a switch case that returns the "stale_flag_name" string literal.
+[[rules]]
+name = "delete_switch_entry"
+query = """
+(
+(switch_entry (switch_pattern (pattern (simple_identifier)@universal_tag.enum_entry_name) @pattern)
+(statements (control_transfer_statement (line_string_literal (line_str_text) @flag_name)))
+) @entry
+
+(#eq? @flag_name "@stale_flag_name")
+)
+"""
+replace_node = "entry"
+replace = ""
+holes = ["stale_flag_name"]
+
+
+# Looks for type aliases using `enum_declaration_name`
+[[rules]] 
+name = "read_only_detect_type_alias"
+query = """
+((typealias_declaration name: (type_identifier)@inherits_plugin_switch 
+	(user_type (type_arguments name : (user_type (type_identifier)@type_arg))))@tdn
+(#eq? @type_arg "@enum_declaration_name")
+)
+"""
+holes = [ "enum_declaration_name"]
+
+# Deletes factory calss that uses the universal_tag.enum_entry_name and inherits the relevant type alias.
+[[rules]]
+name = "delete_factory_class_inherits_relevant_type_alias"
+query = """
+(
+(source_file
+((class_declaration name: (type_identifier)
+    (inheritance_specifier inherits_from: (user_type (type_identifier)@container ))
+        body: (class_body (function_declaration 
+            body: (function_body (statements (call_expression (call_expression
+                (call_suffix (value_arguments (value_argument 
+                    value: (prefix_expression target: (simple_identifier) @name))))))))))))) @source_file
+(#eq? @name "@universal_tag.enum_entry_name")
+(#eq? @container "@inherits_plugin_switch")
+)
+"""
+replace_node = "source_file"
+replace = ""
+holes = ["universal_tag.enum_entry_name", "inherits_plugin_switch"]

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/expected/Experiment.swift
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/expected/Experiment.swift
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Experiment
+
+public enum SomePluginSwitch: PluginSwitch {
+    case defaultIcon
+
+    case defaultTitle
+    case premiumTitle
+
+
+
+    public var generatedExperimentKey: String {
+        switch self {
+        case .defaultIcon: return "Default-Icon"
+
+        case .defaultTitle: return "Default-Title"
+        case .premiumTitle: return "Premium-Title"
+        }
+    }
+}

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/expected/SomeProtocols.swift
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/expected/SomeProtocols.swift
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public typealias SomePluginFactory = PluginFactory<SomePluginSwitch>

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/input/Experiment.swift
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/input/Experiment.swift
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Experiment
+
+public enum SomePluginSwitch: PluginSwitch {
+    case defaultIcon
+    case premiumIcon
+    case defaultTitle
+    case premiumTitle
+
+
+
+    public var generatedExperimentKey: String {
+        switch self {
+        case .defaultIcon: return "Default-Icon"
+        case .premiumIcon: return "Premium-Icon"
+        case .defaultTitle: return "Default-Title"
+        case .premiumTitle: return "Premium-Title"
+        }
+    }
+}

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/input/Factory.swift
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/input/Factory.swift
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public final class SomeFactory: SomePluginFactory {
+    // MARK: - Initializer
+    public init(cachedExperiments: CachedExperimenting) {
+        super.init(pluginSwitch: .premiumIcon) { context in
+            handler(cachedExperiments: cachedExperiments, context: context)
+        }
+    }
+}

--- a/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/input/SomeProtocols.swift
+++ b/polyglot/piranha/test-resources/swift/cascade_file_delete_custom_global_tag/input/SomeProtocols.swift
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public typealias SomePluginFactory = PluginFactory<SomePluginSwitch>


### PR DESCRIPTION
This is a refactoring.  
Trying to make the code structure conform the recommended guideline - https://doc.rust-lang.org/cargo/guide/project-layout.html 
Our `piranha.rs` was actually `lib.rs` we just were not exposing it as a library. This PR does this refactoring (and manages all the access modifiers appropriately).

 While doing this, I also realized that I was unnecessarily exposing `SourceCodeUnit`, while all I needed was its content (Which is part of `PiranhaOutputSummary`). So I made that `pub(crate)` and updated the tests to use `PiranhaOutputSummary`. 


------------
ran `cargo fmt` 