### PR TITLE
Simplify `delete trailing comma`  logic (bug fix/enhancement)

### DIFF
--- a/polyglot/piranha/demo/find_replace/java/TestEnum.java
+++ b/polyglot/piranha/demo/find_replace/java/TestEnum.java
@@ -16,7 +16,7 @@ package com.uber.piranha;
 public enum Something implements ExperimentName {
 
   /** Show menu */
-  SHOW_MENU
+  SHOW_MENU,
 
   /** Foobar */
   STALE_FLAG,

--- a/polyglot/piranha/demo/find_replace/java/TestEnum.java
+++ b/polyglot/piranha/demo/find_replace/java/TestEnum.java
@@ -13,6 +13,14 @@
  */
 package com.uber.piranha;
 
-enum TestEnum {
-    STALE_FLAG
+public enum Something implements ExperimentName {
+
+  /** Show menu */
+  SHOW_MENU
+
+  /** Foobar */
+  STALE_FLAG,
+
+  /** barfoo. */
+  BAR_FOO,
 }

--- a/polyglot/piranha/demo/find_replace/java/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/find_replace/java/configurations/piranha_arguments.toml
@@ -13,3 +13,4 @@ language = ["java"]
 substitutions = [
      ["stale_flag_name", "STALE_FLAG"],
 ]
+cleanup_comment=true

--- a/polyglot/piranha/demo/find_replace/java/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/find_replace/java/configurations/piranha_arguments.toml
@@ -13,4 +13,4 @@ language = ["java"]
 substitutions = [
      ["stale_flag_name", "STALE_FLAG"],
 ]
-cleanup_comment=true
+cleanup_comments=true

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -169,7 +169,7 @@ impl SourceCodeUnit {
   pub(crate) fn _apply_edit(
     &mut self, range: Range, replacement_string: &str, parser: &mut Parser,
   ) -> InputEdit {
-
+    // Check if the edit is a `Delete` operation then delete trailing comma
     let replace_range = if replacement_string.trim().is_empty() {
       self.delete_trailing_comma(range)
     } else {
@@ -202,7 +202,6 @@ impl SourceCodeUnit {
   /// IF this closest node is a comma, extend the {new_delete_range} to include the comma.
   fn delete_trailing_comma(&mut self, deleted_range: Range) -> Range {
     let mut new_deleted_range = deleted_range;
-    // Check if the edit is a `Delete` operation
 
     // Get the node immediately after the to-be-deleted code
     if let Some(node_after_to_be_deleted_node) = self

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -195,6 +195,9 @@ impl SourceCodeUnit {
   /// Deletes the trailing comma after the {deleted_range}
   /// # Arguments
   /// * `deleted_range` - the range of the deleted code
+  /// 
+  /// # Returns
+  /// code range of the closest node
   ///
   /// Algorithm: 
   /// Get the node after the {deleted_range}'s end byte (heuristic 5 characters) 

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -169,7 +169,7 @@ impl SourceCodeUnit {
   pub(crate) fn _apply_edit(
     &mut self, range: Range, replacement_string: &str, parser: &mut Parser,
   ) -> InputEdit {
-    
+
     let replace_range = if replacement_string.trim().is_empty() {
       self.delete_trailing_comma(range)
     } else {
@@ -192,15 +192,14 @@ impl SourceCodeUnit {
     ts_edit
   }
 
-  /// Applies an edit to the source code unit
+  /// Deletes the trailing comma after the {deleted_range}
   /// # Arguments
   /// * `deleted_range` - the range of the deleted code
-  /// * `parser`
   ///
-  /// # Returns
-  /// The `edit:InputEdit` performed.
-  ///
-  /// Note - Causes side effect. - Updates `self.ast` and `self.code`
+  /// Algorithm: 
+  /// Get the node after the {deleted_range}'s end byte (heuristic 5 characters) 
+  /// Traverse this node and get the node closest to the range {deleted_range}'s end byte
+  /// IF this closest node is a comma, extend the {new_delete_range} to include the comma.
   fn delete_trailing_comma(&mut self, deleted_range: Range) -> Range {
     let mut new_deleted_range = deleted_range;
     // Check if the edit is a `Delete` operation

--- a/polyglot/piranha/test-resources/java/feature_flag_system_1/control/expected/XPFlagCleanerPositiveCases.java
+++ b/polyglot/piranha/test-resources/java/feature_flag_system_1/control/expected/XPFlagCleanerPositiveCases.java
@@ -32,6 +32,14 @@ class XPFlagCleanerPositiveCases {
     SOME_OTHER_FLAG
   }
 
+  public enum Something implements ExperimentName {
+    /** Show menu */
+    SHOW_MENU,
+  
+    /** barfoo. */
+    BAR_FOO,
+  }
+
   enum TestEmptyEnum {
   }
 

--- a/polyglot/piranha/test-resources/java/feature_flag_system_1/control/input/XPFlagCleanerPositiveCases.java
+++ b/polyglot/piranha/test-resources/java/feature_flag_system_1/control/input/XPFlagCleanerPositiveCases.java
@@ -34,6 +34,17 @@ class XPFlagCleanerPositiveCases {
     SOME_OTHER_FLAG
   }
 
+  public enum Something implements ExperimentName {
+    /** Show menu */
+    SHOW_MENU,
+  
+    /** Foobar */
+    STALE_FLAG,
+  
+    /** barfoo. */
+    BAR_FOO,
+  }
+
   enum TestEmptyEnum {
   }
 

--- a/polyglot/piranha/test-resources/java/feature_flag_system_1/treated/expected/XPFlagCleanerPositiveCases.java
+++ b/polyglot/piranha/test-resources/java/feature_flag_system_1/treated/expected/XPFlagCleanerPositiveCases.java
@@ -32,6 +32,16 @@ class XPFlagCleanerPositiveCases {
     SOME_OTHER_FLAG
   }
 
+  public enum Something implements ExperimentName {
+    /** Show menu */
+    SHOW_MENU,
+  
+    /** Foobar */
+  
+    /** barfoo. */
+    BAR_FOO,
+  }
+
   enum TestEmptyEnum {
   }
 

--- a/polyglot/piranha/test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java
+++ b/polyglot/piranha/test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java
@@ -39,7 +39,8 @@ class XPFlagCleanerPositiveCases {
     SHOW_MENU,
   
     /** Foobar */
-  
+    STALE_FLAG, 
+    
     /** barfoo. */
     BAR_FOO,
   }

--- a/polyglot/piranha/test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java
+++ b/polyglot/piranha/test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java
@@ -34,6 +34,16 @@ class XPFlagCleanerPositiveCases {
     SOME_OTHER_FLAG
   }
 
+  public enum Something implements ExperimentName {
+    /** Show menu */
+    SHOW_MENU,
+  
+    /** Foobar */
+  
+    /** barfoo. */
+    BAR_FOO,
+  }
+
   enum TestEmptyEnum {
   }
 


### PR DESCRIPTION
I don't know why I did not implement the _"delete trailing comma"_ feature in this manner before. 
Anyhoo. 

#### Previously 
Our current approach to _delete tailing comma_ is  - uses the tree-sitter's error diagnostics and regex heuristics . Unsurprisingly this is flaky.  For instance, Polyglot Piranha fails to delete the comma when deleting the enum constant `STALE_FLAG` in the below case  : 
```
public enum Something implements ExperimentName {

  /** Show menu */
  SHOW_MENU,

  /** Foobar */
  STALE_FLAG,

  /** barfoo. */
  BAR_FOO,
}
```
Tree-sitter diagnosis does not correctly report the extra comma after deleting `STALE_FLAG` (due to the interleaving `block_comment`s) and our regexes dont match (because our regex are not _comment aware_)
Long story short, we should not have relied on Tree-sitter error diagnostics to begin with. 

#### Current idea: 
Remove all the above stuff. 

Implement a very simple algorithm : 
* Identify when the edit is a _Delete operation_
* Look up the node **after** (Like the closest node that begins after the end of this _to be deleted node_ ) this _to be deleted node_.
* If this node is a `,` extend the deletion range to include this node. 


All the current test cases related to deleting commas pass, plus i added this new test scenario. 



P.S.
This significantly simplifies the implementation too. 