### PR TITLE
Polyglot demo: `--no-default-features` flag if macOS

### DIFF
--- a/polyglot/piranha/README.md
+++ b/polyglot/piranha/README.md
@@ -35,7 +35,7 @@ The output JSON format is - `models.PiranhaOutputSummary`.
 
 Languages supported :
 * Java
-* Kotlin (planned)
+* Kotlin
 * Java + Kotlin (planned)
 * Swift (planned)
 * JavaScript (planned)
@@ -50,7 +50,7 @@ Languages supported :
 * Install [Rust](https://www.rust-lang.org/tools/install), Git and [tree-sitter CLI](https://github.com/tree-sitter/tree-sitter/blob/master/cli/README.md)
 * Checkout this repository - `git checkout https://github.com/uber/piranha.git` 
 * `cd piranha/polyglot/piranha`
-* `cargo build --release`
+* `cargo build --release` (you should add the flag `--no-default-features` on macOS)
 * You will see the binary under `target/release`
 
 ## Getting started with Piranha
@@ -59,7 +59,8 @@ Languages supported :
 To run the demo : 
 * `cd polyglot/piranha`
 * `./demo/run_piranha_demo.sh`
-*Please refer to our test cases at [`/polyglot/piranha/src/test-resources/<language>/`](/polyglot/piranha/src/test-resources/) as a reference for handling complicated scenarios*
+
+*Please refer to our test cases at [`/polyglot/piranha/test-resources/<language>/`](/polyglot/piranha/test-resources/) as a reference for handling complicated scenarios*
 
 To get started with Piranha, please follow the below steps:
 * Check if the current version of Piranha supports the required language.

--- a/polyglot/piranha/demo/run_piranha_demo.sh
+++ b/polyglot/piranha/demo/run_piranha_demo.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright (c) 2022 Uber Technologies, Inc.
 
 # <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -9,9 +10,15 @@
 # express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-cargo build --release
-mv target/release/piranha  demo/piranha
-./demo/piranha -c demo/java/ -f demo/java/configurations -j demo/java/output.json
-./demo/piranha -c demo/kt/ -f demo/kt/configurations -j demo/kt/output.json
-./demo/piranha -c demo/swift/ -f demo/swift/configurations -j demo/swift/output.json
-./demo/piranha -c demo/strings/ -f demo/strings/configurations -j demo/strings/output.json
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OSX
+    cargo build --release --no-default-features
+else
+    cargo build --release
+fi
+
+mv target/release/polyglot_piranha demo/polyglot_piranha
+./demo/polyglot_piranha -c demo/java/ -f demo/java/configurations -j demo/java/output.json
+./demo/polyglot_piranha -c demo/kt/ -f demo/kt/configurations -j demo/kt/output.json
+./demo/polyglot_piranha -c demo/swift/ -f demo/swift/configurations -j demo/swift/output.json
+./demo/polyglot_piranha -c demo/strings/ -f demo/strings/configurations -j demo/strings/output.json


### PR DESCRIPTION
Hi 👋
These are changes to properly run Polyglot's demo on macOS by adding the `no-default-features` flag.
Fixes #233 
- Polyglot README:
  - macOS should add the flag
  - fixing link to test-resources
- run_piranha_demo.sh:
  - adding the flag only if macOS
  - executable name change: piranha -> polyglot_piranha

`run_piranha_demo.sh` is working on macOS and Ubuntu.