### PR TITLE
Polyglot README: `pip install --upgrade pip`

### DIFF
--- a/polyglot/piranha/README.md
+++ b/polyglot/piranha/README.md
@@ -201,6 +201,7 @@ To setup the demo please follow the below steps:
   - `python3 -m venv .env`
   - `source .env/bin/activate`
 * Install Polyglot Piranha 
+  - `pip install --upgrade pip`
   - `pip install .` to run demo against current source code (please install [Rust](https://www.rust-lang.org/tools/install), it takes less than a minute)
   - Or, `pip install polyglot-piranha` to run demos against the latest release.
 


### PR DESCRIPTION
Running `pip install --upgrade pip` seems to be needed on a fresh Python 3.7 installation. We get a cryptic error without it.

```
Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/lib/python3.7/tokenize.py", line 447, in open
        buffer = _builtin_open(filename, 'rb')
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-req-build-i21vgg9_/setup.py'
```