### PR TITLE
Refactor polyglot piranha to lower the coupling between the modules

### DIFF
--- a/polyglot/piranha/src/config.rs
+++ b/polyglot/piranha/src/config.rs
@@ -66,13 +66,15 @@ fn read_language_specific_edges(language_name: &str) -> Edges {
 
 fn read_scope_config(language_name: &str) -> Vec<ScopeGenerator> {
   match language_name {
-    "java" => {
-      parse_toml::<ScopeConfig>(include_str!("cleanup_rules/java/scope_config.toml")).scopes()
-    }
-    "kt" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/kt/scope_config.toml")).scopes(),
-    "swift" => {
-      parse_toml::<ScopeConfig>(include_str!("cleanup_rules/swift/scope_config.toml")).scopes()
-    }
+    "java" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/java/scope_config.toml"))
+      .scopes()
+      .to_vec(),
+    "kt" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/kt/scope_config.toml"))
+      .scopes()
+      .to_vec(),
+    "swift" => parse_toml::<ScopeConfig>(include_str!("cleanup_rules/swift/scope_config.toml"))
+      .scopes()
+      .to_vec(),
     _ => Vec::new(),
   }
 }

--- a/polyglot/piranha/src/models/edit.rs
+++ b/polyglot/piranha/src/models/edit.rs
@@ -43,7 +43,7 @@ impl Edit {
   }
 
   #[cfg(test)]
-  pub(crate) fn dummy_edit(replacement_range: Range, replacement_string: String) -> Self {
+  pub(crate) fn from(replacement_range: Range, replacement_string: String) -> Self {
     Self::new(
       Match::new(replacement_range, HashMap::new()),
       replacement_string,

--- a/polyglot/piranha/src/models/piranha_output.rs
+++ b/polyglot/piranha/src/models/piranha_output.rs
@@ -35,7 +35,7 @@ impl PiranhaOutputSummary {
   pub(crate) fn new(source_code_unit: &SourceCodeUnit) -> PiranhaOutputSummary {
     return PiranhaOutputSummary {
       path: String::from(source_code_unit.path().as_os_str().to_str().unwrap()),
-      content: source_code_unit.code(),
+      content: source_code_unit.code().to_string(),
       matches: source_code_unit.matches().iter().cloned().collect_vec(),
       rewrites: source_code_unit.rewrites().iter().cloned().collect_vec(),
     };

--- a/polyglot/piranha/src/models/rule.rs
+++ b/polyglot/piranha/src/models/rule.rs
@@ -15,11 +15,10 @@ use std::collections::{HashMap, HashSet};
 
 use colored::Colorize;
 use serde_derive::Deserialize;
-use tree_sitter::Node;
 
 use crate::utilities::{tree_sitter_utilities::substitute_tags, MapOfVec};
 
-use super::{constraint::Constraint, rule_store::RuleStore, source_code_unit::SourceCodeUnit};
+use super::{constraint::Constraint};
 
 static SEED: &str = "Seed Rule";
 static CLEAN_UP: &str = "Cleanup Rule";
@@ -215,34 +214,6 @@ impl Rule {
 
   pub(crate) fn set_query(&mut self, query: String) {
     self.query = Some(query);
-  }
-}
-
-#[rustfmt::skip]
-pub(crate) trait SatisfiesConstraint {
-    // / Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
-    fn is_satisfied(&self, source_code_unit: &SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,rule_store: &mut RuleStore,) -> bool ;
-}
-
-/// Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
-impl SatisfiesConstraint for Node<'_> {
-  fn is_satisfied(
-    &self, source_code_unit: &SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,
-    rule_store: &mut RuleStore,
-  ) -> bool {
-    let updated_substitutions = &substitutions
-      .clone()
-      .into_iter()
-      .chain(rule_store.default_substitutions())
-      .collect();
-    rule.constraints().iter().all(|constraint| {
-      constraint.is_satisfied(
-        *self,
-        source_code_unit.clone(),
-        rule_store,
-        updated_substitutions,
-      )
-    })
   }
 }
 

--- a/polyglot/piranha/src/models/rule.rs
+++ b/polyglot/piranha/src/models/rule.rs
@@ -14,19 +14,12 @@ Copyright (c) 2022 Uber Technologies, Inc.
 use std::collections::{HashMap, HashSet};
 
 use colored::Colorize;
-use log::{debug, trace};
 use serde_derive::Deserialize;
 use tree_sitter::Node;
 
-use crate::utilities::{
-  tree_sitter_utilities::{get_context, get_node_for_range, substitute_tags, PiranhaHelpers},
-  MapOfVec,
-};
+use crate::utilities::{tree_sitter_utilities::substitute_tags, MapOfVec};
 
-use super::{
-  constraint::Constraint, edit::Edit, matches::Match, rule_store::RuleStore,
-  source_code_unit::SourceCodeUnit,
-};
+use super::{constraint::Constraint, rule_store::RuleStore, source_code_unit::SourceCodeUnit};
 
 static SEED: &str = "Seed Rule";
 static CLEAN_UP: &str = "Cleanup Rule";
@@ -216,108 +209,40 @@ impl Rule {
     String::from(&self.name)
   }
 
-  // Apply all the `rules` to the node, parent, grand parent and great grand parent.
-  // Short-circuit on the first match.
-  pub(crate) fn get_edit_for_context(
-    source_code_unit: &SourceCodeUnit, previous_edit_start: usize, previous_edit_end: usize,
-    rules_store: &mut RuleStore, rules: &Vec<Rule>,
-  ) -> Option<Edit> {
-    let number_of_ancestors_in_parent_scope =
-      *rules_store.get_number_of_ancestors_in_parent_scope();
-    let changed_node = get_node_for_range(
-      source_code_unit.root_node(),
-      previous_edit_start,
-      previous_edit_end,
-    );
-    debug!(
-      "\n{}",
-      format!("Changed node kind {}", changed_node.kind()).blue()
-    );
-    // Context contains -  the changed node in the previous edit, its's parent, grand parent and great grand parent
-    let context = || {
-      get_context(
-        source_code_unit.root_node(),
-        changed_node,
-        source_code_unit.code(),
-        number_of_ancestors_in_parent_scope,
-      )
-    };
-    for rule in rules {
-      for ancestor in &context() {
-        if let Some(edit) = rule.get_edit(&source_code_unit.clone(), rules_store, *ancestor, false)
-        {
-          return Some(edit);
-        }
-      }
-    }
-    None
-  }
-
-  /// Gets the first match for the rule in `self`
-  pub(crate) fn get_matches(
-    &self, source_code_unit: &SourceCodeUnit, rule_store: &mut RuleStore, node: Node,
-    recursive: bool,
-  ) -> Vec<Match> {
-    let mut output: Vec<Match> = vec![];
-    // Get all matches for the query in the given scope `node`.
-    let replace_node_tag = if self.is_match_only_rule() || self.is_dummy_rule() {
-      None
-    } else {
-      Some(self.replace_node())
-    };
-    let all_query_matches = node.get_all_matches_for_query(
-      source_code_unit.code(),
-      rule_store.query(&self.query()),
-      recursive,
-      replace_node_tag,
-    );
-
-    // Return the first match that satisfies constraint of the rule
-    for p_match in all_query_matches {
-      let matched_node = get_node_for_range(
-        source_code_unit.root_node(),
-        p_match.range().start_byte,
-        p_match.range().end_byte,
-      );
-
-      if matched_node.satisfies_constraint(
-        source_code_unit.clone(),
-        self,
-        p_match.matches(),
-        rule_store,
-      ) {
-        trace!("Found match {:#?}", p_match);
-        output.push(p_match);
-      }
-    }
-    debug!("Matches found {}", output.len());
-    output
-  }
-
-  /// Gets the first match for the rule in `self`
-  pub(crate) fn get_edit(
-    &self, source_code_unit: &SourceCodeUnit, rule_store: &mut RuleStore, node: Node,
-    recursive: bool,
-  ) -> Option<Edit> {
-    // Get all matches for the query in the given scope `node`.
-
-    return self
-      .get_matches(source_code_unit, rule_store, node, recursive)
-      .first()
-      .map(|p_match| {
-        let replacement = substitute_tags(self.replace(), p_match.matches(), false);
-        let edit = Edit::new(p_match.clone(), replacement, self.name());
-        trace!("Rewrite found : {:#?}", edit);
-        edit
-      });
-  }
-
   pub(crate) fn set_replace(&mut self, replace: String) {
     self.replace = Some(replace);
   }
 
   pub(crate) fn set_query(&mut self, query: String) {
     self.query = Some(query);
+  }
+}
+
+#[rustfmt::skip]
+pub(crate) trait SatisfiesConstraint {
+    // / Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
+    fn is_satisfied(&self, source_code_unit: &SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,rule_store: &mut RuleStore,) -> bool ;
+}
+
+/// Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
+impl SatisfiesConstraint for Node<'_> {
+  fn is_satisfied(
+    &self, source_code_unit: &SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,
+    rule_store: &mut RuleStore,
+  ) -> bool {
+    let updated_substitutions = &substitutions
+      .clone()
+      .into_iter()
+      .chain(rule_store.default_substitutions())
+      .collect();
+    rule.constraints().iter().all(|constraint| {
+      constraint.is_satisfied(
+        *self,
+        source_code_unit.clone(),
+        rule_store,
+        updated_substitutions,
+      )
+    })
   }
 }
 

--- a/polyglot/piranha/src/models/rule_graph.rs
+++ b/polyglot/piranha/src/models/rule_graph.rs
@@ -72,9 +72,8 @@ impl RuleGraph {
   }
 }
 
-#[cfg(test)]
-impl RuleGraph {
-  pub(crate) fn dummy() -> Self {
+impl Default for RuleGraph {
+  fn default() -> Self {
     RuleGraph(HashMap::new())
   }
 }

--- a/polyglot/piranha/src/models/rule_store.rs
+++ b/polyglot/piranha/src/models/rule_store.rs
@@ -76,6 +76,15 @@ impl RuleStore {
     rule_store
   }
 
+  #[cfg(test)]
+  pub(crate) fn default_with_scopes(scopes: Vec<ScopeGenerator>) -> RuleStore {
+    RuleStore{
+      scopes,
+      ..Default::default()
+    }
+  }
+
+
   pub(crate) fn global_rules(&self) -> Vec<Rule> {
     self.global_rules.clone()
   }
@@ -187,28 +196,16 @@ impl RuleStore {
   }
 }
 
-#[cfg(test)]
-impl RuleStore {
-  pub(crate) fn dummy() -> RuleStore {
+
+impl Default for RuleStore{
+  fn default() -> Self {
     RuleStore {
-      rule_graph: RuleGraph::dummy(),
+      rule_graph: RuleGraph::default(),
       rule_query_cache: HashMap::new(),
       rules_by_name: HashMap::new(),
       global_rules: vec![],
       piranha_args: PiranhaArguments::default(),
       scopes: vec![],
-      global_tags: HashMap::new(),
-    }
-  }
-
-  pub(crate) fn dummy_with_scope(scopes: Vec<ScopeGenerator>) -> RuleStore {
-    RuleStore {
-      rule_graph: RuleGraph::dummy(),
-      rule_query_cache: HashMap::new(),
-      rules_by_name: HashMap::new(),
-      global_rules: vec![],
-      piranha_args: PiranhaArguments::default(),
-      scopes,
       global_tags: HashMap::new(),
     }
   }

--- a/polyglot/piranha/src/models/rule_store.rs
+++ b/polyglot/piranha/src/models/rule_store.rs
@@ -165,7 +165,7 @@ impl RuleStore {
       .scopes
       .iter()
       .find(|level| level.name().eq(scope_level))
-      .map(|scope| scope.rules())
+      .map(|scope| scope.rules().to_vec())
       .unwrap_or_else(Vec::new)
   }
 

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -24,7 +24,7 @@ use tree_sitter::{InputEdit, Node, Parser, Range, Tree};
 use tree_sitter_traversal::{traverse, Order};
 
 use crate::{
-  models::{rule_store::{GLOBAL, PARENT}},
+  models::rule_store::{GLOBAL, PARENT},
   utilities::tree_sitter_utilities::{
     get_context, get_node_for_range, get_replace_range, get_tree_sitter_edit, substitute_tags,
     PiranhaHelpers, TreeSitterHelpers,
@@ -594,34 +594,35 @@ impl SourceCodeUnit {
   }
 }
 
-
 pub(crate) trait SatisfiesConstraint {
   // / Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
-  fn is_satisfied(&self, source_code_unit: &SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,rule_store: &mut RuleStore,) -> bool ;
+  fn is_satisfied(
+    &self, source_code_unit: &SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,
+    rule_store: &mut RuleStore,
+  ) -> bool;
 }
 
 /// Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
 impl SatisfiesConstraint for Node<'_> {
-fn is_satisfied(
-  &self, source_code_unit: &SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,
-  rule_store: &mut RuleStore,
-) -> bool {
-  let updated_substitutions = &substitutions
-    .clone()
-    .into_iter()
-    .chain(rule_store.default_substitutions())
-    .collect();
-  rule.constraints().iter().all(|constraint| {
-    constraint.is_satisfied(
-      *self,
-      source_code_unit.clone(),
-      rule_store,
-      updated_substitutions,
-    )
-  })
+  fn is_satisfied(
+    &self, source_code_unit: &SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,
+    rule_store: &mut RuleStore,
+  ) -> bool {
+    let updated_substitutions = &substitutions
+      .clone()
+      .into_iter()
+      .chain(rule_store.default_substitutions())
+      .collect();
+    rule.constraints().iter().all(|constraint| {
+      constraint.is_satisfied(
+        *self,
+        source_code_unit.clone(),
+        rule_store,
+        updated_substitutions,
+      )
+    })
+  }
 }
-}
-
 
 #[cfg(test)]
 #[path = "unit_tests/source_code_unit_test.rs"]

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -24,7 +24,7 @@ use tree_sitter::{InputEdit, Node, Parser, Range, Tree};
 use tree_sitter_traversal::{traverse, Order};
 
 use crate::{
-  models::{rule_store::{GLOBAL, PARENT}, rule::SatisfiesConstraint},
+  models::{rule_store::{GLOBAL, PARENT}},
   utilities::tree_sitter_utilities::{
     get_context, get_node_for_range, get_replace_range, get_tree_sitter_edit, substitute_tags,
     PiranhaHelpers, TreeSitterHelpers,
@@ -593,6 +593,35 @@ impl SourceCodeUnit {
       });
   }
 }
+
+
+pub(crate) trait SatisfiesConstraint {
+  // / Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
+  fn is_satisfied(&self, source_code_unit: &SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,rule_store: &mut RuleStore,) -> bool ;
+}
+
+/// Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
+impl SatisfiesConstraint for Node<'_> {
+fn is_satisfied(
+  &self, source_code_unit: &SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,
+  rule_store: &mut RuleStore,
+) -> bool {
+  let updated_substitutions = &substitutions
+    .clone()
+    .into_iter()
+    .chain(rule_store.default_substitutions())
+    .collect();
+  rule.constraints().iter().all(|constraint| {
+    constraint.is_satisfied(
+      *self,
+      source_code_unit.clone(),
+      rule_store,
+      updated_substitutions,
+    )
+  })
+}
+}
+
 
 #[cfg(test)]
 #[path = "unit_tests/source_code_unit_test.rs"]

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -11,37 +11,54 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 use std::{
-  collections::HashMap,
+  collections::{HashMap, VecDeque},
   fs,
   path::{Path, PathBuf},
 };
 
-use log::{debug, error};
+use colored::Colorize;
+use itertools::Itertools;
+use log::{debug, error, trace};
 use regex::Regex;
 use tree_sitter::{InputEdit, Node, Parser, Range, Tree};
 use tree_sitter_traversal::{traverse, Order};
 
-use crate::utilities::tree_sitter_utilities::{get_tree_sitter_edit, TreeSitterHelpers};
-
-use super::{
-  edit::Edit, matches::Match, piranha_arguments::PiranhaArguments, rule_store::RuleStore,
+use crate::{
+  models::{rule_store::{GLOBAL, PARENT}, rule::SatisfiesConstraint},
+  utilities::tree_sitter_utilities::{
+    get_context, get_node_for_range, get_replace_range, get_tree_sitter_edit, substitute_tags,
+    PiranhaHelpers, TreeSitterHelpers,
+  },
 };
 
+use super::{
+  edit::Edit, matches::Match, piranha_arguments::PiranhaArguments, rule::Rule,
+  rule_store::RuleStore, scopes::ScopeGenerator,
+};
+use getset::{CopyGetters, Getters, MutGetters};
 // Maintains the updated source code content and AST of the file
-#[derive(Clone)]
+#[derive(Clone, Getters, CopyGetters, MutGetters)]
 pub(crate) struct SourceCodeUnit {
   // The tree representing the file
   ast: Tree,
   // The content of a file
+  #[get = "pub"]
   code: String,
   // The tag substitution cache.
   // This map is looked up to instantiate new rules.
+  #[get = "pub"]
   substitutions: HashMap<String, String>,
   // The path to the source code.
+  #[get = "pub"]
   path: PathBuf,
+
   // Rewrites applied to this source code unit
+  #[get = "pub"]
+  #[get_mut = "pub"]
   rewrites: Vec<Edit>,
   // Matches for the read_only rules in this source code unit
+  #[get = "pub"]
+  #[get_mut = "pub"]
   matches: Vec<(String, Match)>,
   // Piranha Arguments passed by the user
   piranha_arguments: PiranhaArguments,
@@ -68,6 +85,233 @@ impl SourceCodeUnit {
     self.ast.root_node()
   }
 
+  /// Will apply the `rule` to all of its occurrences in the source code unit.
+  fn apply_rule(
+    &mut self, rule: Rule, rules_store: &mut RuleStore, parser: &mut Parser,
+    scope_query: &Option<String>,
+  ) {
+    loop {
+      if !self._apply_rule(rule.clone(), rules_store, parser, scope_query) {
+        break;
+      }
+    }
+  }
+
+  /// Applies the rule to the first match in the source code
+  /// This is implements the main algorithm of piranha.
+  /// Parameters:
+  /// * `rule` : the rule to be applied
+  /// * `rule_store`: contains the input rule graph.
+  ///
+  /// Algorithm:
+  /// * check if the rule is match only
+  /// ** IF not (i.e. it is a rewrite):
+  /// *** Get the first match of the rule for the file
+  ///  (We only get the first match because the idea is that we will apply this change, and keep calling this method `_apply_rule` until all
+  /// matches have been exhaustively updated.
+  /// *** Apply the rewrite
+  /// *** Update the substitution table
+  /// *** Propagate the change
+  /// ** Else (i.e. it is a match only rule):
+  /// *** Get all the matches, and for each match
+  /// *** Update the substitution table
+  /// *** Propagate the change
+  fn _apply_rule(
+    &mut self, rule: Rule, rule_store: &mut RuleStore, parser: &mut Parser,
+    scope_query: &Option<String>,
+  ) -> bool {
+    let scope_node = self.get_scope_node(scope_query, rule_store);
+
+    let mut query_again = false;
+
+    // When rule is a "rewrite" rule :
+    // Update the first match of the rewrite rule
+    // Add mappings to the substitution
+    // Propagate each applied edit. The next rule will be applied relative to the application of this edit.
+    if !rule.is_match_only_rule() {
+      if let Some(edit) = self.get_edit(rule.clone(), rule_store, scope_node, true) {
+        self.rewrites_mut().push(edit.clone());
+        query_again = true;
+
+        // Add all the (code_snippet, tag) mapping to the substitution table.
+        self.add_to_substitutions(edit.matches(), rule_store);
+
+        // Apply edit_1
+        let applied_ts_edit = self.apply_edit(&edit, parser);
+
+        self.propagate(
+          get_replace_range(applied_ts_edit),
+          rule.clone(),
+          rule_store,
+          parser,
+        );
+      }
+    }
+    // When rule is a "match-only" rule :
+    // Get all the matches
+    // Add mappings to the substitution
+    // Propagate each match. Note that,  we pass a identity edit (where old range == new range) in to the propagate logic.
+    // The next edit will be applied relative to the identity edit.
+    else {
+      for m in self.get_matches(rule.clone(), rule_store, scope_node, true) {
+        self.matches_mut().push((rule.name(), m.clone()));
+
+        // In this scenario we pass the match and replace range as the range of the match `m`
+        // This is equivalent to propagating an identity rule
+        //  i.e. a rule that replaces the matched code with itself
+        // Note that, here we DO NOT invoke the `_apply_edit` method and only update the `substitutions`
+        // By NOT invoking this we simulate the application of an identity rule
+        //
+        self.add_to_substitutions(m.matches(), rule_store);
+
+        self.propagate(m.range(), rule.clone(), rule_store, parser);
+      }
+    }
+    query_again
+  }
+
+  /// This is the propagation logic of the Piranha's main algorithm.
+  /// Parameters:
+  ///  * `applied_ts_edit` -  it's(`rule`'s) application site (in terms of replacement range)
+  ///  * `rule` - The `rule` that was just applied
+  ///  * `rule_store` - contains the input "rule graph"
+  ///  * `parser` - parser for the language
+  /// Algorithm:
+  ///
+  /// (i) Lookup the `rule_store` and get all the (next) rules that could be after applying the current rule (`rule`).
+  ///   * We will receive the rules grouped by scope:  `GLOBAL` and `PARENT` are applicable to each language. However, other scopes are determined
+  ///     based on the `<language>/scope_config.toml`.
+  /// (ii) Add the `GLOBAL` rule to the global rule list in the `rule_store` (This will be performed in the next iteration)
+  /// (iii) Apply the local cleanup i.e. `PARENT` scoped rules
+  ///  (iv) Go to step 1 (and repeat this for the applicable parent scoped rule. Do this until, no parent scoped rule is applicable.) (recursive)
+  ///  (iv) Apply the rules based on custom language specific scopes (as defined in `<language>/scope_config.toml`) (recursive)
+  ///
+  fn propagate(
+    &mut self, replace_range: Range, rule: Rule, rules_store: &mut RuleStore, parser: &mut Parser,
+  ) {
+    let mut current_replace_range = replace_range;
+
+    let mut current_rule = rule.name();
+    let mut next_rules_stack: VecDeque<(String, Rule)> = VecDeque::new();
+    // Perform the parent edits, while queueing the Method and Class level edits.
+    // let file_level_scope_names = [METHOD, CLASS];
+    loop {
+      // Get all the (next) rules that could be after applying the current rule (`rule`).
+      let next_rules_by_scope = rules_store.get_next(&current_rule, self.substitutions());
+
+      debug!(
+        "\n{}",
+        &next_rules_by_scope
+          .iter()
+          .map(|(k, v)| {
+            let rules = v.iter().map(|f| f.name()).join(", ");
+            format!("Next Rules:\nScope {k} \nRules {rules}").blue()
+          })
+          .join("\n")
+      );
+
+      // Adds rules of scope != ["Parent", "Global"] to the stack
+      self.add_rules_to_stack(
+        &next_rules_by_scope,
+        current_replace_range,
+        rules_store,
+        &mut next_rules_stack,
+      );
+
+      // Add Global rules as seed rules
+      for r in &next_rules_by_scope[GLOBAL] {
+        rules_store.add_to_global_rules(r, self.substitutions());
+      }
+
+      // Process the parent
+      // Find the rules to be applied in the "Parent" scope that match any parent (context) of the changed node in the previous edit
+      if let Some(edit) = self.get_edit_for_context(
+        current_replace_range.start_byte,
+        current_replace_range.end_byte,
+        rules_store,
+        &next_rules_by_scope[PARENT],
+      ) {
+        self.rewrites_mut().push(edit.clone());
+        debug!(
+          "\n{}",
+          format!(
+            "Cleaning up the context, by applying the rule - {}",
+            edit.matched_rule()
+          )
+          .green()
+        );
+        // Apply the matched rule to the parent
+        let applied_edit = self.apply_edit(&edit, parser);
+        current_replace_range = get_replace_range(applied_edit);
+        current_rule = edit.matched_rule();
+        // Add the (tag, code_snippet) mapping to substitution table.
+        self.add_to_substitutions(edit.matches(), rules_store);
+      } else {
+        // No more parents found for cleanup
+        break;
+      }
+    }
+
+    // Apply the next rules from the stack
+    for (sq, rle) in &next_rules_stack {
+      self.apply_rule(rle.clone(), rules_store, parser, &Some(sq.to_string()));
+    }
+  }
+
+  /// Adds the "Method" and "Class" scoped next rules to the queue.
+  fn add_rules_to_stack(
+    &mut self, next_rules_by_scope: &HashMap<String, Vec<Rule>>, current_match_range: Range,
+    rules_store: &mut RuleStore, stack: &mut VecDeque<(String, Rule)>,
+  ) {
+    for (scope_level, rules) in next_rules_by_scope {
+      // Scope level is not "PArent" or "Global"
+      if ![PARENT, GLOBAL].contains(&scope_level.as_str()) {
+        for rule in rules {
+          let scope_query = ScopeGenerator::get_scope_query(
+            self.clone(),
+            scope_level,
+            current_match_range.start_byte,
+            current_match_range.end_byte,
+            rules_store,
+          );
+          // Add Method and Class scoped rules to the queue
+          stack.push_front((scope_query, rule.instantiate(self.substitutions())));
+        }
+      }
+    }
+  }
+
+  fn get_scope_node(&self, scope_query: &Option<String>, rules_store: &mut RuleStore) -> Node {
+    // Get scope node
+    // let mut scope_node = self.root_node();
+    if let Some(query_str) = scope_query {
+      // Apply the scope query in the source code and get the appropriate node
+      let tree_sitter_scope_query = rules_store.query(query_str);
+      if let Some(p_match) =
+        &self
+          .root_node()
+          .get_match_for_query(&self.code(), tree_sitter_scope_query, true)
+      {
+        return get_node_for_range(
+          self.root_node(),
+          p_match.range().start_byte,
+          p_match.range().end_byte,
+        );
+      }
+    }
+    self.root_node()
+  }
+
+  /// Apply all `rules` sequentially.
+  pub(crate) fn apply_rules(
+    &mut self, rules_store: &mut RuleStore, rules: &[Rule], parser: &mut Parser,
+    scope_query: Option<String>,
+  ) {
+    for rule in rules {
+      self.apply_rule(rule.to_owned(), rules_store, parser, &scope_query)
+    }
+  }
+
   /// Writes the current contents of `code` to the file system.
   /// Based on the user's specifications, this function will delete a file if empty
   /// and replace three consecutive newline characters with two.
@@ -81,7 +325,7 @@ impl SourceCodeUnit {
         let regex = Regex::new(r"\n(\s*\n)+(\s*\n)").unwrap();
         regex.replace_all(&self.code(), "\n${2}").to_string()
       } else {
-        self.code()
+        self.code().to_string()
       };
       fs::write(&self.path, content).expect("Unable to Write file");
     }
@@ -195,12 +439,12 @@ impl SourceCodeUnit {
   /// Deletes the trailing comma after the {deleted_range}
   /// # Arguments
   /// * `deleted_range` - the range of the deleted code
-  /// 
+  ///
   /// # Returns
   /// code range of the closest node
   ///
-  /// Algorithm: 
-  /// Get the node after the {deleted_range}'s end byte (heuristic 5 characters) 
+  /// Algorithm:
+  /// Get the node after the {deleted_range}'s end byte (heuristic 5 characters)
   /// Traverse this node and get the node closest to the range {deleted_range}'s end byte
   /// IF this closest node is a comma, extend the {new_delete_range} to include the comma.
   fn delete_trailing_comma(&mut self, deleted_range: Range) -> Range {
@@ -211,7 +455,7 @@ impl SourceCodeUnit {
       .ast
       .root_node()
       .descendant_for_byte_range(deleted_range.end_byte, deleted_range.end_byte + 1)
-      .and_then(|n|n.parent())
+      .and_then(|n| n.parent())
     {
       // Traverse this `parent_node` to find the closest next node after the `replace_range`
       if let Some(node_after_to_be_deleted_node) = traverse(parent_node.walk(), Order::Post)
@@ -258,15 +502,6 @@ impl SourceCodeUnit {
     self.code = replacement_content.to_string();
   }
 
-  // #[cfg(test)] // Rust analyzer FP
-  pub(crate) fn code(&self) -> String {
-    String::from(&self.code)
-  }
-
-  pub(crate) fn substitutions(&self) -> &HashMap<String, String> {
-    &self.substitutions
-  }
-
   pub(crate) fn add_to_substitutions(
     &mut self, new_entries: &HashMap<String, String>, rule_store: &mut RuleStore,
   ) {
@@ -274,24 +509,88 @@ impl SourceCodeUnit {
     rule_store.add_global_tags(new_entries);
   }
 
-  pub(crate) fn rewrites(&self) -> &[Edit] {
-    self.rewrites.as_ref()
+  // Apply all the `rules` to the node, parent, grand parent and great grand parent.
+  // Short-circuit on the first match.
+  pub(crate) fn get_edit_for_context(
+    &self, previous_edit_start: usize, previous_edit_end: usize, rules_store: &mut RuleStore,
+    rules: &Vec<Rule>,
+  ) -> Option<Edit> {
+    let number_of_ancestors_in_parent_scope =
+      *rules_store.get_number_of_ancestors_in_parent_scope();
+    let changed_node = get_node_for_range(self.root_node(), previous_edit_start, previous_edit_end);
+    debug!(
+      "\n{}",
+      format!("Changed node kind {}", changed_node.kind()).blue()
+    );
+    // Context contains -  the changed node in the previous edit, its's parent, grand parent and great grand parent
+    let context = || {
+      get_context(
+        self.root_node(),
+        changed_node,
+        self.code().to_string(),
+        number_of_ancestors_in_parent_scope,
+      )
+    };
+    for rule in rules {
+      for ancestor in &context() {
+        if let Some(edit) = self.get_edit(rule.clone(), rules_store, *ancestor, false) {
+          return Some(edit);
+        }
+      }
+    }
+    None
   }
 
-  pub(crate) fn path(&self) -> &PathBuf {
-    &self.path
+  /// Gets the first match for the rule in `self`
+  pub(crate) fn get_matches(
+    &self, rule: Rule, rule_store: &mut RuleStore, node: Node, recursive: bool,
+  ) -> Vec<Match> {
+    let mut output: Vec<Match> = vec![];
+    // Get all matches for the query in the given scope `node`.
+    let replace_node_tag = if rule.is_match_only_rule() || rule.is_dummy_rule() {
+      None
+    } else {
+      Some(rule.replace_node())
+    };
+    let all_query_matches = node.get_all_matches_for_query(
+      self.code().to_string(),
+      rule_store.query(&rule.query()),
+      recursive,
+      replace_node_tag,
+    );
+
+    // Return the first match that satisfies constraint of the rule
+    for p_match in all_query_matches {
+      let matched_node = get_node_for_range(
+        self.root_node(),
+        p_match.range().start_byte,
+        p_match.range().end_byte,
+      );
+
+      if matched_node.is_satisfied(&self, &rule, p_match.matches(), rule_store) {
+        trace!("Found match {:#?}", p_match);
+        output.push(p_match);
+      }
+    }
+    debug!("Matches found {}", output.len());
+    output
   }
 
-  pub(crate) fn rewrites_mut(&mut self) -> &mut Vec<Edit> {
-    &mut self.rewrites
-  }
+  /// Gets the first match for the rule in `self`
+  pub(crate) fn get_edit(
+    &self, rule: Rule, rule_store: &mut RuleStore, node: Node, recursive: bool,
+  ) -> Option<Edit> {
+    // Get all matches for the query in the given scope `node`.
 
-  pub(crate) fn matches(&self) -> &[(String, Match)] {
-    self.matches.as_ref()
-  }
-
-  pub(crate) fn matches_mut(&mut self) -> &mut Vec<(String, Match)> {
-    &mut self.matches
+    return self
+      .get_matches(rule.clone(), rule_store, node, recursive)
+      .first()
+      .map(|p_match| {
+        let replacement = substitute_tags(rule.replace(), p_match.matches(), false);
+        let edit = Edit::new(p_match.clone(), replacement, rule.name());
+        trace!("Rewrite found : {:#?}", edit);
+        edit
+      });
   }
 }
 

--- a/polyglot/piranha/src/models/unit_tests/rule_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/rule_test.rs
@@ -93,10 +93,10 @@ fn test_get_edit_positive_recursive() {
     rule_store.piranha_args(),
   );
   let node = source_code_unit.root_node();
-  let matches = rule.get_matches(&source_code_unit, &mut rule_store, node, true);
+  let matches = source_code_unit.get_matches(rule.clone(), &mut rule_store, node, true);
   assert!(!matches.is_empty());
 
-  let edit = rule.get_edit(&source_code_unit, &mut rule_store, node, true);
+  let edit = source_code_unit.get_edit(rule.clone(), &mut rule_store, node, true);
   assert!(edit.is_some());
 }
 
@@ -140,9 +140,9 @@ fn test_get_edit_negative_recursive() {
     rule_store.piranha_args(),
   );
   let node = source_code_unit.root_node();
-  let matches = rule.get_matches(&source_code_unit, &mut rule_store, node, true);
+  let matches = source_code_unit.get_matches(rule.clone(), &mut rule_store, node, true);
   assert!(matches.is_empty());
-  let edit = rule.get_edit(&source_code_unit, &mut rule_store, node, true);
+  let edit = source_code_unit.get_edit(rule.clone(), &mut rule_store, node, true);
   assert!(edit.is_none());
 }
 
@@ -179,13 +179,8 @@ fn test_get_edit_for_context_positive() {
     PathBuf::new().as_path(),
     rule_store.piranha_args(),
   );
-  let edit = Rule::get_edit_for_context(
-    &source_code_unit,
-    41_usize,
-    44_usize,
-    &mut rule_store,
-    &vec![rule],
-  );
+  let edit =
+    source_code_unit.get_edit_for_context(41_usize, 44_usize, &mut rule_store, &vec![rule]);
   // let edit = rule.get_edit(&source_code_unit, &mut rule_store, node, true);
   assert!(edit.is_some());
 }
@@ -224,13 +219,8 @@ fn test_get_edit_for_context_negative() {
     PathBuf::new().as_path(),
     rule_store.piranha_args(),
   );
-  let edit = Rule::get_edit_for_context(
-    &source_code_unit,
-    29_usize,
-    33_usize,
-    &mut rule_store,
-    &vec![rule],
-  );
+  let edit =
+    source_code_unit.get_edit_for_context(29_usize, 33_usize, &mut rule_store, &vec![rule]);
   // let edit = rule.get_edit(&source_code_unit, &mut rule_store, node, true);
   assert!(edit.is_none());
 }

--- a/polyglot/piranha/src/models/unit_tests/rule_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/rule_test.rs
@@ -81,7 +81,7 @@ fn test_get_edit_positive_recursive() {
           }
         }";
 
-  let mut rule_store = RuleStore::dummy();
+  let mut rule_store = RuleStore::default();
 
   let mut parser = get_parser(String::from("java"));
 
@@ -129,7 +129,7 @@ fn test_get_edit_negative_recursive() {
           }
         }";
 
-  let mut rule_store = RuleStore::dummy();
+  let mut rule_store = RuleStore::default();
   let mut parser = get_parser(String::from("java"));
 
   let source_code_unit = SourceCodeUnit::new(
@@ -168,7 +168,7 @@ fn test_get_edit_for_context_positive() {
           boolean f = something && true;
         }";
 
-  let mut rule_store = RuleStore::dummy();
+  let mut rule_store = RuleStore::default();
 
   let mut parser = get_parser(String::from("java"));
 
@@ -208,7 +208,7 @@ fn test_get_edit_for_context_negative() {
           boolean x = something && true;
         }";
 
-  let mut rule_store = RuleStore::dummy();
+  let mut rule_store = RuleStore::default();
 
   let mut parser = get_parser(String::from("java"));
 

--- a/polyglot/piranha/src/models/unit_tests/scopes_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/scopes_test.rs
@@ -78,6 +78,11 @@ fn _get_method_scope() -> ScopeGenerator {
     .unwrap();
 }
 
+
+fn _get_rule_store() -> RuleStore {
+  return RuleStore::default_with_scopes(vec![_get_method_scope(), _get_class_scope()])
+}
+
 /// Positive test for the generated scope query, given scope generators, source code and position of pervious edit.
 #[test]
 fn test_get_scope_query_positive() {
@@ -90,8 +95,8 @@ fn test_get_scope_query_positive() {
         }
       }
     }";
-
-  let mut rule_store = RuleStore::dummy_with_scope(vec![_get_method_scope(), _get_class_scope()]);
+  
+  let mut rule_store =  _get_rule_store();
   let mut parser = get_parser(String::from("java"));
 
   let source_code_unit = SourceCodeUnit::new(
@@ -123,8 +128,8 @@ fn test_get_scope_query_positive() {
        (((constructor_declaration 
                 name: (_) @z
                 parameters : (formal_parameters)@tp))
-        (#eq? @tp \"(int a, int b, int c)\")
         (#eq? @z \"foobar\")
+        (#eq? @tp \"(int a, int b, int c)\")
         )
       ]
     )@qdn"
@@ -154,7 +159,7 @@ fn test_get_scope_query_negative() {
         }
       }
     }";
-  let mut rule_store = RuleStore::dummy_with_scope(vec![_get_method_scope(), _get_class_scope()]);
+  let mut rule_store = _get_rule_store();
   let mut parser = get_parser(String::from("java"));
 
   let source_code_unit = SourceCodeUnit::new(

--- a/polyglot/piranha/src/models/unit_tests/scopes_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/scopes_test.rs
@@ -11,7 +11,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 use {
-  super::{ScopeGenerator, ScopeQueryGenerator},
+  super::{ScopeGenerator, ScopeGeneratorBuilder, ScopeQueryGenerator, ScopeQueryGeneratorBuilder},
   crate::{
     models::{rule_store::RuleStore, source_code_unit::SourceCodeUnit},
     utilities::eq_without_whitespace,
@@ -20,43 +20,81 @@ use {
   std::{collections::HashMap, path::PathBuf},
 };
 
+struct TestScopesGenerators {
+  class: ScopeGenerator,
+  method: ScopeGenerator,
+}
+
+impl Default for TestScopesGenerators {
+  fn default() -> Self {
+    let scope_query_generator_method: ScopeQueryGenerator = ScopeQueryGeneratorBuilder::default()
+      .matcher(
+        "(
+    [(method_declaration 
+              name : (_) @n
+              parameters : (formal_parameters)@fp)
+     (constructor_declaration 
+              name: (_) @n
+              parameters : (formal_parameters)@fp)
+              
+    ]          
+              @xdn)"
+          .to_string(),
+      )
+      .generator(
+        "(
+      [(((method_declaration 
+                name : (_) @z
+                parameters : (formal_parameters)@tp))
+        (#eq? @z \"@n\")
+        (#eq? @tp \"@fp\")                  
+        )
+       (((constructor_declaration 
+                name: (_) @z
+                parameters : (formal_parameters)@tp))
+        (#eq? @tp \"@fp\")
+        (#eq? @z \"@n\")
+        )
+      ]
+    )@qdn"
+          .to_string(),
+      )
+      .build()
+      .unwrap();
+
+    let scope_query_generator_class: ScopeQueryGenerator = ScopeQueryGeneratorBuilder::default()
+      .matcher("(class_declaration name:(_) @n) @c".to_string())
+      .generator(
+        "(
+    ((class_declaration name:(_) @z) @qc)
+    (#eq? @z \"@n\")
+    )"
+        .to_string(),
+      )
+      .build()
+      .unwrap();
+    let scope_generator_class: ScopeGenerator = ScopeGeneratorBuilder::default()
+      .name("Class".to_string())
+      .rules(vec![scope_query_generator_class])
+      .build()
+      .unwrap();
+
+    let scope_generator_method: ScopeGenerator = ScopeGeneratorBuilder::default()
+      .name("Method".to_string())
+      .rules(vec![scope_query_generator_method])
+      .build()
+      .unwrap();
+
+    Self {
+      class: scope_generator_class,
+      method: scope_generator_method,
+    }
+  }
+}
+
 /// Positive test for the generated scope query, given scope generators, source code and position of pervious edit.
 #[test]
 fn test_get_scope_query_positive() {
-  let scope_generator_method = ScopeGenerator::new(
-    "Method",
-    vec![ScopeQueryGenerator::new(
-      "((method_declaration 
-          name : (_) @n
-                parameters : (formal_parameters
-                    (formal_parameter type:(_) @t0)
-                        (formal_parameter type:(_) @t1)
-                        (formal_parameter type:(_) @t2))) @xd2)",
-      "(((method_declaration 
-                        name : (_) @z
-                              parameters : (formal_parameters
-                                  (formal_parameter type:(_) @r0)
-                                      (formal_parameter type:(_) @r1)
-                                      (formal_parameter type:(_) @r2))) @qd)
-                  (#eq? @z \"@n\")
-                  (#eq? @r0 \"@t0\")
-                  (#eq? @r1 \"@t1\")
-                  (#eq? @r2 \"@t2\")
-                  )",
-    )],
-  );
-
-  let scope_generator_class = ScopeGenerator::new(
-    "Class",
-    vec![ScopeQueryGenerator::new(
-      "(class_declaration name:(_) @n) @c",
-      "(
-          ((class_declaration name:(_) @z) @qc)
-          (#eq? @z \"@n\")
-          )",
-    )],
-  );
-
   let source_code = "class Test {
       pub void foobar(int a, int b, int c){
         boolean isFlagTreated = true;
@@ -67,8 +105,12 @@ fn test_get_scope_query_positive() {
       }
     }";
 
-  let mut rule_store =
-    RuleStore::dummy_with_scope(vec![scope_generator_method, scope_generator_class]);
+  let test_scope_generators = TestScopesGenerators::default();
+
+  let mut rule_store = RuleStore::dummy_with_scope(vec![
+    test_scope_generators.method,
+    test_scope_generators.class,
+  ]);
   let mut parser = get_parser(String::from("java"));
 
   let source_code_unit = SourceCodeUnit::new(
@@ -87,19 +129,24 @@ fn test_get_scope_query_positive() {
     &mut rule_store,
   );
 
+  println!("{}", scope_query_method.as_str());
   assert!(eq_without_whitespace(
     scope_query_method.as_str(),
-    "(((method_declaration 
-      name : (_) @z
-            parameters : (formal_parameters
-                (formal_parameter type:(_) @r0)
-                    (formal_parameter type:(_) @r1)
-                    (formal_parameter type:(_) @r2))) @qd)
-            (#eq? @z \"foobar\")
-            (#eq? @r0 \"int\")
-            (#eq? @r1 \"int\")
-            (#eq? @r2 \"int\")
-            )"
+    "(
+      [(((method_declaration 
+                name : (_) @z
+                parameters : (formal_parameters)@tp))
+        (#eq? @z \"foobar\")
+        (#eq? @tp \"(int a, int b, int c)\")                  
+        )
+       (((constructor_declaration 
+                name: (_) @z
+                parameters : (formal_parameters)@tp))
+        (#eq? @tp \"(int a, int b, int c)\")
+        (#eq? @z \"foobar\")
+        )
+      ]
+    )@qdn"
   ));
 
   let scope_query_class =
@@ -117,40 +164,6 @@ fn test_get_scope_query_positive() {
 #[test]
 #[should_panic]
 fn test_get_scope_query_negative() {
-  let scope_generator_method = ScopeGenerator::new(
-    "Method",
-    vec![ScopeQueryGenerator::new(
-      "((method_declaration 
-          name : (_) @n
-                parameters : (formal_parameters
-                    (formal_parameter type:(_) @t0)
-                        (formal_parameter type:(_) @t1)
-                        (formal_parameter type:(_) @t2))) @xd2)",
-      "(((method_declaration 
-                        name : (_) @z
-                              parameters : (formal_parameters
-                                  (formal_parameter type:(_) @r0)
-                                      (formal_parameter type:(_) @r1)
-                                      (formal_parameter type:(_) @r2))) @qd)
-                  (#eq? @z \"@n\")
-                  (#eq? @r0 \"@t0\")
-                  (#eq? @r1 \"@t1\")
-                  (#eq? @r2 \"@t2\")
-                  )",
-    )],
-  );
-
-  let scope_generator_class = ScopeGenerator::new(
-    "Class",
-    vec![ScopeQueryGenerator::new(
-      "(class_declaration name:(_) @n) @c",
-      "(
-          ((class_declaration name:(_) @z) @qc)
-          (#eq? @z \"@n\")
-          )",
-    )],
-  );
-
   let source_code = "class Test {
       pub void foobar(int a, int b, int c, int d){
         boolean isFlagTreated = true;
@@ -161,8 +174,12 @@ fn test_get_scope_query_negative() {
       }
     }";
 
-  let mut rule_store =
-    RuleStore::dummy_with_scope(vec![scope_generator_method, scope_generator_class]);
+  let test_scope_generators = TestScopesGenerators::default();
+
+  let mut rule_store = RuleStore::dummy_with_scope(vec![
+    test_scope_generators.method,
+    test_scope_generators.class,
+  ]);
   let mut parser = get_parser(String::from("java"));
 
   let source_code_unit = SourceCodeUnit::new(
@@ -173,5 +190,5 @@ fn test_get_scope_query_negative() {
     rule_store.piranha_args(),
   );
 
-  let _ = ScopeGenerator::get_scope_query(source_code_unit, "Method", 133, 134, &mut rule_store);
+  let _ = ScopeGenerator::get_scope_query(source_code_unit, "Method", 9, 10, &mut rule_store);
 }

--- a/polyglot/piranha/src/models/unit_tests/scopes_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/scopes_test.rs
@@ -23,10 +23,9 @@ use {
 fn _get_class_scope() -> ScopeGenerator {
   let scope_query_generator_class: ScopeQueryGenerator = ScopeQueryGeneratorBuilder::default()
     .matcher("(class_declaration name:(_) @n) @c".to_string())
-    .generator(
-      "(
-    ((class_declaration name:(_) @z) @qc)
-    (#eq? @z \"@n\")
+    .generator("(
+      ((class_declaration name:(_) @z) @qc)
+      (#eq? @z \"@n\")
     )"
       .to_string(),
     )
@@ -63,8 +62,8 @@ fn _get_method_scope() -> ScopeGenerator {
        (((constructor_declaration 
                 name: (_) @z
                 parameters : (formal_parameters)@tp))
-        (#eq? @tp \"@fp\")
         (#eq? @z \"@n\")
+        (#eq? @tp \"@fp\")
         )
       ])@qdn"
         .to_string(),

--- a/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
@@ -83,7 +83,7 @@ fn test_apply_edit_positive() {
   let mut source_code_unit = SourceCodeUnit::default(source_code, &mut parser, language_name);
 
   let _ = source_code_unit.apply_edit(
-    &Edit::dummy_edit(range(49, 78, 3, 9, 3, 38), String::new()),
+    &Edit::from(range(49, 78, 3, 9, 3, 38), String::new()),
     &mut parser,
   );
   assert!(eq_without_whitespace(
@@ -111,7 +111,7 @@ fn test_apply_edit_negative() {
   let mut source_code_unit = SourceCodeUnit::default(source_code, &mut parser, language_name);
 
   let _ = source_code_unit.apply_edit(
-    &Edit::dummy_edit(range(1000, 2000, 0, 0, 0, 0), String::new()),
+    &Edit::from(range(1000, 2000, 0, 0, 0, 0), String::new()),
     &mut parser,
   );
 }
@@ -133,7 +133,7 @@ fn test_apply_edit_comma_handling_via_grammar() {
   let mut source_code_unit = SourceCodeUnit::default(source_code, &mut parser, language_name);
 
   let _ = source_code_unit.apply_edit(
-    &Edit::dummy_edit(range(37, 47, 2, 26, 2, 36), String::new()),
+    &Edit::from(range(37, 47, 2, 26, 2, 36), String::new()),
     &mut parser,
   );
   assert!(eq_without_whitespace(
@@ -161,7 +161,7 @@ fn test_apply_edit_comma_handling_via_regex() {
   let mut source_code_unit = SourceCodeUnit::default(source_code, &mut parser, language_name);
 
   let _ = source_code_unit.apply_edit(
-    &Edit::dummy_edit(range(59, 75, 3, 23, 3, 41), String::new()),
+    &Edit::from(range(59, 75, 3, 23, 3, 41), String::new()),
     &mut parser,
   );
   assert!(eq_without_whitespace(

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -14,7 +14,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 //! Defines the traits containing with utility functions that interface with tree-sitter.
 
 use crate::{
-  models::{matches::Match, rule::Rule, rule_store::RuleStore, source_code_unit::SourceCodeUnit},
+  models::{matches::Match},
   utilities::MapOfVec,
 };
 use colored::Colorize;

--- a/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
+++ b/polyglot/piranha/src/utilities/tree_sitter_utilities.rs
@@ -81,8 +81,6 @@ pub(crate) trait PiranhaHelpers {
     /// List of matches (list of captures), grouped by the outermost tag of the query
     fn get_query_capture_groups(&self, source_code: &str, query: &Query) -> HashMap<Range, Vec<Vec<QueryCapture>>> ;
 
-    /// Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
-    fn satisfies_constraint(&self, source_code_unit: SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,rule_store: &mut RuleStore,) -> bool ;
     /// Applies the query upon `self`, and gets the first match
     /// # Arguments
     /// * `source_code` - the corresponding source code string for the node.
@@ -107,25 +105,6 @@ pub(crate) trait PiranhaHelpers {
 }
 
 impl PiranhaHelpers for Node<'_> {
-  /// Checks if the given rule satisfies the constraint of the rule, under the substitutions obtained upon matching `rule.query`
-  fn satisfies_constraint(
-    &self, source_code_unit: SourceCodeUnit, rule: &Rule, substitutions: &HashMap<String, String>,
-    rule_store: &mut RuleStore,
-  ) -> bool {
-    let updated_substitutions = &substitutions
-      .clone()
-      .into_iter()
-      .chain(rule_store.default_substitutions())
-      .collect();
-    rule.constraints().iter().all(|constraint| {
-      constraint.is_satisfied(
-        *self,
-        source_code_unit.clone(),
-        rule_store,
-        updated_substitutions,
-      )
-    })
-  }
 
   fn get_match_for_query(
     &self, source_code: &str, query: &Query, recursive: bool,

--- a/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
+++ b/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
@@ -17,7 +17,7 @@ use std::{
 
 use tree_sitter::Query;
 
-use crate::models::piranha_arguments::PiranhaArgumentsBuilder;
+use crate::models::{piranha_arguments::PiranhaArgumentsBuilder, rule::SatisfiesConstraint};
 
 use {
   super::{get_parser, substitute_tags, PiranhaHelpers, TreeSitterHelpers},
@@ -184,8 +184,8 @@ fn test_satisfies_constraints_positive() {
     .descendant_for_byte_range(50, 72)
     .unwrap();
 
-  assert!(node.satisfies_constraint(
-    source_code_unit.clone(),
+  assert!(node.is_satisfied(
+    &source_code_unit,
     &rule,
     &HashMap::from([
       ("variable_name".to_string(), "isFlagTreated".to_string()),
@@ -251,8 +251,8 @@ fn test_satisfies_constraints_negative() {
     .descendant_for_byte_range(50, 72)
     .unwrap();
 
-  assert!(!node.satisfies_constraint(
-    source_code_unit.clone(),
+  assert!(!node.is_satisfied(
+    &source_code_unit,
     &rule,
     &HashMap::from([
       ("variable_name".to_string(), "isFlagTreated".to_string()),

--- a/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
+++ b/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
@@ -164,7 +164,7 @@ fn test_satisfies_constraints_positive() {
        }
       }";
 
-  let mut rule_store = RuleStore::dummy();
+  let mut rule_store = RuleStore::default();
   let language_name = String::from("java");
   let mut parser = get_parser(language_name.to_string());
   let piranha_args = PiranhaArgumentsBuilder::default()
@@ -231,7 +231,7 @@ fn test_satisfies_constraints_negative() {
        }
       }";
 
-  let mut rule_store = RuleStore::dummy();
+  let mut rule_store = RuleStore::default();
   let language_name = String::from("java");
   let mut parser = get_parser(language_name.to_string());
   let piranha_arguments = &PiranhaArgumentsBuilder::default()

--- a/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
+++ b/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
@@ -17,7 +17,7 @@ use std::{
 
 use tree_sitter::Query;
 
-use crate::models::{piranha_arguments::PiranhaArgumentsBuilder, rule::SatisfiesConstraint};
+use crate::models::{piranha_arguments::PiranhaArgumentsBuilder, source_code_unit::SatisfiesConstraint};
 
 use {
   super::{get_parser, substitute_tags, PiranhaHelpers, TreeSitterHelpers},


### PR DESCRIPTION
This step 0 for the large refactoring that organizes the codebase into cargo workspace. #271 
As part of this cleanup I have : 
1. Moved functions from `Rule` to `SourceCodeUnit` 
2. Replace get/set with macro
3. Remove redundancy in `scope_tests.rs`

(I have annotated the diff)