### PR TITLE
Onboarding python

### DIFF
--- a/polyglot/piranha/Cargo.toml
+++ b/polyglot/piranha/Cargo.toml
@@ -43,6 +43,7 @@ tree-sitter-kotlin = { git = "https://github.com/ketkarameya/tree-sitter-kotlin.
 tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java.git" }
 tree-sitter-swift = { git = "https://github.com/ketkarameya/tree-sitter-swift.git", branch = "add_parser" }
 tree-sitter-strings = { git = "https://github.com/ketkarameya/tree-sitter-strings.git" }
+tree-sitter-python = { git = "https://github.com/tree-sitter/tree-sitter-python.git" }
 derive_builder = "0.11.2"
 getset = "0.1.2"
 pyo3 =  "0.17.1"

--- a/polyglot/piranha/README.md
+++ b/polyglot/piranha/README.md
@@ -178,7 +178,7 @@ The output JSON is the serialization of- [`PiranhaOutputSummary`](/polyglot/pira
 | Java + Kotlin    | :x:                         | :calendar:                               | :calendar:                           |
 | Swift            | :heavy_check_mark:          | :construction:                           | :construction:                       |
 | Go               | :construction:              | :construction:                           | :construction:                       |
-| Python           | :calendar:                  | :calendar:                               | :calendar:                           |
+| Python           | :heavy_check_mark:          | :calendar:                               | :calendar:                           |
 | TypeScript       | :calendar:                  | :calendar:                               | :calendar:                           |
 | C#               | :calendar:                  | :calendar:                               | :calendar:                           |
 | JavaScript       | :calendar:                  | :calendar:                               | :calendar:                           |

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/edges.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/edges.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+scope = "Parent"
+from = "delete_str_literal_in_list"
+to = ["delete_empty_list_assignment"]

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/piranha_arguments.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["py"]
+substitutions = [
+    ["str_literal", "dependency2"]
+]

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/piranha_arguments.toml
@@ -11,5 +11,7 @@
 
 language = ["py"]
 substitutions = [
-    ["str_literal", "dependency2"]
+    ["str_literal", "dependency2"],
+    ["str_to_replace", "dependency1"],
+    ["str_replacement", "dependency1_1"]
 ]

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/rules.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/rules.toml
@@ -1,0 +1,78 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains rules to the specific feature flag API.
+
+# Deletes the single quote string literal inside a list
+# For @str_literal = dep
+# Before
+#  a = [ 'a', 'dep', 'c']
+# After
+#  a = [ 'a', 'c']
+#
+[[rules]]
+name = "delete_str_literal_single_quote_in_list"
+groups = ["delete_str_literal_in_list"]
+query = """
+(
+    (list
+        (string) @s
+        (_)*
+    ) @ls
+    (#eq? @s "'@str_literal'")
+)
+"""
+replace_node = "s"
+replace = ""
+holes = ["str_literal"]
+
+# Deletes the double quote string literal inside a list
+# For @str_literal = dep
+# Before
+#  a = [ "a", "dep", "c"]
+# After
+#  a = [ "a", "c"]
+#
+[[rules]]
+name = "delete_str_literal_double_quote_in_list"
+groups = ["delete_str_literal_in_list"]
+query = """
+(
+    (list
+        (string) @s
+        (_)*
+    ) @ls
+    (#eq? @s "\\"@str_literal\\"")
+)
+"""
+replace_node = "s"
+replace = ""
+holes = ["str_literal"]
+
+# Deletes an assignment to an empty list. Example: `a = []`
+#
+# Note the multiple escapes (`\`) for the regex below
+# `\[` (match the `[` character) -> `\\\\[`
+# `\s*` (match zero or more empty spaces) -> `\\\\s*`
+[[rules]]
+name = "delete_empty_list_assignment"
+groups = ["Cleanup Rule"]
+query = """
+(
+(assignment
+    	left: (_) @i
+        right: (list) @list
+) @assignment
+(#match? @list "\\\\[\\\\s*,?\\\\]")
+)
+"""
+replace_node = "@assignment"
+replace = ""

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/rules.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/rules.toml
@@ -47,10 +47,10 @@ groups = ["delete_str_literal_in_list"]
 query = """
 (
     (list
-        (string) @s
+        (string) @string_literal
         (_)*
     ) @ls
-    (#eq? @s "\\"@str_literal\\"")
+    (#eq? @string_literal "\\"@str_literal\\"")
 )
 """
 replace_node = "s"

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/rules.toml
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/python/configurations/rules.toml
@@ -9,7 +9,49 @@
 # express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file contains rules to the specific feature flag API.
+# Replaces the single quote string literal inside a list
+# For @str_replacement = "a" and @str_replace = "z"
+# Before
+#  a = [ 'a', 'b', 'c']
+# After
+#  a = [ 'z', 'b', 'c']
+#
+[[rules]]
+name = "replace_str_literal_single_quote_in_list"
+query = """
+(
+    (list
+        (string) @string_literal
+        (_)*
+    ) @ls
+    (#eq? @string_literal "'@str_to_replace'")
+)
+"""
+replace_node = "string_literal"
+replace = "'@str_replacement'"
+holes = ["str_to_replace", "str_replacement"]
+
+# Replaces the double quote string literal inside a list
+# For @str_replacement = "a" and @double_quote_str_replacement = "z"
+# Before
+#  a = [ "a", "b", "c"]
+# After
+#  a = [ "z", "b", "c"]
+#
+[[rules]]
+name = "replace_str_literal_double_quote_in_list"
+query = """
+(
+    (list
+        (string) @string_literal
+        (_)*
+    ) @ls
+    (#eq? @string_literal "\\"@str_to_replace\\"")
+)
+"""
+replace_node = "string_literal"
+replace = "\"@str_replacement\""
+holes = ["str_to_replace", "str_replacement"]
 
 # Deletes the single quote string literal inside a list
 # For @str_literal = dep
@@ -24,13 +66,13 @@ groups = ["delete_str_literal_in_list"]
 query = """
 (
     (list
-        (string) @s
+        (string) @string_literal
         (_)*
     ) @ls
-    (#eq? @s "'@str_literal'")
+    (#eq? @string_literal "'@str_literal'")
 )
 """
-replace_node = "s"
+replace_node = "string_literal"
 replace = ""
 holes = ["str_literal"]
 
@@ -53,7 +95,7 @@ query = """
     (#eq? @string_literal "\\"@str_literal\\"")
 )
 """
-replace_node = "s"
+replace_node = "string_literal"
 replace = ""
 holes = ["str_literal"]
 

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/python/only_lists.py
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/python/only_lists.py
@@ -1,3 +1,14 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
 deps = ['dependency1', 'dependency2', 'dependency3']
 nums = [1, 2, 3]
 deps2 = ["dependency2", "dependency1"]

--- a/polyglot/piranha/demo/find_replace_custom_cleanup/python/only_lists.py
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup/python/only_lists.py
@@ -1,0 +1,5 @@
+deps = ['dependency1', 'dependency2', 'dependency3']
+nums = [1, 2, 3]
+deps2 = ["dependency2", "dependency1"]
+deps3 = ['dependency2']
+empty_list = []

--- a/polyglot/piranha/demo/find_replace_custom_cleanup_demos.py
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup_demos.py
@@ -20,6 +20,7 @@ def python_demo():
     The string literal can be a single quotes or double quotes python string.
     Also deletes an assignment to an empty list if @str_literal is the only element of the list.
     The purpose of having `empty_list` is to demonstrate that the empty list assignment is only triggered as a consequence of the seed rule.
+    Finally, replaces the string literal `@str_to_replace` with `@str_replacement` (from `substitutions` in `piranha_arguments.toml`) if it appears as a list element.
     """
     print("Running the Find/Replace Custom Cleanup demo for Python")
     _ = run_piranha_cli(join(find_Replace_dir, "python"), join(find_Replace_dir, "python/configurations"), True)

--- a/polyglot/piranha/demo/find_replace_custom_cleanup_demos.py
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup_demos.py
@@ -16,7 +16,7 @@ def java_demo():
 
 def python_demo():
     """
-    Deletes the @str_literal (substitution in `piranha_arguments`) string literal when present as list element.
+    Deletes the string literal `@str_literal` (from `substitutions` in `piranha_arguments.toml`) if it appears as a list element.
     The string literal can be a single quotes or double quotes python string.
     Also deletes an assignment to an empty list if @str_literal is the only element of the list.
     The purpose of having `empty_list` is to demonstrate that the empty list assignment is only triggered as a consequence of the seed rule.

--- a/polyglot/piranha/demo/find_replace_custom_cleanup_demos.py
+++ b/polyglot/piranha/demo/find_replace_custom_cleanup_demos.py
@@ -14,5 +14,16 @@ def java_demo():
     print("Running the Find/Replace Custom Cleanup demo for Java")
     _ = run_piranha_cli(join(find_Replace_dir, "java"), join(find_Replace_dir, "java/configurations"), True)
 
+def python_demo():
+    """
+    Deletes the @str_literal (substitution in `piranha_arguments`) string literal when present as list element.
+    The string literal can be a single quotes or double quotes python string.
+    Also deletes an assignment to an empty list if @str_literal is the only element of the list.
+    The purpose of having `empty_list` is to demonstrate that the empty list assignment is only triggered as a consequence of the seed rule.
+    """
+    print("Running the Find/Replace Custom Cleanup demo for Python")
+    _ = run_piranha_cli(join(find_Replace_dir, "python"), join(find_Replace_dir, "python/configurations"), True)
+
 java_demo()
+python_demo()
 print("Completed running the Find/Replace Custom Cleanup demos")

--- a/polyglot/piranha/src/tests/mod.rs
+++ b/polyglot/piranha/src/tests/mod.rs
@@ -28,6 +28,8 @@ mod test_piranha_strings;
 
 mod test_piranha_swift;
 
+mod test_piranha_python;
+
 use std::sync::Once;
 
 static INIT: Once = Once::new();

--- a/polyglot/piranha/src/tests/test_piranha_python.rs
+++ b/polyglot/piranha/src/tests/test_piranha_python.rs
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2022 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+use super::{initialize, run_match_test};
+
+static LANGUAGE: &str = "python";
+
+#[test]
+fn test_python_match_only() {
+  initialize();
+  run_match_test(&format!("{}/{}", LANGUAGE, "structural_find"), 3);
+}

--- a/polyglot/piranha/src/tests/test_piranha_python.rs
+++ b/polyglot/piranha/src/tests/test_piranha_python.rs
@@ -11,9 +11,18 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use super::{initialize, run_match_test};
+use super::{initialize, run_match_test, run_rewrite_test};
 
 static LANGUAGE: &str = "python";
+
+#[test]
+fn test_python_delete_str_literal_from_list() {
+  initialize();
+  run_rewrite_test(
+    &format!("{}/{}", LANGUAGE, "delete_cleanup_str_in_list"),
+    1,
+  );
+}
 
 #[test]
 fn test_python_match_only() {

--- a/polyglot/piranha/src/tests/test_piranha_python.rs
+++ b/polyglot/piranha/src/tests/test_piranha_python.rs
@@ -16,7 +16,7 @@ use super::{initialize, run_match_test, run_rewrite_test};
 static LANGUAGE: &str = "python";
 
 #[test]
-fn test_python_delete_str_literal_from_list() {
+fn test_python_delete_modify_str_literal_from_list() {
   initialize();
   run_rewrite_test(
     &format!("{}/{}", LANGUAGE, "delete_cleanup_str_in_list"),

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -49,6 +49,7 @@ impl TreeSitterHelpers for String {
     match self.as_str() {
       "java" => tree_sitter_java::language(),
       "kt" => tree_sitter_kotlin::language(),
+      "py" => tree_sitter_python::language(),
       "swift" => tree_sitter_swift::language(),
       "strings" => tree_sitter_strings::language(),
       _ => panic!("Language not supported"),

--- a/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/configurations/edges.toml
+++ b/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/configurations/edges.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+scope = "Parent"
+from = "delete_str_literal_in_list"
+to = ["delete_empty_list_assignment"]

--- a/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/configurations/piranha_arguments.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["py"]
+substitutions = [
+    ["str_literal", "dependency2"]
+]

--- a/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/configurations/piranha_arguments.toml
@@ -11,5 +11,7 @@
 
 language = ["py"]
 substitutions = [
-    ["str_literal", "dependency2"]
+    ["str_literal", "dependency2"],
+    ["str_to_replace", "dependency1"],
+    ["str_replacement", "dependency1_1"]
 ]

--- a/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/configurations/rules.toml
@@ -9,7 +9,49 @@
 # express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file contains rules to the specific feature flag API.
+# Replaces the single quote string literal inside a list
+# For @str_replacement = "a" and @str_replace = "z"
+# Before
+#  a = [ 'a', 'b', 'c']
+# After
+#  a = [ 'z', 'b', 'c']
+#
+[[rules]]
+name = "replace_str_literal_single_quote_in_list"
+query = """
+(
+    (list
+        (string) @string_literal
+        (_)*
+    ) @ls
+    (#eq? @string_literal "'@str_to_replace'")
+)
+"""
+replace_node = "string_literal"
+replace = "'@str_replacement'"
+holes = ["str_to_replace", "str_replacement"]
+
+# Replaces the double quote string literal inside a list
+# For @str_replacement = "a" and @double_quote_str_replacement = "z"
+# Before
+#  a = [ "a", "b", "c"]
+# After
+#  a = [ "z", "b", "c"]
+#
+[[rules]]
+name = "replace_str_literal_double_quote_in_list"
+query = """
+(
+    (list
+        (string) @string_literal
+        (_)*
+    ) @ls
+    (#eq? @string_literal "\\"@str_to_replace\\"")
+)
+"""
+replace_node = "string_literal"
+replace = "\"@str_replacement\""
+holes = ["str_to_replace", "str_replacement"]
 
 # Deletes the single quote string literal inside a list
 # For @str_literal = dep
@@ -24,13 +66,13 @@ groups = ["delete_str_literal_in_list"]
 query = """
 (
     (list
-        (string) @s
+        (string) @string_literal
         (_)*
     ) @ls
-    (#eq? @s "'@str_literal'")
+    (#eq? @string_literal "'@str_literal'")
 )
 """
-replace_node = "s"
+replace_node = "string_literal"
 replace = ""
 holes = ["str_literal"]
 
@@ -47,13 +89,13 @@ groups = ["delete_str_literal_in_list"]
 query = """
 (
     (list
-        (string) @s
+        (string) @string_literal
         (_)*
     ) @ls
-    (#eq? @s "\\"@str_literal\\"")
+    (#eq? @string_literal "\\"@str_literal\\"")
 )
 """
-replace_node = "s"
+replace_node = "string_literal"
 replace = ""
 holes = ["str_literal"]
 

--- a/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/configurations/rules.toml
@@ -1,0 +1,78 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains rules to the specific feature flag API.
+
+# Deletes the single quote string literal inside a list
+# For @str_literal = dep
+# Before
+#  a = [ 'a', 'dep', 'c']
+# After
+#  a = [ 'a', 'c']
+#
+[[rules]]
+name = "delete_str_literal_single_quote_in_list"
+groups = ["delete_str_literal_in_list"]
+query = """
+(
+    (list
+        (string) @s
+        (_)*
+    ) @ls
+    (#eq? @s "'@str_literal'")
+)
+"""
+replace_node = "s"
+replace = ""
+holes = ["str_literal"]
+
+# Deletes the double quote string literal inside a list
+# For @str_literal = dep
+# Before
+#  a = [ "a", "dep", "c"]
+# After
+#  a = [ "a", "c"]
+#
+[[rules]]
+name = "delete_str_literal_double_quote_in_list"
+groups = ["delete_str_literal_in_list"]
+query = """
+(
+    (list
+        (string) @s
+        (_)*
+    ) @ls
+    (#eq? @s "\\"@str_literal\\"")
+)
+"""
+replace_node = "s"
+replace = ""
+holes = ["str_literal"]
+
+# Deletes an assignment to an empty list. Example: `a = []`
+#
+# Note the multiple escapes (`\`) for the regex below
+# `\[` (match the `[` character) -> `\\\\[`
+# `\s*` (match zero or more empty spaces) -> `\\\\s*`
+[[rules]]
+name = "delete_empty_list_assignment"
+groups = ["Cleanup Rule"]
+query = """
+(
+(assignment
+    	left: (_) @i
+        right: (list) @list
+) @assignment
+(#match? @list "\\\\[\\\\s*,?\\\\]")
+)
+"""
+replace_node = "@assignment"
+replace = ""

--- a/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/expected/only_lists.py
+++ b/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/expected/only_lists.py
@@ -1,0 +1,4 @@
+deps = ['dependency1', 'dependency3']
+nums = [1, 2, 3]
+deps2 = ["dependency1"]
+empty_list = []

--- a/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/expected/only_lists.py
+++ b/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/expected/only_lists.py
@@ -1,4 +1,15 @@
-deps = ['dependency1', 'dependency3']
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+deps = ['dependency1_1', 'dependency3']
 nums = [1, 2, 3]
-deps2 = ["dependency1"]
+deps2 = ["dependency1_1"]
 empty_list = []

--- a/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/input/only_lists.py
+++ b/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/input/only_lists.py
@@ -1,3 +1,14 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
 deps = ['dependency1', 'dependency2', 'dependency3']
 nums = [1, 2, 3]
 deps2 = ["dependency2", "dependency1"]

--- a/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/input/only_lists.py
+++ b/polyglot/piranha/test-resources/python/delete_cleanup_str_in_list/input/only_lists.py
@@ -1,0 +1,5 @@
+deps = ['dependency1', 'dependency2', 'dependency3']
+nums = [1, 2, 3]
+deps2 = ["dependency2", "dependency1"]
+deps3 = ['dependency2']
+empty_list = []

--- a/polyglot/piranha/test-resources/python/structural_find/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/python/structural_find/configurations/piranha_arguments.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["py"]
+substitutions = []

--- a/polyglot/piranha/test-resources/python/structural_find/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/python/structural_find/configurations/rules.toml
@@ -12,8 +12,8 @@
 # This file contains rules to the specific feature flag API.
 
 # For the two lists below, the query will match 1 result (the `a` list).
-# a = ['a', 'b']
-# b = [1, 2]
+#  a = ['a', 'b']
+#  b = [1, 2]
 # `@ls` will match lists that contain string literals as elements
 #
 [[rules]]

--- a/polyglot/piranha/test-resources/python/structural_find/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/python/structural_find/configurations/rules.toml
@@ -1,0 +1,28 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains rules to the specific feature flag API.
+
+# For the two lists below, the query will match 1 result (the `a` list).
+# a = ['a', 'b']
+# b = [1, 2]
+# `@ls` will match lists that contain string literals as elements
+#
+[[rules]]
+name = "find_lists_with_str_literals"
+query = """
+(
+    (list
+        (string)+ @s
+        (_)*
+    ) @ls
+)
+"""

--- a/polyglot/piranha/test-resources/python/structural_find/input/list_as_arg.py
+++ b/polyglot/piranha/test-resources/python/structural_find/input/list_as_arg.py
@@ -1,0 +1,13 @@
+func_call(
+    name = "call",
+    deps = [
+        'dependency1',
+        'dependency2',
+        'dependency3',
+    ],
+    nums = [
+        1,
+        2,
+        3,
+    ],
+)

--- a/polyglot/piranha/test-resources/python/structural_find/input/only_lists.py
+++ b/polyglot/piranha/test-resources/python/structural_find/input/only_lists.py
@@ -1,0 +1,3 @@
+deps = ['dependency1', 'dependency2', 'dependency3']
+nums = [1, 2, 3]
+deps2 = ["dependency1"]

--- a/polyglot/piranha/test-resources/python/structural_find/input/only_lists.py
+++ b/polyglot/piranha/test-resources/python/structural_find/input/only_lists.py
@@ -1,3 +1,14 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
 deps = ['dependency1', 'dependency2', 'dependency3']
 nums = [1, 2, 3]
 deps2 = ["dependency1"]


### PR DESCRIPTION
This PR adds the Python grammar as a dependency and a custom cleanup demo.

## Demo

The demo deletes a given string literal that is a list element. If this string literal is the only element, a custom cleanup will delete an assignment to the resulting empty list (e.g., `deps3` in the example below).
It also replaces a string literal that is a list element with another string literal.

Given that:

- the string literal argument to delete is `dependency2`.
- the string literal to replace is `dependency1` and its replacement is `dependency1_1`.

Before

```python
deps = ['dependency1', 'dependency2', 'dependency3']
nums = [1, 2, 3]
deps2 = ["dependency2", "dependency1"]
deps3 = ['dependency2']
empty_list = []
```

After

```python
deps = ['dependency1_1', 'dependency3']
nums = [1, 2, 3]
deps2 = ["dependency1_1"]
empty_list = []
```