### PR TITLE
Failing test for Java `delete_all_statements_after_return`

### DIFF
--- a/polyglot/piranha/test-resources/java/feature_flag_system_1/control/expected/XPFlagCleanerPositiveCases.java
+++ b/polyglot/piranha/test-resources/java/feature_flag_system_1/control/expected/XPFlagCleanerPositiveCases.java
@@ -205,6 +205,10 @@ class XPFlagCleanerPositiveCases {
     }
   }
 
+  public String multiple_stmt_after_return() {
+    return "not enabled";
+  }
+
   class XPTest {
     public boolean isToggleEnabled(TestExperimentName x) {
       return true;

--- a/polyglot/piranha/test-resources/java/feature_flag_system_1/control/input/XPFlagCleanerPositiveCases.java
+++ b/polyglot/piranha/test-resources/java/feature_flag_system_1/control/input/XPFlagCleanerPositiveCases.java
@@ -267,6 +267,19 @@ class XPFlagCleanerPositiveCases {
     }
   }
 
+  public String multiple_stmt_after_return() {
+    if (!experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
+      return "not enabled";
+    }
+
+    System.out.println("remove 1");
+    System.out.println("remove 2");
+    System.out.println("remove 3");
+    System.out.println("remove 4");
+    System.out.println("remove 5");
+    return "enabled";
+  }
+
   class XPTest {
     public boolean isToggleEnabled(TestExperimentName x) {
       return true;


### PR DESCRIPTION
## Problem

Java `delete_all_statements_after_return` is only working for the 1st statement.
From the code below (considering that the `experimentation.isToggleEnabled()` call is replaced by `false`):
```java
public String multiple_stmt_after_return() {
  if (!experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
    return "not enabled";
  }

  System.out.println("remove 1");
  System.out.println("remove 2");
  System.out.println("remove 3");
  System.out.println("remove 4");
  System.out.println("remove 5");
  return "enabled";
}
```

We would expect the following:
```java
public String multiple_stmt_after_return() {
  return "not enabled";
}
```

Instead, we are getting:
```java
public String multiple_stmt_after_return() {
  return "not enabled";

  
  System.out.println("remove 2");
  System.out.println("remove 3");
  System.out.println("remove 4");
  System.out.println("remove 5");
  return "enabled";
}
```

## Discussion

This is the query for `delete_all_statements_after_return`:

```lisp
(
  (block  
    ((statement)* @pre)
    ((return_statement) @r)
    ((statement)+ @post)
  ) @b
)
```

Using tree-sitter CLI, this is the match we get:

```
pattern: 0
  capture: b, start: (0, 43), end: (9, 1)
  capture: 1 - r, start: (1, 2), end: (1, 23), text: `return "not enabled";`
  capture: 2 - post, start: (3, 2), end: (3, 33), text: `System.out.println("remove 1");`
  capture: 2 - post, start: (4, 2), end: (4, 33), text: `System.out.println("remove 2");`
  capture: 2 - post, start: (5, 2), end: (5, 33), text: `System.out.println("remove 3");`
  capture: 2 - post, start: (6, 2), end: (6, 33), text: `System.out.println("remove 4");`
  capture: 2 - post, start: (7, 2), end: (7, 33), text: `System.out.println("remove 5");`
  capture: 2 - post, start: (8, 2), end: (8, 19), text: `return "enabled";`
```

So `((statement)+ @post)` is producing multiple matches, one for each statement.
Perhaps the internal **replace** implementation is expecting a multi-line match for `@post` (as from `(block) @b`)?

## Possible Solution

The self-edge solution from #265 would also work here; not requiring any modification to the rust code.
```toml
[[edges]]
scope = "Parent"
from = "delete_all_statements_after_return"
to = ["delete_all_statements_after_return"]
```