### PR TITLE
Bugfix/Cleanup: Piranha was escaping and unescaping new line characters when not required 

### DIFF
--- a/polyglot/piranha/src/models/constraint.rs
+++ b/polyglot/piranha/src/models/constraint.rs
@@ -23,7 +23,7 @@ impl Constraint {
   }
 
   pub(crate) fn matcher(&self, substitutions: &HashMap<String, String>) -> String {
-    substitute_tags(String::from(&self.matcher), substitutions)
+    substitute_tags(String::from(&self.matcher), substitutions, true)
   }
 
   /// Checks if the node satisfies the constraints.
@@ -55,7 +55,7 @@ impl Constraint {
           p_match.range().end_byte,
         );
         for query_with_holes in self.queries() {
-          let query_str = substitute_tags(query_with_holes.to_string(), substitutions);
+          let query_str = substitute_tags(query_with_holes.to_string(), substitutions, true);
           let query = &rule_store.query(&query_str);
           // If this query matches anywhere within the scope, return false.
           if scope_node

--- a/polyglot/piranha/src/models/rule.rs
+++ b/polyglot/piranha/src/models/rule.rs
@@ -204,11 +204,11 @@ impl Rule {
   }
 
   pub(crate) fn update_replace(&mut self, substitutions: &HashMap<String, String>) {
-    self.set_replace(substitute_tags(self.replace(), substitutions));
+    self.set_replace(substitute_tags(self.replace(), substitutions, false));
   }
 
   pub(crate) fn update_query(&mut self, substitutions: &HashMap<String, String>) {
-    self.set_query(substitute_tags(self.query(), substitutions));
+    self.set_query(substitute_tags(self.query(), substitutions, false));
   }
 
   pub(crate) fn name(&self) -> String {
@@ -297,7 +297,7 @@ impl Rule {
       .get_matches(source_code_unit, rule_store, node, recursive)
       .first()
       .map(|p_match| {
-        let replacement = substitute_tags(self.replace(), p_match.matches()).replace("\\n", "\n");
+        let replacement = substitute_tags(self.replace(), p_match.matches(), false);
         Edit::new(p_match.clone(), replacement, self.name())
       });
   }

--- a/polyglot/piranha/src/models/scopes.rs
+++ b/polyglot/piranha/src/models/scopes.rs
@@ -72,7 +72,7 @@ impl ScopeGenerator {
         ) {
           // Generate the scope query for the specific context by substituting the
           // the tags with code snippets appropriately in the `generator` query.
-          return substitute_tags(m.generator(), p_match.matches());
+          return substitute_tags(m.generator(), p_match.matches(), true);
         } else {
           changed_node = parent;
         }

--- a/polyglot/piranha/src/models/scopes.rs
+++ b/polyglot/piranha/src/models/scopes.rs
@@ -63,9 +63,9 @@ impl ScopeGenerator {
     let scope_matchers = rules_store.get_scope_query_generators(scope_level);
 
     // Match the `scope_matcher.matcher` to the parent
-    while let Some(parent) = changed_node.parent() {
+    loop {
       for m in &scope_matchers {
-        if let Some(p_match) = parent.get_match_for_query(
+        if let Some(p_match) = changed_node.get_match_for_query(
           &source_code_unit.code(),
           rules_store.query(&m.matcher()),
           false,
@@ -73,9 +73,12 @@ impl ScopeGenerator {
           // Generate the scope query for the specific context by substituting the
           // the tags with code snippets appropriately in the `generator` query.
           return substitute_tags(m.generator(), p_match.matches(), true);
-        } else {
-          changed_node = parent;
         }
+      }
+      if let Some(parent) = changed_node.parent() {
+        changed_node = parent;
+      } else {
+        break;
       }
     }
     panic!("Could not create scope query for {:?}", scope_level);

--- a/polyglot/piranha/src/tests/test_piranha_java.rs
+++ b/polyglot/piranha/src/tests/test_piranha_java.rs
@@ -76,6 +76,12 @@ fn test_java_scenarios_new_line_character_used_in_string_literal() {
   run_rewrite_test(&format!("{}/{}", LANGUAGE, "new_line_character_used_in_string_literal"), 1);
 }
 
+#[test]
+fn test_java_scenarios_consecutive_scope_level_rules() {
+  initialize();
+  run_rewrite_test(&format!("{}/{}", LANGUAGE, "consecutive_scope_level_rules"), 1);
+}
+
 // run_match_test
 #[test]
 fn test_java_match_only() {

--- a/polyglot/piranha/src/tests/test_piranha_java.rs
+++ b/polyglot/piranha/src/tests/test_piranha_java.rs
@@ -64,13 +64,17 @@ fn test_java_scenarios_user_defined_non_seed_rules() {
   run_rewrite_test(&format!("{}/{}", LANGUAGE, "non_seed_user_rule"), 1);
 }
 
-
 #[test]
 fn test_java_scenarios_insert_field_and_initializer() {
   initialize();
   run_rewrite_test(&format!("{}/{}", LANGUAGE, "insert_field_and_initializer"), 1);
 }
 
+#[test]
+fn test_java_scenarios_new_line_character_used_in_string_literal() {
+  initialize();
+  run_rewrite_test(&format!("{}/{}", LANGUAGE, "new_line_character_used_in_string_literal"), 1);
+}
 
 // run_match_test
 #[test]

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -314,12 +314,19 @@ fn _get_tree_sitter_edit(
   }
 }
 
-pub(crate) fn substitute_tags(s: String, substitutions: &HashMap<String, String>) -> String {
-  let mut output = s;
+pub(crate) fn substitute_tags(
+  input_string: String, substitutions: &HashMap<String, String>, is_tree_sitter_query: bool,
+) -> String {
+  let mut output = input_string;
   for (tag, substitute) in substitutions {
     // Before replacing the key, it is transformed to a tree-sitter tag by adding `@` as prefix
     let key = format!("@{}", tag);
-    output = output.replace(&key, &substitute.replace('\n', "\\n"))
+    let substitution_value = if is_tree_sitter_query {
+      substitute.replace('\n', "\\n").to_string()
+    } else {
+      substitute.to_string()
+    };
+    output = output.replace(&key, &substitution_value);
   }
   output
 }
@@ -360,12 +367,12 @@ pub(crate) fn get_context<'a>(
 }
 
 pub(crate) fn get_replace_range(input_edit: InputEdit) -> Range {
-    Range {
-      start_byte: input_edit.start_byte,
-      end_byte: input_edit.new_end_byte,
-      start_point: input_edit.start_position,
-      end_point: input_edit.new_end_position,
-    }
+  Range {
+    start_byte: input_edit.start_byte,
+    end_byte: input_edit.new_end_byte,
+    start_point: input_edit.start_position,
+    end_point: input_edit.new_end_position,
+  }
 }
 
 #[cfg(test)]

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -314,11 +314,17 @@ fn _get_tree_sitter_edit(
   }
 }
 
-/// As input, `substitute_tags` requires the (i) `input_string`, (ii) substitutions for the tags (i.e. @<var>) 
-/// and whether the input string is a tree-sitter query (else it is considered as a replacement pattern).
-/// `substitute_tags` replaces the all the occurrences of a specific tag  with the corresponding string values 
-/// specified in `substitutions`, 
-/// Not it escapes newline characters for tree-sitter-queries. 
+/// Replaces the all the occurrences of a specific tag  with the corresponding string values 
+/// specified in `substitutions`, and returns this new string. 
+/// 
+/// # Arguments 
+/// 
+/// * `input_string` : the string to be transformed 
+/// * `substitutions` : a map between tree-sitter tag and the replacement string 
+/// * `is_tree_sitter_query` : true if the `input_string` is a tree-sitter query, false if it is a 
+///     replacement pattern.
+/// 
+/// Note that,  it escapes newline characters for tree-sitter-queries. 
 pub(crate) fn substitute_tags(
   input_string: String, substitutions: &HashMap<String, String>, is_tree_sitter_query: bool,
 ) -> String {

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -314,6 +314,11 @@ fn _get_tree_sitter_edit(
   }
 }
 
+/// As input, `substitute_tags` requires the (i) `input_string`, (ii) substitutions for the tags (i.e. @<var>) 
+/// and whether the input string is a tree-sitter query (else it is considered as a replacement pattern).
+/// `substitute_tags` replaces the all the occurrences of a specific tag  with the corresponding string values 
+/// specified in `substitutions`, 
+/// Not it escapes newline characters for tree-sitter-queries. 
 pub(crate) fn substitute_tags(
   input_string: String, substitutions: &HashMap<String, String>, is_tree_sitter_query: bool,
 ) -> String {

--- a/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
+++ b/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
@@ -244,7 +244,7 @@ fn test_substitute_tags() {
     ("init".to_string(), "true".to_string()),
   ]);
   assert_eq!(
-    substitute_tags("@variable_name foo bar @init".to_string(), &substitutions),
+    substitute_tags("@variable_name foo bar @init".to_string(), &substitutions, false),
     "isFlagTreated foo bar true"
   )
 }

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/edges.toml
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/edges.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The edges in this file specify the flow between the rules
+[[edges]]
+scope = "Class"
+from = "add_inner_class"
+to = ["add_field_declaration"]

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/piranha_arguments.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["java"]
+substitutions = []

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/rules.toml
@@ -1,0 +1,55 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains rules to the specific feature flag API.
+
+#
+
+
+[[rules]]
+name = "add_inner_class"
+query = """(
+(class_declaration name: (_)@class_name 
+    body : (class_body ((_)*) @class_members)  @class_body
+ ) @class_declaration
+(#eq? @class_name "FooBar")
+)"""
+replace_node = "class_body"
+replace = """{
+ @class_members
+ public class InnerFooBar {  
+    private String name;
+ }  
+}"""
+[[rules.constraints]]
+matcher = "(class_declaration ) @c_cd"
+queries = ["""(
+(class_declaration name:(_) @name ) @cd
+(#eq? @name "InnerFooBar")
+)"""]
+
+[[rules]]
+name = "add_field_declaration"
+query = """(
+(class_declaration name: (_)@class_name 
+    body : (class_body ((_)*) @class_members)  @class_body
+ ) @class_declaration
+)"""
+replace_node = "class_body"
+replace = "{\n private String address;\n @class_members \n}"
+groups = ["Cleanup Rule"]
+[[rules.constraints]]
+matcher = "(class_declaration ) @c_cd"
+queries = ["""(
+(field_declaration (variable_declarator name:(_) @name )) @field
+(#eq? @name "address")
+)"""]
+

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/expected/TestClass.java
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/expected/TestClass.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha;
+
+class FooBar {
+
+  int Id; 
+
+  FooBar(int id){
+    this.Id = id;
+  }
+
+  public class InnerFooBar {  
+    private String address;
+    private String name;
+  }
+
+}

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/input/TestClass.java
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/input/TestClass.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha;
+
+class FooBar {
+
+  int Id; 
+
+  FooBar(int id){
+    this.Id = id;
+  }
+  
+
+}
+

--- a/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/configurations/piranha_arguments.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["java"]
+substitutions = []

--- a/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/configurations/rules.toml
@@ -1,0 +1,25 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+[[rules]]
+name = "replace_arrays_as_list_with_collection_singleton"
+query = """
+(
+((method_invocation object: (identifier) @object
+                   name: (_) @name
+                   arguments : (argument_list (string_literal) @literal)) @mi) 
+(#eq? @name "equals")
+)
+"""
+replace_node = "mi"
+replace = "@literal.equals(@object)"
+

--- a/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/expected/SomeClass.java
+++ b/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/expected/SomeClass.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha;
+
+class SomeClass {
+  
+  void someMethod(String s){      
+      assert("Hello \n World".equals(s));
+    }
+}

--- a/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/input/SomeClass.java
+++ b/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/input/SomeClass.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha;
+
+class SomeClass {
+  
+  void someMethod(String s){      
+      assert(s.equals("Hello \n World"));
+    }
+}


### PR DESCRIPTION
Sometimes we need to escape new line characters when it is part of the tree-sitter query. i.e. convert `\n` to `\\n`. 
Problem is that, I was using the method `substitute_tags` for both substituting tags in a replacement pattern and in a tree-sitter query. There was a bug because of this. 
To fix this bug, I basically added a boolean flag indicating wether the input is a tree-sitter query . This flag determines if a  new line character is escaped in the substituted value. 