### PR TITLE
Use objects instead of tuples for top-level matches

### DIFF
--- a/polyglot/piranha/demo/match_only_demos.py
+++ b/polyglot/piranha/demo/match_only_demos.py
@@ -10,7 +10,7 @@ def java_demo():
     info("Running the Match-only demo for Java")
     output_summary_java = run_piranha_cli(join(match_only_dir, "java"), join(match_only_dir, "java/configurations"), False)
 
-    rule_match_counter = Counter([m[0] for m in output_summary_java[0].matches])
+    rule_match_counter = Counter([m.name for m in output_summary_java[0].matches])
 
     assert rule_match_counter['find_fooBar_anywhere'] == 2
 
@@ -21,7 +21,7 @@ def go_demo():
     info("Running the Match-only demo for go")
     output_summary_go = run_piranha_cli(join(match_only_dir, "go"), join(match_only_dir, "go/configurations"), False)
 
-    rule_match_counter = Counter([m[0] for m in output_summary_go[0].matches])
+    rule_match_counter = Counter([m.name for m in output_summary_go[0].matches])
 
     assert rule_match_counter['find_go_stmt_for_loop'] == 1
 
@@ -31,7 +31,7 @@ def ts_demo():
     info("Running the Match-only demo for TypeScript")
     output_summary_typescript = run_piranha_cli(join(match_only_dir, "ts"), join(match_only_dir, "ts/configurations"), False)
 
-    rule_match_counter = Counter([m[0] for m in output_summary_typescript[0].matches])
+    rule_match_counter = Counter([m.name for m in output_summary_typescript[0].matches])
 
     assert rule_match_counter['find_fors'] == 3
     assert rule_match_counter['find_fors_within_functions'] == 2
@@ -41,7 +41,7 @@ def tsx_demo():
     info("Running the Match-only demo for TypeScript with React")
     output_summary_typescript = run_piranha_cli(join(match_only_dir, "tsx"), join(match_only_dir, "tsx/configurations"), False)
 
-    rule_match_counter = Counter([m[0] for m in output_summary_typescript[0].matches])
+    rule_match_counter = Counter([m.name for m in output_summary_typescript[0].matches])
 
     assert rule_match_counter['find_jsx_elements'] == 4
     assert rule_match_counter['find_props_identifiers_within_b_jsx_elements'] == 2

--- a/polyglot/piranha/src/models/piranha_output.rs
+++ b/polyglot/piranha/src/models/piranha_output.rs
@@ -18,6 +18,16 @@ use serde_derive::Serialize;
 
 use super::{edit::Edit, matches::Match, source_code_unit::SourceCodeUnit};
 use pyo3::prelude::pyclass;
+
+#[derive(Serialize, Debug, Clone)]
+#[pyclass]
+pub struct MatchDto {
+  #[pyo3(get)]
+  name: String,
+  #[pyo3(get)]
+  match_: Match,
+}
+
 #[derive(Serialize, Debug, Clone, Default)]
 #[pyclass]
 pub struct PiranhaOutputSummary {
@@ -26,22 +36,33 @@ pub struct PiranhaOutputSummary {
   #[pyo3(get)]
   content: String,
   #[pyo3(get)]
-  matches: Vec<(String, Match)>,
+  matches: Vec<MatchDto>,
   #[pyo3(get)]
   rewrites: Vec<Edit>,
 }
 
 impl PiranhaOutputSummary {
   pub(crate) fn new(source_code_unit: &SourceCodeUnit) -> PiranhaOutputSummary {
+    let mut match_dtos = Vec::<MatchDto>::new();
+
+    for r in source_code_unit.matches().iter() {
+      let match_dto = MatchDto {
+        name: r.0.clone(),
+        match_: r.1.clone(),
+      };
+
+      match_dtos.push(match_dto)
+    }
+
     return PiranhaOutputSummary {
       path: String::from(source_code_unit.path().as_os_str().to_str().unwrap()),
       content: source_code_unit.code(),
-      matches: source_code_unit.matches().iter().cloned().collect_vec(),
+      matches: match_dtos,
       rewrites: source_code_unit.rewrites().iter().cloned().collect_vec(),
     };
   }
 
-  pub(crate) fn matches(&self) -> &[(String, Match)] {
+  pub(crate) fn matches(&self) -> &Vec<MatchDto> {
     self.matches.as_ref()
   }
 


### PR DESCRIPTION
Since tuples are hard for deserialization for some libraries (namely fp-ts), I changed the `(String, Match)` tuple into the `MatchDto` structure.

@ketkarameya I hope you like the change, but I don't know what your plans for deserialization are.