### PR TITLE
Use include_str! 

### DIFF
--- a/polyglot/piranha/src/config.rs
+++ b/polyglot/piranha/src/config.rs
@@ -22,10 +22,10 @@ use crate::{
     rule::{Rule, Rules},
     scopes::{ScopeConfig, ScopeGenerator},
   },
-  utilities::read_toml,
+  utilities::{read_toml, parse_toml},
 };
 
-use std::path::{Path, PathBuf};
+use std::path::{Path};
 
 use clap::Parser;
 
@@ -44,28 +44,41 @@ pub(crate) struct CommandLineArguments {
   pub(crate) path_to_output_summary: Option<String>,
 }
 
-pub(crate) fn read_config_files(
-  args: &PiranhaArguments,
-) -> (Vec<Rule>, Vec<OutgoingEdges>, Vec<ScopeGenerator>) {
-  let path_to_config = Path::new(args.path_to_configurations());
-  let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-  let path_to_language_specific_cleanup_config =
-    &project_root.join(format!("src/cleanup_rules/{}", args.language_name()));
 
-  // Read the language specific cleanup rules and edges
-  let language_rules: Rules = read_toml(
-    &path_to_language_specific_cleanup_config.join("rules.toml"),
-    true,
-  );
-  let language_edges: Edges = read_toml(
-    &path_to_language_specific_cleanup_config.join("edges.toml"),
-    true,
-  );
-  let scopes = read_toml::<ScopeConfig>(
-    &path_to_language_specific_cleanup_config.join("scope_config.toml"),
-    true,
-  )
-  .scopes();
+fn read_language_specific_rules(language_name: &str) -> Rules{
+  match language_name {
+      "java" => parse_toml(include_str!("cleanup_rules/java/rules.toml")), 
+      "kt" => parse_toml(include_str!("cleanup_rules/kt/rules.toml")), 
+      "swift" => parse_toml(include_str!("cleanup_rules/kt/rules.toml")), 
+      _ => Rules::default()
+  }
+}
+
+fn read_language_specific_edges(language_name: &str) -> Edges{
+  match language_name {
+      "java" => parse_toml(include_str!("cleanup_rules/java/edges.toml")), 
+      "kt" => parse_toml(include_str!("cleanup_rules/kt/edges.toml")), 
+      _ => Edges::default()
+  }
+}
+
+fn read_scope_config(language_name: &str) -> Vec<ScopeGenerator>{
+  match language_name {
+      "java" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/java/scope_config.toml")).scopes(), 
+      "kt" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/kt/scope_config.toml")).scopes(),
+      "swift" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/swift/scope_config.toml")).scopes(), 
+      _ => Vec::new()
+  }
+}
+
+pub(crate) fn read_config_files(
+    args: &PiranhaArguments,
+  ) -> (Vec<Rule>, Vec<OutgoingEdges>, Vec<ScopeGenerator>) {
+    let path_to_config = Path::new(args.path_to_configurations());
+    // Read the language specific cleanup rules and edges
+    let language_rules: Rules = read_language_specific_rules(args.language_name());
+    let language_edges: Edges = read_language_specific_edges(args.language_name());
+    let scopes = read_scope_config(args.language_name());
 
   // Read the API specific cleanup rules and edges
   let mut input_rules: Rules = read_toml(&path_to_config.join("rules.toml"), true);

--- a/polyglot/piranha/src/config.rs
+++ b/polyglot/piranha/src/config.rs
@@ -22,10 +22,10 @@ use crate::{
     rule::{Rule, Rules},
     scopes::{ScopeConfig, ScopeGenerator},
   },
-  utilities::{read_toml, parse_toml},
+  utilities::{parse_toml, read_toml},
 };
 
-use std::path::{Path};
+use std::path::Path;
 
 use clap::Parser;
 
@@ -44,41 +44,44 @@ pub(crate) struct CommandLineArguments {
   pub(crate) path_to_output_summary: Option<String>,
 }
 
-
-fn read_language_specific_rules(language_name: &str) -> Rules{
+fn read_language_specific_rules(language_name: &str) -> Rules {
   match language_name {
-      "java" => parse_toml(include_str!("cleanup_rules/java/rules.toml")), 
-      "kt" => parse_toml(include_str!("cleanup_rules/kt/rules.toml")), 
-      "swift" => parse_toml(include_str!("cleanup_rules/kt/rules.toml")), 
-      _ => Rules::default()
+    "java" => parse_toml(include_str!("cleanup_rules/java/rules.toml")),
+    "kt" => parse_toml(include_str!("cleanup_rules/kt/rules.toml")),
+    "swift" => parse_toml(include_str!("cleanup_rules/kt/rules.toml")),
+    _ => Rules::default(),
   }
 }
 
-fn read_language_specific_edges(language_name: &str) -> Edges{
+fn read_language_specific_edges(language_name: &str) -> Edges {
   match language_name {
-      "java" => parse_toml(include_str!("cleanup_rules/java/edges.toml")), 
-      "kt" => parse_toml(include_str!("cleanup_rules/kt/edges.toml")), 
-      _ => Edges::default()
+    "java" => parse_toml(include_str!("cleanup_rules/java/edges.toml")),
+    "kt" => parse_toml(include_str!("cleanup_rules/kt/edges.toml")),
+    _ => Edges::default(),
   }
 }
 
-fn read_scope_config(language_name: &str) -> Vec<ScopeGenerator>{
+fn read_scope_config(language_name: &str) -> Vec<ScopeGenerator> {
   match language_name {
-      "java" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/java/scope_config.toml")).scopes(), 
-      "kt" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/kt/scope_config.toml")).scopes(),
-      "swift" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/swift/scope_config.toml")).scopes(), 
-      _ => Vec::new()
+    "java" => {
+      parse_toml::<ScopeConfig>(include_str!("cleanup_rules/java/scope_config.toml")).scopes()
+    }
+    "kt" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/kt/scope_config.toml")).scopes(),
+    "swift" => {
+      parse_toml::<ScopeConfig>(include_str!("cleanup_rules/swift/scope_config.toml")).scopes()
+    }
+    _ => Vec::new(),
   }
 }
 
 pub(crate) fn read_config_files(
-    args: &PiranhaArguments,
-  ) -> (Vec<Rule>, Vec<OutgoingEdges>, Vec<ScopeGenerator>) {
-    let path_to_config = Path::new(args.path_to_configurations());
-    // Read the language specific cleanup rules and edges
-    let language_rules: Rules = read_language_specific_rules(args.language_name());
-    let language_edges: Edges = read_language_specific_edges(args.language_name());
-    let scopes = read_scope_config(args.language_name());
+  args: &PiranhaArguments,
+) -> (Vec<Rule>, Vec<OutgoingEdges>, Vec<ScopeGenerator>) {
+  let path_to_config = Path::new(args.path_to_configurations());
+  // Read the language specific cleanup rules and edges
+  let language_rules: Rules = read_language_specific_rules(args.language_name());
+  let language_edges: Edges = read_language_specific_edges(args.language_name());
+  let scopes = read_scope_config(args.language_name());
 
   // Read the API specific cleanup rules and edges
   let mut input_rules: Rules = read_toml(&path_to_config.join("rules.toml"), true);

--- a/polyglot/piranha/src/lib.rs
+++ b/polyglot/piranha/src/lib.rs
@@ -106,20 +106,29 @@ pub fn execute_piranha(
 }
 
 fn log_the_summary(summaries: &Vec<PiranhaOutputSummary>) {
-    let mut total_number_of_matches : usize = summaries.iter().map(|x|x.matches().len()).sum();
-    let mut total_number_of_rewrites : usize = summaries.iter().map(|x|x.rewrites().len()).sum();
-    for summary in summaries {
-      let number_of_rewrites =&summary.rewrites().len();
-      let number_of_matches = &summary.matches().len();
-      info!("File : {:?}", &summary.path());
-      info!("{}", format!("# Rewrites : {number_of_rewrites}"));
-      info!("{}", format!("# Matches : {number_of_matches}"));
-      total_number_of_rewrites += number_of_rewrites;
-      total_number_of_matches += number_of_matches;
-    }
-    info!("{}", format!("Total files affected/matched {}", &summaries.len()));
-    info!("{}", format!("Total number of matches {total_number_of_matches}"));
-    info!("{}", format!("Total number of rewrites {total_number_of_rewrites}"));
+  let mut total_number_of_matches: usize = summaries.iter().map(|x| x.matches().len()).sum();
+  let mut total_number_of_rewrites: usize = summaries.iter().map(|x| x.rewrites().len()).sum();
+  for summary in summaries {
+    let number_of_rewrites = &summary.rewrites().len();
+    let number_of_matches = &summary.matches().len();
+    info!("File : {:?}", &summary.path());
+    info!("{}", format!("# Rewrites : {number_of_rewrites}"));
+    info!("{}", format!("# Matches : {number_of_matches}"));
+    total_number_of_rewrites += number_of_rewrites;
+    total_number_of_matches += number_of_matches;
+  }
+  info!(
+    "{}",
+    format!("Total files affected/matched {}", &summaries.len())
+  );
+  info!(
+    "{}",
+    format!("Total number of matches {total_number_of_matches}")
+  );
+  info!(
+    "{}",
+    format!("Total number of rewrites {total_number_of_rewrites}")
+  );
 }
 
 impl SourceCodeUnit {

--- a/polyglot/piranha/src/main.rs
+++ b/polyglot/piranha/src/main.rs
@@ -14,7 +14,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 //! Defines the entry-point for Piranha.
 use std::{fs, time::Instant};
 
-use log::{info, debug};
+use log::{debug, info};
 use polyglot_piranha::{
   execute_piranha, models::piranha_arguments::PiranhaArguments,
   models::piranha_output::PiranhaOutputSummary,

--- a/polyglot/piranha/src/models/piranha_arguments.rs
+++ b/polyglot/piranha/src/models/piranha_arguments.rs
@@ -65,13 +65,12 @@ pub struct PiranhaArguments {
   /// parent scoped rules
   #[getset(get = "pub")]
   number_of_ancestors_in_parent_scope: u8,
-  /// The number of lines to consider for cleaning up the comments 
+  /// The number of lines to consider for cleaning up the comments
   #[getset(get = "pub")]
   cleanup_comments_buffer: usize,
   /// The AST Kinds for which comments should be deleted
   #[getset(get = "pub")]
   cleanup_comments: bool,
-  
 }
 
 impl PiranhaArguments {
@@ -111,11 +110,11 @@ impl PiranhaArguments {
       args_builder.global_tag_prefix(v);
     }
 
-    if let Some(buffer_size) = piranha_args_from_config.cleanup_comments_buffer(){
+    if let Some(buffer_size) = piranha_args_from_config.cleanup_comments_buffer() {
       args_builder.cleanup_comments_buffer(buffer_size);
     }
 
-    if let Some(ast_kinds) = piranha_args_from_config.cleanup_comments(){
+    if let Some(ast_kinds) = piranha_args_from_config.cleanup_comments() {
       args_builder.cleanup_comments(ast_kinds);
     }
 

--- a/polyglot/piranha/src/models/piranha_output.rs
+++ b/polyglot/piranha/src/models/piranha_output.rs
@@ -1,4 +1,3 @@
-
 /*
 Copyright (c) 2022 Uber Technologies, Inc.
 

--- a/polyglot/piranha/src/models/rule.rs
+++ b/polyglot/piranha/src/models/rule.rs
@@ -222,14 +222,17 @@ impl Rule {
     source_code_unit: &SourceCodeUnit, previous_edit_start: usize, previous_edit_end: usize,
     rules_store: &mut RuleStore, rules: &Vec<Rule>,
   ) -> Option<Edit> {
-    let number_of_ancestors_in_parent_scope = *rules_store
-      .get_number_of_ancestors_in_parent_scope();
+    let number_of_ancestors_in_parent_scope =
+      *rules_store.get_number_of_ancestors_in_parent_scope();
     let changed_node = get_node_for_range(
       source_code_unit.root_node(),
       previous_edit_start,
       previous_edit_end,
     );
-    debug!("\n{}", format!("Changed node kind {}", changed_node.kind()).blue());
+    debug!(
+      "\n{}",
+      format!("Changed node kind {}", changed_node.kind()).blue()
+    );
     // Context contains -  the changed node in the previous edit, its's parent, grand parent and great grand parent
     let context = || {
       get_context(
@@ -304,7 +307,7 @@ impl Rule {
       .map(|p_match| {
         let replacement = substitute_tags(self.replace(), p_match.matches(), false);
         let edit = Edit::new(p_match.clone(), replacement, self.name());
-        trace!("Rewrite found : {:#?}", edit );
+        trace!("Rewrite found : {:#?}", edit);
         edit
       });
   }

--- a/polyglot/piranha/src/models/rule_graph.rs
+++ b/polyglot/piranha/src/models/rule_graph.rs
@@ -15,7 +15,7 @@ use crate::{
   models::{outgoing_edges::OutgoingEdges, rule::Rule},
   utilities::MapOfVec,
 };
-use std::collections::{HashMap};
+use std::collections::HashMap;
 
 #[derive(Debug)]
 pub(crate) struct RuleGraph(HashMap<String, Vec<(String, String)>>);
@@ -64,9 +64,9 @@ impl RuleGraph {
 
   /// Get the number of nodes and edges in the rule graph
   pub(crate) fn get_number_of_rules_and_edges(&self) -> (usize, usize) {
-    let mut edges  = 0;
+    let mut edges = 0;
     for (_, destinations) in &self.0 {
-        edges += destinations.len();
+      edges += destinations.len();
     }
     (self.0.len(), edges)
   }

--- a/polyglot/piranha/src/models/rule_store.rs
+++ b/polyglot/piranha/src/models/rule_store.rs
@@ -14,7 +14,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 use std::collections::HashMap;
 
 use colored::Colorize;
-use log::{info, debug, trace};
+use log::{debug, info, trace};
 use tree_sitter::{Language, Query};
 
 use crate::{
@@ -68,7 +68,10 @@ impl RuleStore {
         rule_store.add_to_global_rules(&rule, args.input_substitutions());
       }
     }
-    info!("Number of rules and edges loaded : {:?}", rule_store.rule_graph.get_number_of_rules_and_edges());
+    info!(
+      "Number of rules and edges loaded : {:?}",
+      rule_store.rule_graph.get_number_of_rules_and_edges()
+    );
     trace!("Rule Store {}", format!("{:#?}", rule_store));
     rule_store
   }
@@ -180,7 +183,7 @@ impl RuleStore {
   }
 
   pub(crate) fn piranha_args(&self) -> &PiranhaArguments {
-      &self.piranha_args
+    &self.piranha_args
   }
 }
 

--- a/polyglot/piranha/src/models/scopes.rs
+++ b/polyglot/piranha/src/models/scopes.rs
@@ -64,7 +64,11 @@ impl ScopeGenerator {
 
     // Match the `scope_matcher.matcher` to the parent
     loop {
-      trace!("Getting scope {} for node kind {}", scope_level, changed_node.kind());
+      trace!(
+        "Getting scope {} for node kind {}",
+        scope_level,
+        changed_node.kind()
+      );
       for m in &scope_matchers {
         if let Some(p_match) = changed_node.get_match_for_query(
           &source_code_unit.code(),

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -1,4 +1,3 @@
-
 /*
 Copyright (c) 2022 Uber Technologies, Inc.
 
@@ -17,7 +16,7 @@ use std::{
   path::{Path, PathBuf},
 };
 
-use log::{debug};
+use log::debug;
 use regex::Regex;
 use tree_sitter::{InputEdit, Node, Parser, Range, Tree};
 use tree_sitter_traversal::{traverse, Order};
@@ -132,7 +131,9 @@ impl SourceCodeUnit {
     let mut relevant_nodes_are_comments = true;
     let mut comment_range = None;
     // Since the previous edit was a delete, the start and end of the replacement range is [start_byte].
-    let node = self.ast.root_node()
+    let node = self
+      .ast
+      .root_node()
       .descendant_for_byte_range(start_byte, start_byte)
       .unwrap_or(self.ast.root_node());
 

--- a/polyglot/piranha/src/models/unit_tests/rule_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/rule_test.rs
@@ -90,7 +90,7 @@ fn test_get_edit_positive_recursive() {
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args()
+    rule_store.piranha_args(),
   );
   let node = source_code_unit.root_node();
   let matches = rule.get_matches(&source_code_unit, &mut rule_store, node, true);
@@ -137,7 +137,7 @@ fn test_get_edit_negative_recursive() {
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args()
+    rule_store.piranha_args(),
   );
   let node = source_code_unit.root_node();
   let matches = rule.get_matches(&source_code_unit, &mut rule_store, node, true);
@@ -177,7 +177,7 @@ fn test_get_edit_for_context_positive() {
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args()
+    rule_store.piranha_args(),
   );
   let edit = Rule::get_edit_for_context(
     &source_code_unit,
@@ -222,7 +222,7 @@ fn test_get_edit_for_context_negative() {
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args()
+    rule_store.piranha_args(),
   );
   let edit = Rule::get_edit_for_context(
     &source_code_unit,

--- a/polyglot/piranha/src/models/unit_tests/scopes_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/scopes_test.rs
@@ -76,7 +76,7 @@ fn test_get_scope_query_positive() {
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args()
+    rule_store.piranha_args(),
   );
 
   let scope_query_method = ScopeGenerator::get_scope_query(
@@ -170,7 +170,7 @@ fn test_get_scope_query_negative() {
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args()
+    rule_store.piranha_args(),
   );
 
   let _ = ScopeGenerator::get_scope_query(source_code_unit, "Method", 133, 134, &mut rule_store);

--- a/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
@@ -38,7 +38,10 @@ impl SourceCodeUnit {
       content.to_string(),
       &HashMap::new(),
       PathBuf::new().as_path(),
-      &PiranhaArgumentsBuilder::default().language_name(language_name).build().unwrap()
+      &PiranhaArgumentsBuilder::default()
+        .language_name(language_name)
+        .build()
+        .unwrap(),
     )
   }
 }
@@ -73,7 +76,7 @@ fn test_apply_edit_positive() {
         }
       }
     }";
-  
+
   let language_name = String::from("java");
   let mut parser = get_parser(language_name.to_string());
 
@@ -81,7 +84,7 @@ fn test_apply_edit_positive() {
 
   let _ = source_code_unit.apply_edit(
     &Edit::dummy_edit(range(49, 78, 3, 9, 3, 38), String::new()),
-    &mut parser
+    &mut parser,
   );
   assert!(eq_without_whitespace(
     &source_code.replace("boolean isFlagTreated = true;", ""),
@@ -102,14 +105,14 @@ fn test_apply_edit_negative() {
         }
       }
     }";
-  
+
   let language_name = String::from("java");
   let mut parser = get_parser(language_name.to_string());
   let mut source_code_unit = SourceCodeUnit::default(source_code, &mut parser, language_name);
 
   let _ = source_code_unit.apply_edit(
     &Edit::dummy_edit(range(1000, 2000, 0, 0, 0, 0), String::new()),
-    &mut parser
+    &mut parser,
   );
 }
 
@@ -131,7 +134,7 @@ fn test_apply_edit_comma_handling_via_grammar() {
 
   let _ = source_code_unit.apply_edit(
     &Edit::dummy_edit(range(37, 47, 2, 26, 2, 36), String::new()),
-    &mut parser
+    &mut parser,
   );
   assert!(eq_without_whitespace(
     &source_code.replace("\"NullAway\",", ""),
@@ -151,7 +154,6 @@ fn test_apply_edit_comma_handling_via_regex() {
   }
 }";
 
-
   let language_name = String::from("swift");
 
   let mut parser = get_parser(language_name.to_string());
@@ -160,7 +162,7 @@ fn test_apply_edit_comma_handling_via_regex() {
 
   let _ = source_code_unit.apply_edit(
     &Edit::dummy_edit(range(59, 75, 3, 23, 3, 41), String::new()),
-    &mut parser
+    &mut parser,
   );
   assert!(eq_without_whitespace(
     &source_code.replace("name: \"BMX Bike\",", ""),
@@ -176,13 +178,16 @@ fn execute_persist_in_temp_folder(
   let tmp_dir = TempDir::new("example")?;
   let file_path = &tmp_dir.path().join("Sample1.java");
   _ = fs::write(&file_path.as_path(), source_code);
-  let piranha_args = PiranhaArgumentsBuilder::default().language_name(language_name).build().unwrap();
+  let piranha_args = PiranhaArgumentsBuilder::default()
+    .language_name(language_name)
+    .build()
+    .unwrap();
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
     source_code.to_string(),
     &HashMap::new(),
     file_path.as_path(),
-    &piranha_args
+    &piranha_args,
   );
   source_code_unit.persist(args);
   check_predicate(&tmp_dir)

--- a/polyglot/piranha/src/utilities/mod.rs
+++ b/polyglot/piranha/src/utilities/mod.rs
@@ -55,7 +55,7 @@ pub(crate) fn parse_toml<T>(content: &str) -> T
 where
   T: serde::de::DeserializeOwned + Default,
 {
- return toml::from_str::<T>(content).unwrap();
+  return toml::from_str::<T>(content).unwrap();
 }
 
 pub(crate) trait MapOfVec<T, V> {
@@ -98,9 +98,6 @@ pub(crate) fn find_file(input_dir: &PathBuf, name: &str) -> PathBuf {
     .unwrap()
     .path()
 }
-
-
-
 
 #[cfg(test)]
 #[path = "unit_tests/utilities_test.rs"]

--- a/polyglot/piranha/src/utilities/mod.rs
+++ b/polyglot/piranha/src/utilities/mod.rs
@@ -51,6 +51,13 @@ where
   }
 }
 
+pub(crate) fn parse_toml<T>(content: &str) -> T
+where
+  T: serde::de::DeserializeOwned + Default,
+{
+ return toml::from_str::<T>(content).unwrap();
+}
+
 pub(crate) trait MapOfVec<T, V> {
   fn collect(&mut self, key: T, value: V);
 }
@@ -91,6 +98,9 @@ pub(crate) fn find_file(input_dir: &PathBuf, name: &str) -> PathBuf {
     .unwrap()
     .path()
 }
+
+
+
 
 #[cfg(test)]
 #[path = "unit_tests/utilities_test.rs"]

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use colored::Colorize;
 use itertools::Itertools;
-use log::{debug};
+use log::debug;
 use std::collections::HashMap;
 #[cfg(test)]
 use tree_sitter::Parser;
@@ -33,7 +33,7 @@ pub(crate) trait TreeSitterHelpers {
   /// Compiles query string to `tree_sitter::Query`
   fn create_query(&self, language: Language) -> Query;
   /// Determines if the given node kind is a comment for the respective language (`self`)
-  fn is_comment(&self, kind: &str) -> bool ;
+  fn is_comment(&self, kind: &str) -> bool;
 }
 
 impl TreeSitterHelpers for String {

--- a/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
+++ b/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
@@ -1,4 +1,3 @@
-
 /*
 Copyright (c) 2022 Uber Technologies, Inc.
 
@@ -18,7 +17,7 @@ use std::{
 
 use tree_sitter::Query;
 
-use crate::models::piranha_arguments::{PiranhaArgumentsBuilder};
+use crate::models::piranha_arguments::PiranhaArgumentsBuilder;
 
 use {
   super::{get_parser, substitute_tags, PiranhaHelpers, TreeSitterHelpers},
@@ -168,13 +167,16 @@ fn test_satisfies_constraints_positive() {
   let mut rule_store = RuleStore::dummy();
   let language_name = String::from("java");
   let mut parser = get_parser(language_name.to_string());
-  let piranha_args = PiranhaArgumentsBuilder::default().language_name(language_name).build().unwrap();
+  let piranha_args = PiranhaArgumentsBuilder::default()
+    .language_name(language_name)
+    .build()
+    .unwrap();
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    &piranha_args
+    &piranha_args,
   );
 
   let node = &source_code_unit
@@ -232,13 +234,16 @@ fn test_satisfies_constraints_negative() {
   let mut rule_store = RuleStore::dummy();
   let language_name = String::from("java");
   let mut parser = get_parser(language_name.to_string());
-  let piranha_arguments = &PiranhaArgumentsBuilder::default().language_name(language_name).build().unwrap();
+  let piranha_arguments = &PiranhaArgumentsBuilder::default()
+    .language_name(language_name)
+    .build()
+    .unwrap();
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    piranha_arguments
+    piranha_arguments,
   );
 
   let node = &source_code_unit

--- a/polyglot/piranha/src/utilities/unit_tests/utilities_test.rs
+++ b/polyglot/piranha/src/utilities/unit_tests/utilities_test.rs
@@ -1,4 +1,3 @@
-
 /*
 Copyright (c) 2022 Uber Technologies, Inc.
 


### PR DESCRIPTION
Since we know the path to the language specific rules/edges/scopes at static time, we can use the `include_str!` feature. 