### PR TITLE
GoLang: tests and demo for structural replacement and cleanup

### DIFF
--- a/polyglot/piranha/Cargo.toml
+++ b/polyglot/piranha/Cargo.toml
@@ -43,6 +43,7 @@ tree-sitter-kotlin = { git = "https://github.com/ketkarameya/tree-sitter-kotlin.
 tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java.git" }
 tree-sitter-swift = { git = "https://github.com/ketkarameya/tree-sitter-swift.git", branch = "add_parser" }
 tree-sitter-strings = { git = "https://github.com/ketkarameya/tree-sitter-strings.git" }
+tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go.git" }
 derive_builder = "0.11.2"
 getset = "0.1.2"
 pyo3 =  "0.17.1"

--- a/polyglot/piranha/README.md
+++ b/polyglot/piranha/README.md
@@ -177,7 +177,7 @@ The output JSON is the serialization of- [`PiranhaOutputSummary`](/polyglot/pira
 | Kotlin           | :heavy_check_mark:          | :heavy_check_mark:                       | :heavy_check_mark:                   |
 | Java + Kotlin    | :x:                         | :calendar:                               | :calendar:                           |
 | Swift            | :heavy_check_mark:          | :construction:                           | :construction:                       |
-| Go               | :construction:              | :construction:                           | :construction:                       |
+| Go               | :heavy_check_mark:          | :construction:                           | :construction:                       |
 | Python           | :calendar:                  | :calendar:                               | :calendar:                           |
 | TypeScript       | :calendar:                  | :calendar:                               | :calendar:                           |
 | C#               | :calendar:                  | :calendar:                               | :calendar:                           |
@@ -227,7 +227,8 @@ Currently, we have demos for the following :
 <h4>  Structural Find/Replace with Custom Cleanup </h4> 
 
    * run `python3 demo/find_replace_custom_cleanup_demos.py`
-   * This demo shows how to replace `new ArrayList<>()` with `Collections.emptyList()`. Note it also adds the required import statement. 
+   * This demo shows how to replace `new ArrayList<>()` with `Collections.emptyList()` in Java. Note it also adds the required import statement.
+   * This demo also shows how to replace `fmt.Print()` with `fmt.Println()` in Go, which leads to a cleanup of a trailing `\n` in the `string` argument.
 
 
 *Please refer to our test cases at [`/polyglot/piranha/test-resources/<language>/`](/polyglot/piranha/test-resources/) as a reference for handling complicated scenarios*
@@ -449,3 +450,14 @@ To add new scenarios to the existing tests for a given language, you can add the
 Update the `piranha_arguments_treated.toml` and `piranha_arguments_control.toml` files too.
 
 To add tests for a new language, please add a new `<language>` folder inside `test-resources/` and populate the `input`, `expected_treated` and `expected_control` directories appropriately.
+
+<h4> Support for a new language</h4>
+
+Below we list an overview of the basic changes to support a new language.
+[PR#244](https://github.com/uber/piranha/pull/244) can be used as an example.
+
+- `Cargo.toml`: Add the dependency for the tree-sitter grammar.
+- Add the language in `tree_sitter_utilities.rs`.
+- Add tests.
+- Add a demo.
+- Update the README.

--- a/polyglot/piranha/README.md
+++ b/polyglot/piranha/README.md
@@ -208,7 +208,7 @@ Currently, we have demos for the following :
 
 <h4>Stale Feature Flag Cleanup:</h4>
 
-  * run `python3 demo/stale_feature_flag_cleanup_demos.py`. It will execute the scenarios listed under [demo/java/ff](/polyglot/piranha/demo/java/ff/configurations/rules.toml) and [demo/kt/ff](/polyglot/piranha/demo/kt/ff/configurations/rules.toml). These scenarios use simple feature flag API. 
+  * run `python3 demo/stale_feature_flag_cleanup_demos.py`. It will execute the scenarios listed under [demo/java/ff](/polyglot/piranha/demo/java/ff/configurations/rules.toml), [demo/kt/ff](/polyglot/piranha/demo/kt/ff/configurations/rules.toml), and [demo/feature_flag_cleanup/go](/polyglot/piranha/demo/feature_flag_cleanup/go/configurations/rules.toml). These scenarios use simple feature flag API. 
   * In these demos the `configurations` contain :
     * `rules.toml` : expresses how to capture different feature flag APIs (`isTreated`, `enum constant`)
     * `piranha_arguments.toml` : expresses the flag behavior, i.e. the flag name and whether it is treated or not. Basically the `substitutions` provided in the `piranha_arguments.toml` can be used to instantiate the rules [reference](#piranha-arguments).

--- a/polyglot/piranha/README.md
+++ b/polyglot/piranha/README.md
@@ -219,7 +219,7 @@ Currently, we have demos for the following :
   * This demo also shows how the piranha summary output can be used. 
     * `rules.toml` : express how to capture two patterns - (i) invocation of the method `fooBar("...")`  and invocation of the method `barFoo("...")` (but only in static methods)
 
-<h4>  Structural Find/Replace </h4> 
+<h4>  Structural Find/Replace </h4>
 
   * run `python3 demo/find_replace_demos.py`
   * This demo shows how to use Piranha as a simple structural find/replace tool (that optionally hooks up to built-in cleanup rules)
@@ -228,7 +228,7 @@ Currently, we have demos for the following :
 
    * run `python3 demo/find_replace_custom_cleanup_demos.py`
    * This demo shows how to replace `new ArrayList<>()` with `Collections.emptyList()` in Java. Note it also adds the required import statement.
-   * This demo also shows how to replace `fmt.Print()` with `fmt.Println()` in Go, which leads to a cleanup of a trailing `\n` in the `string` argument.
+   * This demo also shows how to find a trailing `\n` in a `argument` of `fmt.Print()` in Go, and then replace `fmt.Print()` with `fmt.Println()`.
 
 
 *Please refer to our test cases at [`/polyglot/piranha/test-resources/<language>/`](/polyglot/piranha/test-resources/) as a reference for handling complicated scenarios*

--- a/polyglot/piranha/README.md
+++ b/polyglot/piranha/README.md
@@ -451,13 +451,13 @@ Update the `piranha_arguments_treated.toml` and `piranha_arguments_control.toml`
 
 To add tests for a new language, please add a new `<language>` folder inside `test-resources/` and populate the `input`, `expected_treated` and `expected_control` directories appropriately.
 
-<h4> Support for a new language</h4>
+<h4> Support for a new language </h4>
 
 Below we list an overview of the basic changes to support a new language.
-[PR#244](https://github.com/uber/piranha/pull/244) can be used as an example.
+Please refer to [PR#244](https://github.com/uber/piranha/pull/244) as an example.
 
-- `Cargo.toml`: Add the dependency for the tree-sitter grammar.
-- Add the language in `tree_sitter_utilities.rs`.
-- Add tests.
-- Add a demo.
+- `Cargo.toml`: add the tree-sitter grammar dependency.
+- `tree_sitter_utilities.rs`: add the language string pointing to the grammar.
+- `src/tests/mod.rs`: add end-to-end tests.
+- Add demo examples.
 - Update the README.

--- a/polyglot/piranha/demo/feature_flag_cleanup/go/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/feature_flag_cleanup/go/configurations/piranha_arguments.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["go"]
+substitutions = [
+    ["stale_flag_name", "staleFlag"],
+    ["treated", "true"]
+]

--- a/polyglot/piranha/demo/feature_flag_cleanup/go/configurations/rules.toml
+++ b/polyglot/piranha/demo/feature_flag_cleanup/go/configurations/rules.toml
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# For @stale_flag_name = staleFlag and @treated = true
+# Before
+#  experimentation.enabled(staleFlag)
+# After
+#  true
+#
+[[rules]]
+groups = ["replace_expression_with_boolean_literal"]
+name = "replace_experimentation_Enabled_with_boolean_literal"
+query = """
+(
+    (call_expression
+        function: (selector_expression
+            operand: (identifier) @func_id
+            field: (field_identifier) @func_field
+        )
+        arguments: (argument_list
+            (identifier) @arg_id
+        )
+    ) @call_exp
+    (#eq? @func_id "experimentation")
+    (#eq? @func_field "Enabled")
+    (#eq? @arg_id "@stale_flag_name")
+)
+"""
+replace_node = "call_exp"
+replace = "@treated"
+holes = ["stale_flag_name", "treated"]

--- a/polyglot/piranha/demo/feature_flag_cleanup/go/sample.go
+++ b/polyglot/piranha/demo/feature_flag_cleanup/go/sample.go
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package piranha
+
+import (
+	_ "experimentation"
+	"fmt"
+)
+
+const (
+	staleFlag = "staleFlag"
+)
+
+func d() {
+	fmt.Println("Before")
+	if experimentation.Enabled(staleFlag) {
+		fmt.Println("Enabled")
+	} else {
+		fmt.Println("Disabled")
+	}
+	fmt.Println("After")
+}

--- a/polyglot/piranha/demo/find_replace/go/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/find_replace/go/configurations/piranha_arguments.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["go"]
+substitutions = [
+     ["stale_flag_name", "staleFlag"],
+     ["stale_flag_value", "staleFlag"]
+]

--- a/polyglot/piranha/demo/find_replace/go/configurations/rules.toml
+++ b/polyglot/piranha/demo/find_replace/go/configurations/rules.toml
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+# note the quotes escape `\\"` for the string literal
+name = "remove_staleFlag"
+query = """
+(
+	(const_spec
+        name: (identifier) @const_id
+        value: (_) @val
+    ) @const_spec
+    (#eq? @const_id "@stale_flag_name")
+    (#eq? @val "\\"@stale_flag_value\\"")
+)
+"""
+replace_node = "const_spec"
+replace = ""
+holes = ["stale_flag_name", "stale_flag_value"]

--- a/polyglot/piranha/demo/find_replace/go/configurations/rules.toml
+++ b/polyglot/piranha/demo/find_replace/go/configurations/rules.toml
@@ -9,8 +9,19 @@
 # express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-[[rules]]
+#
+# For @stale_flag_name = staleFlag and @stale_flag_value = staleFlag
+# Before
+#  const (
+#      staleFlag = "staleFlag"
+#  )
+# After
+#  const (
+#
+#  )
+#
 # note the quotes escape `\\"` for the string literal
+[[rules]]
 name = "remove_staleFlag"
 query = """
 (

--- a/polyglot/piranha/demo/find_replace/go/sample.go
+++ b/polyglot/piranha/demo/find_replace/go/sample.go
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package piranha
+
+const (
+	staleFlag = "staleFlag"
+	okFlag    = "okFlag"
+)

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/edges.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/edges.toml
@@ -12,5 +12,5 @@
 # The edges in this file specify the flow between the rules
 [[edges]]
 scope = "Parent"
-from = "replace_fmt_Print_with_fmt_Println"
-to = ["newline_cleanup"]
+from = "remove_last_new_line_escape_in_intepreted_string_literal_in_fmt_Print"
+to = ["replace_fmt_Print_with_fmt_Println"]

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/edges.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/edges.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+scope = "Parent"
+from = "replace_fmt_Print_with_fmt_Println"
+to = ["newline_cleanup"]

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/edges.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/edges.toml
@@ -9,6 +9,7 @@
 # express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The edges in this file specify the flow between the rules
 [[edges]]
 scope = "Parent"
 from = "replace_fmt_Print_with_fmt_Println"

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/piranha_arguments.toml
@@ -1,0 +1,17 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["go"]
+substitutions = [
+    ["receiver_name", "fmt"],
+    ["fn_name", "Print"],
+    ["fn_replacement", "Println"]
+]

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/rules.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/rules.toml
@@ -10,41 +10,15 @@
 # limitations under the License.
 
 #
-# For @receiver_name = fmt and @fn_name = Print and @fn_replacement = Println
+# For @receiver_name = fmt and @fn_name = Print
 # Before
 #  fmt.Print("found", n, "cases\n")
 # After
-#  fmt.Println("found", n, "cases\n")
-#
-[[rules]]
-name = "replace_fmt_Print_with_fmt_Println"
-query = """
-(
-    (call_expression
-        function: (selector_expression
-            operand: (identifier) @func_id
-            field: (field_identifier) @func_field
-        )
-    )
-    (#eq? @func_id "@receiver_name")
-    (#eq? @func_field "@fn_name")
-)
-"""
-replace_node = "func_field"
-replace = "@fn_replacement"
-holes = ["receiver_name", "fn_name", "fn_replacement"]
-
-#
-# For @receiver_name = fmt and @fn_replacement = Println
-# Before
-#  fmt.Println("found", n, "cases\n")
-# After
-#  fmt.Println("found", n, "cases")
+#  fmt.Print("found", n, "cases")
 #
 # the `.` anchor matches the last interpreted_string_literal
 [[rules]]
-groups = ["newline_cleanup"]
-name = "remove_last_new_line_escape_in_intepreted_string_literal"
+name = "remove_last_new_line_escape_in_intepreted_string_literal_in_fmt_Print"
 query = """
 (
     (call_expression
@@ -61,8 +35,8 @@ query = """
 """
 replace_node = "escape_seq"
 replace = ""
-holes = ["receiver_name", "fn_replacement"]
-# The constraint rejects any call_expression that does not match @receiver_name.@fn_replacement
+holes = ["receiver_name", "fn_name"]
+# The constraint rejects any call_expression that does not match @receiver_name.@fn_name
 # ("fmt.Println")
 [[rules.constraints]]
 matcher = "(call_expression) @cd"
@@ -75,6 +49,33 @@ queries = [
         )
     )
     (#not-eq? @func_id "@receiver_name")
-    (#not-eq? @func_field "@fn_replacement")
+    (#not-eq? @func_field "@fn_name")
 )"""
 ]
+
+#
+# For @receiver_name = fmt and @fn_name = Print and @fn_replacement = Println
+# Before
+#  fmt.Print("found", n, "cases")
+# After
+#  fmt.Println("found", n, "cases")
+#
+[[rules]]
+# Linking this rule to a group so it's not treated as a seed rule.
+groups = ["Cleanup Rule"]
+name = "replace_fmt_Print_with_fmt_Println"
+query = """
+(
+    (call_expression
+        function: (selector_expression
+            operand: (identifier) @func_id
+            field: (field_identifier) @func_field
+        )
+    ) @call_exp
+    (#eq? @func_id "@receiver_name")
+    (#eq? @func_field "@fn_name")
+)
+"""
+replace_node = "func_field"
+replace = "@fn_replacement"
+holes = ["receiver_name", "fn_name", "fn_replacement"]

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/rules.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/rules.toml
@@ -1,0 +1,63 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+name = "replace_fmt_Print_with_fmt_Println"
+query = """
+(
+    (call_expression
+        function: (selector_expression
+            operand: (identifier) @func_id
+            field: (field_identifier) @func_field
+        )
+    )
+    (#eq? @func_id "@receiver_name")
+    (#eq? @func_field "@fn_name")
+)
+"""
+replace_node = "func_field"
+replace = "@fn_replacement"
+holes = ["receiver_name", "fn_name", "fn_replacement"]
+
+[[rules]]
+groups = ["newline_cleanup"]
+name = "remove_last_new_line_escape_in_intepreted_string_literal"
+query = """
+(
+    (call_expression
+        arguments: (argument_list
+            (_)*
+            (interpreted_string_literal
+                .
+                (escape_sequence) @escape_seq
+            )
+        )
+    )
+    (#eq @escape_seq "\\n")
+)
+"""
+replace_node = "escape_seq"
+replace = ""
+holes = ["receiver_name", "fn_replacement"]
+[[rules.constraints]]
+matcher = "(call_expression) @cd"
+queries = [
+"""(
+    (call_expression
+        function: (selector_expression
+            operand: (identifier) @func_id
+            field: (field_identifier) @func_field
+        )
+    )
+    (#not-eq? @func_id "@receiver_name")
+    (#not-eq? @func_field "@fn_replacement")
+)"""
+]

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/rules.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/go/configurations/rules.toml
@@ -9,6 +9,13 @@
 # express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# For @receiver_name = fmt and @fn_name = Print and @fn_replacement = Println
+# Before
+#  fmt.Print("found", n, "cases\n")
+# After
+#  fmt.Println("found", n, "cases\n")
+#
 [[rules]]
 name = "replace_fmt_Print_with_fmt_Println"
 query = """
@@ -27,6 +34,14 @@ replace_node = "func_field"
 replace = "@fn_replacement"
 holes = ["receiver_name", "fn_name", "fn_replacement"]
 
+#
+# For @receiver_name = fmt and @fn_replacement = Println
+# Before
+#  fmt.Println("found", n, "cases\n")
+# After
+#  fmt.Println("found", n, "cases")
+#
+# the `.` anchor matches the last interpreted_string_literal
 [[rules]]
 groups = ["newline_cleanup"]
 name = "remove_last_new_line_escape_in_intepreted_string_literal"
@@ -47,6 +62,8 @@ query = """
 replace_node = "escape_seq"
 replace = ""
 holes = ["receiver_name", "fn_replacement"]
+# The constraint rejects any call_expression that does not match @receiver_name.@fn_replacement
+# ("fmt.Println")
 [[rules.constraints]]
 matcher = "(call_expression) @cd"
 queries = [

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/go/sample.go
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/go/sample.go
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package piranha
+
+import (
+	"fmt"
+)
+
+func main() {
+	const notReplaced = "No replace\n"
+	const name, age = "Kim", 22
+	fmt.Print(name, " is ", age, " years old.\n")
+}

--- a/polyglot/piranha/demo/find_replace_custom_cleanup_demos.py
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup_demos.py
@@ -14,5 +14,14 @@ def java_demo():
     print("Running the Find/Replace Custom Cleanup demo for Java")
     _ = run_piranha_cli(join(find_Replace_dir, "java"), join(find_Replace_dir, "java/configurations"), True)
 
+def go_demo():
+    """
+    Replace `fmt.Print("String\n")` with `fmt.Println("String")`.
+    We define a rule to replace `fmt.Print` with `fmt.Println` which then triggers the cleanup of the trailing `\n` on a matching `call_expression`.
+    """
+    print("Running the Find/Replace Custom Cleanup demo for Go")
+    _ = run_piranha_cli(join(find_Replace_dir, "go"), join(find_Replace_dir, "go/configurations"), True)
+
 java_demo()
+go_demo()
 print("Completed running the Find/Replace Custom Cleanup demos")

--- a/polyglot/piranha/demo/find_replace_demos.py
+++ b/polyglot/piranha/demo/find_replace_demos.py
@@ -29,9 +29,15 @@ def java_demo():
     print("Running the Find/Replace demo for Java")
     _ = run_piranha_cli(join(find_Replace_dir, "java"), join(find_Replace_dir, "java/configurations"), True)
 
-
+def go_demo():
+    """
+    This shows how we can use Piranha to execute structural find/replace without hooking up to any existent pre-built rules.
+    """
+    print("Running the Find/Replace demo for Go")
+    _ = run_piranha_cli(join(find_Replace_dir, "go"), join(find_Replace_dir, "go/configurations"), True)
 
 swift_demo()
 strings_demo()
 java_demo()
+go_demo()
 print("Completed running the Find/Replace demos")

--- a/polyglot/piranha/demo/stale_feature_flag_cleanup_demos.py
+++ b/polyglot/piranha/demo/stale_feature_flag_cleanup_demos.py
@@ -20,8 +20,15 @@ def run_kt_ff_demo():
     for summary in output_summary_kt:
         assert len(summary.rewrites) > 0
 
+def run_go_ff_demo():
+    print("Running the stale feature flag cleanup demo for Go")
+    output_summary_go = run_piranha_cli(join(feature_flag_dir, "go"), join(feature_flag_dir, 'go/configurations'), True)
+    assert len(output_summary_go) == 1
 
+    for summary in output_summary_go:
+        assert len(summary.rewrites) > 0
 
 run_java_ff_demo()
 run_kt_ff_demo()
+run_go_ff_demo()
 print("Completed running the stale feature flag cleanup demos")

--- a/polyglot/piranha/src/cleanup_rules/go/edges.toml
+++ b/polyglot/piranha/src/cleanup_rules/go/edges.toml
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The edges in this file specify the flow between the rules.
+[[edges]]
+scope = "Parent"
+from = "replace_expression_with_boolean_literal"
+to = ["boolean_literal_cleanup"]
+
+[[edges]]
+scope = "Parent"
+from = "boolean_literal_cleanup"
+to = ["statement_cleanup"]
+
+[[edges]]
+scope = "Parent"
+from = "statement_cleanup"
+to = ["if_cleanup"]
+
+[[edges]]
+scope = "Parent"
+from = "if_cleanup"
+to = ["remove_unnecessary_nested_block"]

--- a/polyglot/piranha/src/cleanup_rules/go/rules.toml
+++ b/polyglot/piranha/src/cleanup_rules/go/rules.toml
@@ -1,0 +1,90 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The language specific rules in this file are applied after the API specific change has been performed.
+
+# Before
+#  if (true) { doSomething() }
+# After
+#  { doSomething() }
+# Before
+#  if true { doSomething() } else { doSomethingElse() }
+# After
+#  { doSomething() }
+# Before
+#  if :flag := "a"; true { doSomething() }
+# After
+#  :flag := "a"
+#  doSomething()
+#
+# Adds an unnecessary blank line when there is no initializer
+# If the blank line is unwanted, we could split the rule into two queries.
+# `!initializer` would match `if_statement`s w/o initializer
+[[rules]]
+groups = ["if_cleanup"]
+name = "simplify_if_statement_true"
+query = """
+(
+    (if_statement
+        initializer: (_)? @initializer
+        condition: ([
+                (parenthesized_expression [
+                    (parenthesized_expression (true))
+                    (true)
+                ])
+                (true)
+                ]
+        )
+        consequence: (block (_)) @consequence_block
+    ) @if_statement
+)
+"""
+replace = "@initializer\n@consequence_block"
+replace_node = "if_statement"
+
+# Before
+#  func { 
+#    a := "a" 
+#    {
+#        doSomething() 
+#    } 
+#    b := "b" 
+#  }
+# After
+#  func { 
+#    a := "a" 
+#    doSomething() 
+#    b := "b" 
+#  }
+#
+# Currently, @pre, @post, @nested.block match only the 1st node
+# problem with tree-sitter-go queries and quantifiers
+[[rules]]
+name = "remove_unnecessary_nested_block"
+query = """
+((block
+    (
+        (_)* @pre
+        (block (_) @nested.stmts) @nested.block
+        (_)* @post
+    )
+)@block)
+"""
+replace = "@nested.stmts"
+replace_node = "nested.block"
+
+# Dummy rule that acts as a junction for all boolean based cleanups
+[[rules]]
+name = "boolean_literal_cleanup"
+
+# Dummy rule that acts as a junction for all statement based cleanups
+[[rules]]
+name = "statement_cleanup"

--- a/polyglot/piranha/src/cleanup_rules/go/scope_config.toml
+++ b/polyglot/piranha/src/cleanup_rules/go/scope_config.toml
@@ -1,0 +1,14 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# For information about why this file is needed, please refer to /src/cleanup_rules/java/scope_config.rs. 
+# This file specifies how functions and classes should be captured by Piranha. 

--- a/polyglot/piranha/src/tests/mod.rs
+++ b/polyglot/piranha/src/tests/mod.rs
@@ -28,6 +28,8 @@ mod test_piranha_strings;
 
 mod test_piranha_swift;
 
+mod test_piranha_go;
+
 use std::sync::Once;
 
 static INIT: Once = Once::new();

--- a/polyglot/piranha/src/tests/test_piranha_go.rs
+++ b/polyglot/piranha/src/tests/test_piranha_go.rs
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2022 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+use super::{initialize, run_rewrite_test};
+
+static LANGUAGE: &str = "go";
+
+#[test]
+fn test_go_structural_replacement() {
+  initialize();
+  run_rewrite_test(
+    &format!("{}/{}", LANGUAGE, "structural_replacement"),
+    1,
+  );
+}
+
+#[test]
+fn test_go_replacement_cleanup() {
+  initialize();
+  run_rewrite_test(
+    &format!("{}/{}", LANGUAGE, "replacement_cleanup"),
+    1,
+  );
+}

--- a/polyglot/piranha/src/tests/test_piranha_go.rs
+++ b/polyglot/piranha/src/tests/test_piranha_go.rs
@@ -32,3 +32,12 @@ fn test_go_replacement_cleanup() {
     1,
   );
 }
+
+#[test]
+fn test_go_if_replacement_cleanup() {
+  initialize();
+  run_rewrite_test(
+    &format!("{}/{}", LANGUAGE, "if_replacement_cleanup"),
+    1,
+  );
+}

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -51,6 +51,7 @@ impl TreeSitterHelpers for String {
       "kt" => tree_sitter_kotlin::language(),
       "swift" => tree_sitter_swift::language(),
       "strings" => tree_sitter_strings::language(),
+      "go" => tree_sitter_go::language(),
       _ => panic!("Language not supported"),
     }
   }
@@ -60,6 +61,7 @@ impl TreeSitterHelpers for String {
       "java" => kind.eq("line_comment") || kind.eq("block_comment"),
       "kt" => kind.eq("comment"),
       "swift" => kind.eq("comment") || kind.eq("multiline_comment"),
+      "go" => kind.eq("comment"),
       _ => false,
     }
   }

--- a/polyglot/piranha/test-resources/go/if_replacement_cleanup/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/go/if_replacement_cleanup/configurations/piranha_arguments.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["go"]
+substitutions = [
+    ["stale_flag_name", "staleFlag"],
+    ["treated", "true"]
+]

--- a/polyglot/piranha/test-resources/go/if_replacement_cleanup/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/go/if_replacement_cleanup/configurations/rules.toml
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# For @stale_flag_name = staleFlag and @treated = true
+# Before
+#  experimentation.enabled(staleFlag)
+# After
+#  true
+#
+[[rules]]
+groups = ["replace_expression_with_boolean_literal"]
+name = "replace_experimentation_Enabled_with_boolean_literal"
+query = """
+(
+    (call_expression
+        function: (selector_expression
+            operand: (identifier) @func_id
+            field: (field_identifier) @func_field
+        )
+        arguments: (argument_list
+            (identifier) @arg_id
+        )
+    ) @call_exp
+    (#eq? @func_id "experimentation")
+    (#eq? @func_field "Enabled")
+    (#eq? @arg_id "@stale_flag_name")
+)
+"""
+replace_node = "call_exp"
+replace = "@treated"
+holes = ["stale_flag_name", "treated"]

--- a/polyglot/piranha/test-resources/go/if_replacement_cleanup/expected/sample.go
+++ b/polyglot/piranha/test-resources/go/if_replacement_cleanup/expected/sample.go
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package piranha
+
+import (
+	_ "experimentation"
+	"fmt"
+)
+
+const (
+	staleFlag = "staleFlag"
+)
+
+func d() {
+	fmt.Println("Before")
+	fmt.Println("Enabled")
+	fmt.Println("After")
+}

--- a/polyglot/piranha/test-resources/go/if_replacement_cleanup/input/sample.go
+++ b/polyglot/piranha/test-resources/go/if_replacement_cleanup/input/sample.go
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package piranha
+
+import (
+	_ "experimentation"
+	"fmt"
+)
+
+const (
+	staleFlag = "staleFlag"
+)
+
+func d() {
+	fmt.Println("Before")
+	if experimentation.Enabled(staleFlag) {
+		fmt.Println("Enabled")
+	} else {
+		fmt.Println("Disabled")
+	}
+	fmt.Println("After")
+}

--- a/polyglot/piranha/test-resources/go/replacement_cleanup/configurations/edges.toml
+++ b/polyglot/piranha/test-resources/go/replacement_cleanup/configurations/edges.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+scope = "Parent"
+from = "replace_fmt_Print_with_fmt_Println"
+to = ["newline_cleanup"]

--- a/polyglot/piranha/test-resources/go/replacement_cleanup/configurations/edges.toml
+++ b/polyglot/piranha/test-resources/go/replacement_cleanup/configurations/edges.toml
@@ -11,5 +11,5 @@
 
 [[edges]]
 scope = "Parent"
-from = "replace_fmt_Print_with_fmt_Println"
-to = ["newline_cleanup"]
+from = "remove_last_new_line_escape_in_intepreted_string_literal_in_fmt_Print"
+to = ["replace_fmt_Print_with_fmt_Println"]

--- a/polyglot/piranha/test-resources/go/replacement_cleanup/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/go/replacement_cleanup/configurations/piranha_arguments.toml
@@ -1,0 +1,17 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["go"]
+substitutions = [
+    ["receiver_name", "fmt"],
+    ["fn_name", "Print"],
+    ["fn_replacement", "Println"]
+]

--- a/polyglot/piranha/test-resources/go/replacement_cleanup/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/go/replacement_cleanup/configurations/rules.toml
@@ -9,27 +9,16 @@
 # express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# For @receiver_name = fmt and @fn_name = Print
+# Before
+#  fmt.Print("found", n, "cases\n")
+# After
+#  fmt.Print("found", n, "cases")
+#
+# the `.` anchor matches the last interpreted_string_literal
 [[rules]]
-name = "replace_fmt_Print_with_fmt_Println"
-query = """
-(
-    (call_expression
-        function: (selector_expression
-            operand: (identifier) @func_id
-            field: (field_identifier) @func_field
-        )
-    )
-    (#eq? @func_id "@receiver_name")
-    (#eq? @func_field "@fn_name")
-)
-"""
-replace_node = "func_field"
-replace = "@fn_replacement"
-holes = ["receiver_name", "fn_name", "fn_replacement"]
-
-[[rules]]
-groups = ["newline_cleanup"]
-name = "remove_last_new_line_escape_in_intepreted_string_literal"
+name = "remove_last_new_line_escape_in_intepreted_string_literal_in_fmt_Print"
 query = """
 (
     (call_expression
@@ -46,7 +35,9 @@ query = """
 """
 replace_node = "escape_seq"
 replace = ""
-holes = ["receiver_name", "fn_replacement"]
+holes = ["receiver_name", "fn_name"]
+# The constraint rejects any call_expression that does not match @receiver_name.@fn_name
+# ("fmt.Println")
 [[rules.constraints]]
 matcher = "(call_expression) @cd"
 queries = [
@@ -58,6 +49,33 @@ queries = [
         )
     )
     (#not-eq? @func_id "@receiver_name")
-    (#not-eq? @func_field "@fn_replacement")
+    (#not-eq? @func_field "@fn_name")
 )"""
 ]
+
+#
+# For @receiver_name = fmt and @fn_name = Print and @fn_replacement = Println
+# Before
+#  fmt.Print("found", n, "cases")
+# After
+#  fmt.Println("found", n, "cases")
+#
+[[rules]]
+# Linking this rule to a group so it's not treated as a seed rule.
+groups = ["Cleanup Rule"]
+name = "replace_fmt_Print_with_fmt_Println"
+query = """
+(
+    (call_expression
+        function: (selector_expression
+            operand: (identifier) @func_id
+            field: (field_identifier) @func_field
+        )
+    ) @call_exp
+    (#eq? @func_id "@receiver_name")
+    (#eq? @func_field "@fn_name")
+)
+"""
+replace_node = "func_field"
+replace = "@fn_replacement"
+holes = ["receiver_name", "fn_name", "fn_replacement"]

--- a/polyglot/piranha/test-resources/go/replacement_cleanup/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/go/replacement_cleanup/configurations/rules.toml
@@ -1,0 +1,63 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+name = "replace_fmt_Print_with_fmt_Println"
+query = """
+(
+    (call_expression
+        function: (selector_expression
+            operand: (identifier) @func_id
+            field: (field_identifier) @func_field
+        )
+    )
+    (#eq? @func_id "@receiver_name")
+    (#eq? @func_field "@fn_name")
+)
+"""
+replace_node = "func_field"
+replace = "@fn_replacement"
+holes = ["receiver_name", "fn_name", "fn_replacement"]
+
+[[rules]]
+groups = ["newline_cleanup"]
+name = "remove_last_new_line_escape_in_intepreted_string_literal"
+query = """
+(
+    (call_expression
+        arguments: (argument_list
+            (_)*
+            (interpreted_string_literal
+                .
+                (escape_sequence) @escape_seq
+            )
+        )
+    )
+    (#eq @escape_seq "\\n")
+)
+"""
+replace_node = "escape_seq"
+replace = ""
+holes = ["receiver_name", "fn_replacement"]
+[[rules.constraints]]
+matcher = "(call_expression) @cd"
+queries = [
+"""(
+    (call_expression
+        function: (selector_expression
+            operand: (identifier) @func_id
+            field: (field_identifier) @func_field
+        )
+    )
+    (#not-eq? @func_id "@receiver_name")
+    (#not-eq? @func_field "@fn_replacement")
+)"""
+]

--- a/polyglot/piranha/test-resources/go/replacement_cleanup/expected/sample.go
+++ b/polyglot/piranha/test-resources/go/replacement_cleanup/expected/sample.go
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package piranha
+
+import (
+	"fmt"
+)
+
+func main() {
+	const notReplaced = "No replace\n"
+	const name, age = "Kim", 22
+	fmt.Println(name, " is ", age, " years old.")
+}

--- a/polyglot/piranha/test-resources/go/replacement_cleanup/input/sample.go
+++ b/polyglot/piranha/test-resources/go/replacement_cleanup/input/sample.go
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package piranha
+
+import (
+	"fmt"
+)
+
+func main() {
+	const notReplaced = "No replace\n"
+	const name, age = "Kim", 22
+	fmt.Print(name, " is ", age, " years old.\n")
+}

--- a/polyglot/piranha/test-resources/go/structural_replacement/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/go/structural_replacement/configurations/piranha_arguments.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["go"]
+substitutions = [
+     ["stale_flag_name", "staleFlag"],
+     ["stale_flag_value", "staleFlag"]
+]

--- a/polyglot/piranha/test-resources/go/structural_replacement/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/go/structural_replacement/configurations/rules.toml
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+# note the quotes escape `\\"` for the string literal
+name = "remove_staleFlag"
+query = """
+(
+	(const_spec
+        name: (identifier) @const_id
+        value: (_) @val
+    ) @const_spec
+    (#eq? @const_id "@stale_flag_name")
+    (#eq? @val "\\"@stale_flag_value\\"")
+)
+"""
+replace_node = "const_spec"
+replace = ""
+holes = ["stale_flag_name", "stale_flag_value"]

--- a/polyglot/piranha/test-resources/go/structural_replacement/expected/sample.go
+++ b/polyglot/piranha/test-resources/go/structural_replacement/expected/sample.go
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package piranha
+
+const (
+    okFlag    = "okFlag"
+)

--- a/polyglot/piranha/test-resources/go/structural_replacement/input/sample.go
+++ b/polyglot/piranha/test-resources/go/structural_replacement/input/sample.go
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package piranha
+
+const (
+	staleFlag = "staleFlag"
+	okFlag    = "okFlag"
+)


### PR DESCRIPTION
## README

- ✔️ for `Go`'s _Structural Find-Replace_.
- Text description for `Go`'s _Structural Find/Replace with Custom Cleanup_.
- No text description for `Go`'s _Structural Find-Replace_ as I believe the current description is accurate already.
  - _"This demo shows how to use Piranha as a simple structural find/replace tool (that optionally hooks up to built-in cleanup rules)"_
  - Subsection on _Contributing_ with an overview on how to add support for a new language.
- Mentioning `Go`'s demo in _State Feature Flag Cleanup_.

## Overview of Demo examples

### Structural Find/Replace

Removes a `const` based on its `identifier` and string literal value.

```diff
const (
-    staleFlag  = "staleFlag"
      okFlag    = "okFlag"
)
```

### Structural Find-Replace with Custom Cleanup

Consists of two rules.
Replaces `fmt.Print` for `fmt.Println`, which triggers the removal of a trailing `\n` in the `string` argument.

```diff
- fmt.Print(name, " is ", age, " years old.\n")
+ fmt.Println(name, " is ", age, " years old.")
```

### Simple Stale Feature Flag Cleanup

Introduces a seed rule `replace_experimentation_Enabled_with_boolean_literal` which hooks up to the pre-built rule `simplify_if_statement_true`.
`simplify_if_statement_true` has an edge (through `if_cleanup` group) to the pre-built rule `remove_unnecessary_nested_block`.

```diff
func d() {
	fmt.Println("Before")
-	if experimentation.Enabled(staleFlag) {
-		fmt.Println("Enabled")
-	} else {
-		fmt.Println("Disabled")
-	}
+       fmt.Println("Enabled")
	fmt.Println("After")
}
```

## Code changes

- `Cargo.toml`: [tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go) as dependency.
- `tree-sitter_utilities.rs`: `go` pointing to the dependency; specifying `go`'s comment node.
-  `tests/mod.rs`: added test module (`test_piranha_go.rs`) for `go`. The tests are exercising the demo examples.

## Python demo code

Added Go example in `stale_feature_flag_cleanup_demos.py`.

Documented Python functions for executing the two added demos.

- `find_replace_custom_cleanup_demos.py`
- `find_replace_demos.py`