### PR TITLE
Onboarding Go

### DIFF
--- a/polyglot/piranha/Cargo.toml
+++ b/polyglot/piranha/Cargo.toml
@@ -44,6 +44,7 @@ tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java.git"
 tree-sitter-swift = { git = "https://github.com/ketkarameya/tree-sitter-swift.git", branch = "add_parser" }
 tree-sitter-strings = { git = "https://github.com/ketkarameya/tree-sitter-strings.git" }
 tree-sitter-python = { git = "https://github.com/tree-sitter/tree-sitter-python.git" }
+tree-sitter-go = { git = "https://github.com/tree-sitter/tree-sitter-go.git" }
 derive_builder = "0.11.2"
 getset = "0.1.2"
 pyo3 =  "0.17.1"

--- a/polyglot/piranha/README.md
+++ b/polyglot/piranha/README.md
@@ -177,7 +177,7 @@ The output JSON is the serialization of- [`PiranhaOutputSummary`](/polyglot/pira
 | Kotlin           | :heavy_check_mark:          | :heavy_check_mark:                       | :heavy_check_mark:                   |
 | Java + Kotlin    | :x:                         | :calendar:                               | :calendar:                           |
 | Swift            | :heavy_check_mark:          | :construction:                           | :construction:                       |
-| Go               | :construction:              | :construction:                           | :construction:                       |
+| Go               | :heavy_check_mark:          | :construction:                           | :construction:                       |
 | Python           | :heavy_check_mark:          | :calendar:                               | :calendar:                           |
 | TypeScript       | :calendar:                  | :calendar:                               | :calendar:                           |
 | C#               | :calendar:                  | :calendar:                               | :calendar:                           |

--- a/polyglot/piranha/demo/match_only/go/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/match_only/go/configurations/piranha_arguments.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["go"]
+substitutions = []

--- a/polyglot/piranha/demo/match_only/go/configurations/rules.toml
+++ b/polyglot/piranha/demo/match_only/go/configurations/rules.toml
@@ -13,15 +13,12 @@
 name = "find_go_stmt_for_loop"
 query = """
 (
-    (for_statement
-        (block
-            (_)*
-            (go_statement) @go_stmt
-            (_)*
-        ) @block
-    ) @for_stmt
+    (go_statement) @go_stmt
 )
 """
+[[rules.constraints]]
+matcher = "(for_statement) @fs"
+queries=[]
 
 [[rules]]
 name = "find_for"

--- a/polyglot/piranha/demo/match_only/go/configurations/rules.toml
+++ b/polyglot/piranha/demo/match_only/go/configurations/rules.toml
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+name = "find_go_stmt_for_loop"
+query = """
+(
+    (for_statement
+        (block
+            (_)*
+            (go_statement) @go_stmt
+            (_)*
+        ) @block
+    ) @for_stmt
+)
+"""
+
+[[rules]]
+name = "find_for"
+query = """
+(
+    (for_statement) @for_stmt
+)
+"""

--- a/polyglot/piranha/demo/match_only/go/sample.go
+++ b/polyglot/piranha/demo/match_only/go/sample.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2022 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import "fmt"
+
+func f(n int) {
+	for i := 0; i < 10; i++ {
+		fmt.Println(n, ":", i)
+	}
+}
+
+func main() {
+	go f(0) // go_statement does not get matched
+	go f(1) // go_statement does not get matched
+}
+
+func go_stmt() {
+	for i := 0; i < 10; i++ {
+		go f(i) // go_statement gets matched
+	}
+	var input string
+	fmt.Scanln(&input)
+}
+
+func f2() {
+	sum := 1
+	for sum < 100 {
+		sum += sum
+	}
+	fmt.Println(sum)
+}
+
+func f3() {
+	var pow = []int{1, 2, 4, 8, 16, 32, 64, 128}
+	for i, v := range pow {
+		fmt.Printf("2**%d = %d\n", i, v)
+	}
+}

--- a/polyglot/piranha/demo/match_only_demos.py
+++ b/polyglot/piranha/demo/match_only_demos.py
@@ -6,7 +6,7 @@ from logging import info
 
 match_only_dir = join(dirname(__file__), 'match_only')
 
-def demo():
+def java_demo():
     info("Running the Match-only demo for Java")
     output_summary_java = run_piranha_cli(join(match_only_dir, "java"), join(match_only_dir, "java/configurations"), True)
 
@@ -17,9 +17,21 @@ def demo():
 
     assert rule_match_counter['find_barFoo_in_non_static_method'] == 1
 
+def go_demo():
+    info("Running the Match-only demo for go")
+    output_summary_go = run_piranha_cli(join(match_only_dir, "go"), join(match_only_dir, "go/configurations"), True)
+
+    rule_match_counter = Counter([m[0] for m in output_summary_go[0].matches])
+
+    assert rule_match_counter['find_go_stmt_for_loop'] == 1
+
+    assert rule_match_counter['find_for'] == 4
+
+
 FORMAT = '%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s'
 logging.basicConfig(format=FORMAT)
 logging.getLogger().setLevel(logging.INFO)
 
-demo()
+java_demo()
+go_demo()
 info("Completed running the Match-only demo")

--- a/polyglot/piranha/src/tests/mod.rs
+++ b/polyglot/piranha/src/tests/mod.rs
@@ -30,6 +30,8 @@ mod test_piranha_swift;
 
 mod test_piranha_python;
 
+mod test_piranha_go;
+
 use std::sync::Once;
 
 static INIT: Once = Once::new();

--- a/polyglot/piranha/src/tests/test_piranha_go.rs
+++ b/polyglot/piranha/src/tests/test_piranha_go.rs
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2022 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+use super::{initialize, run_match_test};
+
+static LANGUAGE: &str = "go";
+
+#[test]
+fn test_go_match_only_go_expr_for_loop() {
+  initialize();
+  run_match_test(&format!("{}/{}/{}", LANGUAGE, "structural_find", "go_stmt_for_loop"), 1);
+}
+
+#[test]
+fn test_go_match_only_for_loop() {
+  initialize();
+  run_match_test(&format!("{}/{}/{}", LANGUAGE, "structural_find", "for_loop"), 4);
+}

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -48,6 +48,7 @@ impl TreeSitterHelpers for String {
   fn get_language(&self) -> Language {
     match self.as_str() {
       "java" => tree_sitter_java::language(),
+      "go" => tree_sitter_go::language(),
       "kt" => tree_sitter_kotlin::language(),
       "py" => tree_sitter_python::language(),
       "swift" => tree_sitter_swift::language(),

--- a/polyglot/piranha/test-resources/go/structural_find/for_loop/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/go/structural_find/for_loop/configurations/piranha_arguments.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["go"]
+substitutions = []

--- a/polyglot/piranha/test-resources/go/structural_find/for_loop/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/go/structural_find/for_loop/configurations/rules.toml
@@ -1,0 +1,18 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+name = "find_for"
+query = """
+(
+    (for_statement) @for_stmt
+)
+"""

--- a/polyglot/piranha/test-resources/go/structural_find/for_loop/input/sample.go
+++ b/polyglot/piranha/test-resources/go/structural_find/for_loop/input/sample.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2022 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import "fmt"
+
+func f(n int) {
+	for i := 0; i < 10; i++ {
+		fmt.Println(n, ":", i)
+	}
+}
+
+func main() {
+	go f(0)
+	var input string
+	fmt.Scanln(&input)
+}
+
+func f2() {
+	sum := 1
+	for sum < 100 {
+		sum += sum
+	}
+	fmt.Println(sum)
+}
+
+func f3() {
+	var pow = []int{1, 2, 4, 8, 16, 32, 64, 128}
+	for i, v := range pow {
+		fmt.Printf("2**%d = %d\n", i, v)
+	}
+}
+
+func go_stmt() {
+	for i := 0; i < 10; i++ {
+		go f(i)
+	}
+	var input string
+	fmt.Scanln(&input)
+}

--- a/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/piranha_arguments.toml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+language = ["go"]
+substitutions = []

--- a/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/rules.toml
@@ -1,0 +1,24 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+name = "find_go_stmt_for_loop"
+query = """
+(
+    (for_statement
+        (block
+            (_)*
+            (go_statement) @go_stmt
+            (_)*
+        ) @block
+    ) @for_stmt
+)
+"""

--- a/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/rules.toml
@@ -13,12 +13,9 @@
 name = "find_go_stmt_for_loop"
 query = """
 (
-    (for_statement
-        (block
-            (_)*
-            (go_statement) @go_stmt
-            (_)*
-        ) @block
-    ) @for_stmt
+    (go_statement) @go_stmt
 )
 """
+[[rules.constraints]]
+matcher = "(for_statement) @fs"
+queries=[]

--- a/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/input/sample.go
+++ b/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/input/sample.go
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2022 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import "fmt"
+
+func f(n int) {
+	for i := 0; i < 10; i++ {
+		fmt.Println(n, ":", i)
+	}
+}
+
+func main() {
+	go f(0) // go_statement does not get matched
+	go f(1) // go_statement does not get matched
+}
+
+func go_stmt() {
+	for i := 0; i < 10; i++ {
+		go f(i) // go_statement gets matched
+	}
+	var input string
+	fmt.Scanln(&input)
+}


### PR DESCRIPTION
This PR adds the Go grammar as a dependency and a match only demo.

## Demo

The demo has two simple match rules:

- rule`find_for`: matches  any `for_statement`
- rule `find_go_stmt_for_loop`: matches a `go_stmt` inside the block of a `for_statement`

For the code below (reduced version of the demo), the rules will produce the following matches:

- `find_for`: 3
- `find_go_stmt_for_loop`: 1

```go
func f(n int) {
	for i := 0; i < 10; i++ {
		fmt.Println(n, ":", i)
	}
}

func main() {
	go f(0) // go_statement does not get matched
	go f(1) // go_statement does not get matched
}

func go_stmt() {
	for i := 0; i < 10; i++ {
		go f(i) // go_statement gets matched
	}
	var input string
	fmt.Scanln(&input)
}

func f3() {
	var pow = []int{1, 2, 4, 8, 16, 32, 64, 128}
	for i, v := range pow {
		fmt.Printf("2**%d = %d\n", i, v)
	}
}
```