### PR TITLE
Bug Fix/ Feature ? Allow performing consecutive scope level rules. 

### DIFF
--- a/polyglot/piranha/src/models/scopes.rs
+++ b/polyglot/piranha/src/models/scopes.rs
@@ -63,9 +63,9 @@ impl ScopeGenerator {
     let scope_matchers = rules_store.get_scope_query_generators(scope_level);
 
     // Match the `scope_matcher.matcher` to the parent
-    while let Some(parent) = changed_node.parent() {
+    loop {
       for m in &scope_matchers {
-        if let Some(p_match) = parent.get_match_for_query(
+        if let Some(p_match) = changed_node.get_match_for_query(
           &source_code_unit.code(),
           rules_store.query(&m.matcher()),
           false,
@@ -73,9 +73,12 @@ impl ScopeGenerator {
           // Generate the scope query for the specific context by substituting the
           // the tags with code snippets appropriately in the `generator` query.
           return substitute_tags(m.generator(), p_match.matches(), true);
-        } else {
-          changed_node = parent;
         }
+      }
+      if let Some(parent) = changed_node.parent() {
+        changed_node = parent;
+      } else {
+        break;
       }
     }
     panic!("Could not create scope query for {:?}", scope_level);

--- a/polyglot/piranha/src/tests/test_piranha_java.rs
+++ b/polyglot/piranha/src/tests/test_piranha_java.rs
@@ -76,6 +76,12 @@ fn test_java_scenarios_new_line_character_used_in_string_literal() {
   run_rewrite_test(&format!("{}/{}", LANGUAGE, "new_line_character_used_in_string_literal"), 1);
 }
 
+#[test]
+fn test_java_scenarios_consecutive_scope_level_rules() {
+  initialize();
+  run_rewrite_test(&format!("{}/{}", LANGUAGE, "consecutive_scope_level_rules"), 1);
+}
+
 // run_match_test
 #[test]
 fn test_java_match_only() {

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/edges.toml
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/edges.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The edges in this file specify the flow between the rules
+[[edges]]
+scope = "Global"
+from = "find_interface_extension"
+to = ["delete_class"]

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/edges.toml
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/edges.toml
@@ -11,6 +11,6 @@
 
 # The edges in this file specify the flow between the rules
 [[edges]]
-scope = "Global"
-from = "find_interface_extension"
-to = ["delete_class"]
+scope = "Class"
+from = "add_inner_class"
+to = ["add_field_declaration"]

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/piranha_arguments.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["java"]
+substitutions = []

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/rules.toml
@@ -1,0 +1,53 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains rules to the specific feature flag API.
+
+#
+
+
+[[rules]]
+name = "add_inner_class"
+query = """(
+(class_declaration name: (_)@class_name 
+    body : (class_body ((_)*) @class_members)  @class_body
+ ) @class_declaration
+(#eq? @class_name "FooBar")
+)"""
+replace_node = "class_body"
+replace = """{
+ @class_members
+ public class InnerFooBar {  
+    private String name;
+ }  
+}"""
+[[rules.constraints]]
+matcher = "(class_declaration ) @c_cd"
+queries = ["""(
+(class_declaration name:(_) @name ) @cd
+(#eq? @name "InnerFooBar")
+)"""]
+
+[[rules]]
+name = "add_field_declaration"
+query = """(
+(class_declaration name: (_)@class_name 
+    body : (class_body ((_)*) @class_members)  @class_body
+ ) @class_declaration
+)"""
+replace_node = "class_body"
+replace = "{\n private String address;\n @class_members \n}"
+[[rules.constraints]]
+matcher = "(class_declaration ) @c_cd"
+queries = ["""(
+(field_declaration (variable_declarator name:(_) @name )) @field
+(#eq? @name "address")
+)"""]

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/rules.toml
@@ -45,9 +45,11 @@ query = """(
 )"""
 replace_node = "class_body"
 replace = "{\n private String address;\n @class_members \n}"
+groups = ["Cleanup Rule"]
 [[rules.constraints]]
 matcher = "(class_declaration ) @c_cd"
 queries = ["""(
 (field_declaration (variable_declarator name:(_) @name )) @field
 (#eq? @name "address")
 )"""]
+

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/expected/TestClass.java
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/expected/TestClass.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha;
+
+class FooBar {
+
+  int Id; 
+
+  FooBar(int id){
+    this.Id = id;
+  }
+
+  public class InnerFooBar {  
+    private String address;
+    private String name;
+  }
+
+}

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/input/TestClass.java
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/input/TestClass.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.piranha;
+
+class FooBar {
+
+  int Id; 
+
+  FooBar(int id){
+    this.Id = id;
+  }
+  
+
+}
+


### PR DESCRIPTION
Currently, when we say apply `Rule 1` and then apply `Rule 2` in the class scope of `Rule 1`, we assume that `Rule 1` is applied to a node which is a child node of the `Class` (i.e. `Class` node should be ancestor of the node changed by `Rule 1`). But it could happen that, `Rule 1` changes the class node itself.  
For such case, we now also match the scope query against the changed node itself and its ancestors. 
Earlier we matched scope query only against ancestors. 