### PR TITLE
refactoring/ Cargo clippy and some cleanup 

### DIFF
--- a/polyglot/piranha/src/lib.rs
+++ b/polyglot/piranha/src/lib.rs
@@ -61,7 +61,7 @@ pub fn execute_piranha(
 
   if should_rewrite_files {
     for scu in source_code_units {
-      scu.persist(&configuration);
+      scu.persist(configuration);
     }
   }
 
@@ -69,7 +69,7 @@ pub fn execute_piranha(
   flag_cleaner
     .get_updated_files()
     .iter()
-    .map(|f| PiranhaOutputSummary::new(f))
+    .map(PiranhaOutputSummary::new)
     .collect_vec()
 }
 

--- a/polyglot/piranha/src/main.rs
+++ b/polyglot/piranha/src/main.rs
@@ -43,7 +43,7 @@ fn write_output_summary(
   piranha_output_summaries: Vec<PiranhaOutputSummary>, path_to_json: &String,
 ) {
   if let Ok(contents) = serde_json::to_string_pretty(&piranha_output_summaries) {
-    if let Ok(_) = fs::write(path_to_json, contents) {
+    if fs::write(path_to_json, contents).is_ok() {
       return;
     }
   }

--- a/polyglot/piranha/src/models/piranha_arguments.rs
+++ b/polyglot/piranha/src/models/piranha_arguments.rs
@@ -125,7 +125,7 @@ impl PiranhaArguments {
     if let Some(t) = &self.global_tag_prefix{
       return t.as_str();
     }
-    return "GLOBAL_TAG."
+    "GLOBAL_TAG."
   }
 }
 

--- a/polyglot/piranha/src/models/rule.rs
+++ b/polyglot/piranha/src/models/rule.rs
@@ -292,7 +292,7 @@ impl Rule {
       .first()
       .map(|p_match| {
         let replacement = substitute_tags(self.replace(), p_match.matches()).replace("\\n", "\n");
-        return Edit::new(p_match.clone(), replacement, self.name());
+        Edit::new(p_match.clone(), replacement, self.name())
       });
   }
 

--- a/polyglot/piranha/src/models/rule_store.rs
+++ b/polyglot/piranha/src/models/rule_store.rs
@@ -85,7 +85,7 @@ impl RuleStore {
   pub(crate) fn default_substitutions(&self) -> HashMap<String, String> {
     let mut default_subs = self.piranha_args.input_substitutions().clone();
     default_subs.extend(self.global_tags().clone());
-    return default_subs;
+    default_subs
   }
 
   /// Add a new global rule, along with grep heuristics (If it doesn't already exist)
@@ -121,7 +121,7 @@ impl RuleStore {
     // let rule_name = rule.name();
     let mut next_rules: HashMap<String, Vec<Rule>> = HashMap::new();
     // Iterate over each entry (Edge) in the adjacency list corresponding to `rule_name`
-    for (scope, to_rule) in self.rule_graph.get_neighbors(&rule_name) {
+    for (scope, to_rule) in self.rule_graph.get_neighbors(rule_name) {
       let to_rule_name = &self.rules_by_name[&to_rule];
       // If the to_rule_name is a dummy rule, skip it and rather return it's next rules.
       if to_rule_name.is_dummy_rule() {
@@ -169,7 +169,7 @@ impl RuleStore {
       .filter(|e| e.0.starts_with(self.piranha_args.global_tag_prefix()))
       .map(|(a, b)| (a.to_string(), b.to_string()))
       .collect();
-    let _ = &self.global_tags.extend(global_substitutions.clone());
+    let _ = &self.global_tags.extend(global_substitutions);
   }
 }
 

--- a/polyglot/piranha/src/tests/mod.rs
+++ b/polyglot/piranha/src/tests/mod.rs
@@ -97,7 +97,7 @@ fn check_result(updated_files: Vec<PiranhaOutputSummary>, path_to_expected: Path
     let expected_file_path = find_file(&path_to_expected, updated_file_name);
     let expected_content = read_file(&expected_file_path).unwrap();
 
-    if !eq_without_whitespace(&source_code_unit.content(), &expected_content) {
+    if !eq_without_whitespace(source_code_unit.content(), &expected_content) {
       all_files_match = false;
       println!("{}", &source_code_unit.content());
     }

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -64,7 +64,7 @@ pub(crate) trait PiranhaHelpers {
     ///
     /// # Returns
     /// List of matches (list of captures), grouped by the outermost tag of the query
-    fn get_query_capture_groups(&self, source_code: &String, query: &Query) -> HashMap<Range, Vec<Vec<QueryCapture>>> ;
+    fn get_query_capture_groups(&self, source_code: &str, query: &Query) -> HashMap<Range, Vec<Vec<QueryCapture>>> ;
 
     /// Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
     fn satisfies_constraint(&self, source_code_unit: SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,rule_store: &mut RuleStore,) -> bool ;
@@ -164,7 +164,7 @@ impl PiranhaHelpers for Node<'_> {
   }
 
   fn get_query_capture_groups(
-    &self, source_code: &String, query: &Query,
+    &self, source_code: &str, query: &Query,
   ) -> HashMap<Range, Vec<Vec<QueryCapture>>> {
     let mut cursor = QueryCursor::new();
 
@@ -195,7 +195,7 @@ impl PiranhaHelpers for Node<'_> {
 // If tag name did not match a code snippet, add an empty string.
 // Returns the mapping between the tag and source code snippet (accumulated).
 fn accumulate_repeated_tags(
-  query: &Query, query_matches: Vec<Vec<tree_sitter::QueryCapture>>, source_code: &String,
+  query: &Query, query_matches: Vec<Vec<tree_sitter::QueryCapture>>, source_code: &str,
 ) -> HashMap<String, String> {
   let mut code_snippet_by_tag: HashMap<String, String> = HashMap::new();
   let tag_names_by_index: HashMap<usize, &String> =
@@ -359,7 +359,7 @@ pub(crate) fn get_context<'a>(
 }
 
 pub(crate) fn get_match_and_replace_range(input_edit: InputEdit) -> (Range, Range) {
-  return (
+  (
     Range {
       start_byte: input_edit.start_byte,
       end_byte: input_edit.old_end_byte,
@@ -372,7 +372,7 @@ pub(crate) fn get_match_and_replace_range(input_edit: InputEdit) -> (Range, Rang
       start_point: input_edit.start_position,
       end_point: input_edit.new_end_position,
     },
-  );
+  )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Some auto-refactoring done by `clippy`. 
Followed by a small cleanup that removes the annotation hack I was using for serializing the type `tree_sitter::Range`. 
Now I simply, convert `tree_sitter::Range` to `Matches::Range` internally.  I do this so that I can "derive" whatever I Want using `Matches::Range`

No new test required. 