### PR TITLE
Selectively triggering GitHub workflows based on directory changes

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -1,0 +1,6 @@
+js:
+  - javascript/**
+java:
+  - java/**
+polyglot:
+  - polyglot/**

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Format
+name: JS Format
 on:
   push:
     branches: [ master ]
@@ -14,11 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: '.github/filters.yaml'
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
       - name: Format
+        if: ${{ steps.filter.outputs.js == 'true' }}
         run: |
           npm ci
           npm run check_format
-

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -29,11 +29,17 @@ jobs:
     steps:
       - name: Check out Piranha sources
         uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: '.github/filters.yaml'
       - name: 'Set up JDK ${{ matrix.java }}'
+        if: ${{ steps.filter.outputs.java == 'true' }}
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
       - name: Build and test using Gradle and Java
+        if: ${{ steps.filter.outputs.java == 'true' }}
         uses: eskatos/gradle-command-action@v1
         with:
           build-root-directory: ./java
@@ -48,4 +54,4 @@ jobs:
           wrapper-directory: ./java
           arguments: jacocoTestReport coverallsJacoco
         continue-on-error: true
-        if: runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/piranha'
+        if: steps.filter.outputs.java == 'true' && runner.os == 'Linux' && matrix.java == '8' && github.repository == 'uber/piranha'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: JS Lint
 
 on:
   push:
@@ -13,12 +13,14 @@ jobs:
         HUSKY_SKIP_INSTALL: 1
     steps:
       - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: '.github/filters.yaml'
       - uses: hallee/eslint-action@1.0.3
         # GITHUB_TOKEN in forked repositories is read-only
         # https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }} 
+        if: ${{ steps.filter.outputs.js == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }} 
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}
           source-root: javascript
-          
-

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,11 +23,19 @@ jobs:
         node-version: [10.x, 12.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm test
-    - run: npm test
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: '.github/filters.yaml'
+      - name: Use Node.js ${{ matrix.node-version }}
+        if: ${{ steps.filter.outputs.js == 'true' }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - if: ${{ steps.filter.outputs.js == 'true' }}
+        run: npm ci
+      - if: ${{ steps.filter.outputs.js == 'true' }}
+        run: npm test
+      - if: ${{ steps.filter.outputs.js == 'true' }}
+        run: npm test

--- a/.github/workflows/polyglot_build.yml
+++ b/.github/workflows/polyglot_build.yml
@@ -8,37 +8,48 @@ env:
   CARGO_TERM_COLOR: always
 jobs:
   build_and_test:
-    name: Piranha
+    name: Polyglot Piranha Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Piranha sources
         uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: '.github/filters.yaml'
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
+        if: ${{ steps.filter.outputs.polyglot == 'true' }}
         with:
           profile: minimal
           toolchain: stable
           override: true
           components: rustfmt, clippy
       - name: Build Piranha
+        if: ${{ steps.filter.outputs.polyglot == 'true' }}
         run: cargo build
         working-directory: polyglot/piranha
       - name: Clippy check
+        if: ${{ steps.filter.outputs.polyglot == 'true' }}
         run: cargo clippy
         working-directory: polyglot/piranha
       - run: cargo test
+        if: ${{ steps.filter.outputs.polyglot == 'true' }}
         working-directory: polyglot/piranha
       - name: Set up Python 3.9
+        if: ${{ steps.filter.outputs.polyglot == 'true' }}
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Create virtualenv and install dependencies
+        if: ${{ steps.filter.outputs.polyglot == 'true' }}
         run: |
           python -m venv .env
           source .env/bin/activate
           pip install maturin pytest
         working-directory: polyglot/piranha
       - name: Run tests
+        if: ${{ steps.filter.outputs.polyglot == 'true' }}
         run: |
           source .env/bin/activate
           maturin develop


### PR DESCRIPTION
## Context

Currently, every pull request is triggering all GitHub workflows, regardless of where the changes are made. For instance, all the recent Polyglot's PRs are executing unrelated CI jobs for Java and JavaScript.

This PR uses https://github.com/dorny/paths-filter to conditionally execute GitHub workflows based on changes made to specific directories.
paths-filter seems stable and is used by established projects/organizations (e.g., [GoogleChrome](https://github.com/GoogleChrome/web.dev/blob/e1f0c28964e99ce6a996c1e3fd3ee1985a7a04f6/.github/workflows/lint-and-test-workflow.yml#L33), [Roblox](https://github.com/Roblox-ActionsCache/dorny-paths-filter), [sentry.io](https://github.com/getsentry/sentry/blob/ca0e43dc5602a9ab2e06d3f6397cc48fb5a78541/.github/workflows/backend-test-py3.6.yml#L32)).

GitHub has a feature to skip workflow executions with path filtering, [but it leaves the checks as "Pending"](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs). AFAIK, Piranha requires all checks to pass for pull request approval.
With this PR, skipped jobs will still appear as passing.

## Details

The filters globs are defined in `.github/filters.yaml` and reused across the workflows `.yaml` files.

I have three PRS on my fork testing the conditional execution:

- https://github.com/dvmarcilio/piranha/pull/1 targeting only Java CI.
- https://github.com/dvmarcilio/piranha/pull/2 aiming at only JS CI.
- https://github.com/dvmarcilio/piranha/pull/3 triggering Java, JS, and Polyglot.

During my tests, I noticed that the filter has to be declared after `actions/checkout`. It cannot figure out the changes before it.

Finally, I did some minor workflows/jobs renaming. I added the `JS` prefix for both `Lint` and `Format` to improve clarity.
