### PR TITLE
Simplify the rules

### DIFF
--- a/polyglot/piranha/demo/match_only/go/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/match_only/go/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["go"]
-substitutions = []
+

--- a/polyglot/piranha/demo/match_only/ts/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/match_only/ts/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["ts"]
-substitutions = []
+

--- a/polyglot/piranha/demo/match_only/tsx/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/match_only/tsx/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["tsx"]
-substitutions = []
+

--- a/polyglot/piranha/demo/match_only/tsx/configurations/rules.toml
+++ b/polyglot/piranha/demo/match_only/tsx/configurations/rules.toml
@@ -36,7 +36,7 @@ matcher = """
     ) @j
 )
 """
-queries = []
+
 
 [[rules]]
 name = "find_props_identifiers_within_variable_declarators_not_within_divs"

--- a/polyglot/piranha/src/models/constraint.rs
+++ b/polyglot/piranha/src/models/constraint.rs
@@ -21,6 +21,7 @@ pub(crate) struct Constraint {
   matcher: String,
   /// The Tree-sitter queries that need to be applied in the `matcher` scope
   #[get = "pub"]
+  #[serde(default)]
   queries: Vec<String>,
 }
 

--- a/polyglot/piranha/src/models/language.rs
+++ b/polyglot/piranha/src/models/language.rs
@@ -5,7 +5,7 @@ use tree_sitter::{Parser, Query};
 use crate::utilities::parse_toml;
 
 use super::{
-  default_configs::{default_language, GO, JAVA, KOTLIN, PYTHON, STRINGS, SWIFT, TSX, TYPESCRIPT},
+  default_configs::{GO, JAVA, KOTLIN, PYTHON, STRINGS, SWIFT, TSX, TYPESCRIPT},
   outgoing_edges::Edges,
   rule::Rules,
   scopes::{ScopeConfig, ScopeGenerator},
@@ -75,7 +75,7 @@ impl PiranhaLanguage {
 
 impl Default for PiranhaLanguage {
   fn default() -> Self {
-    PiranhaLanguage::from(default_language().as_str())
+    PiranhaLanguage::from(JAVA)
   }
 }
 

--- a/polyglot/piranha/src/models/rule.rs
+++ b/polyglot/piranha/src/models/rule.rs
@@ -270,14 +270,6 @@ impl Rule {
     }
     .to_string()
   }
-
-  pub(crate) fn is_rewrite(&self) -> bool {
-    matches!(self, Self::Rewrite { .. })
-  }
-
-  pub(crate) fn is_dummy(&self) -> bool {
-    matches!(self, Self::Dummy { .. })
-  }
 }
 
 #[cfg(test)]

--- a/polyglot/piranha/src/models/rule_graph.rs
+++ b/polyglot/piranha/src/models/rule_graph.rs
@@ -23,7 +23,7 @@ pub(crate) struct RuleGraph(HashMap<String, Vec<(String, String)>>);
 impl RuleGraph {
   // Constructs a graph of rules based on the input `edges` that represent the relationship between two rules or groups of rules.
   pub(crate) fn new(edges: &Vec<OutgoingEdges>, all_rules: &Vec<Rule>) -> Self {
-    let (rules_by_name, rules_by_group) = Rule::group_rules(all_rules);
+    let (rules_by_name, rules_by_group) = Self::group_rules(all_rules);
 
     // A closure that gets the rules corresponding to the given rule name or group name.
     let get_rules_for_tag_or_name = |val: &String| {
@@ -69,6 +69,22 @@ impl RuleGraph {
       edges += destinations.len();
     }
     (self.0.len(), edges)
+  }
+
+  /// Groups the rules based on the field `rule.groups`
+  /// Note: a rule can belong to more than one group.
+  pub(crate) fn group_rules(
+    rules: &Vec<Rule>,
+  ) -> (HashMap<String, Rule>, HashMap<String, Vec<String>>) {
+    let mut rules_by_name = HashMap::new();
+    let mut rules_by_group = HashMap::new();
+    for rule in rules {
+      rules_by_name.insert(rule.name(), rule.clone());
+      for tag in rule.groups() {
+        rules_by_group.collect(tag.to_string(), rule.name());
+      }
+    }
+    (rules_by_name, rules_by_group)
   }
 }
 

--- a/polyglot/piranha/src/models/rule_store.rs
+++ b/polyglot/piranha/src/models/rule_store.rs
@@ -138,7 +138,7 @@ impl RuleStore {
     for (scope, to_rule) in self.rule_graph.get_neighbors(rule_name) {
       let to_rule_name = &self.rules_by_name[&to_rule];
       // If the to_rule_name is a dummy rule, skip it and rather return it's next rules.
-      if let Rule::Dummy { .. } = to_rule_name {
+      if to_rule_name.is_dummy() {
         // Call this method recursively on the dummy node
         for (next_next_rules_scope, next_next_rules) in
           self.get_next(&to_rule_name.name(), tag_matches)

--- a/polyglot/piranha/src/models/rule_store.rs
+++ b/polyglot/piranha/src/models/rule_store.rs
@@ -105,13 +105,10 @@ impl RuleStore {
   pub(crate) fn add_to_global_rules(
     &mut self, rule: &Rule, tag_captures: &HashMap<String, String>,
   ) {
-    if let Ok(mut r) = rule.try_instantiate(tag_captures) {
-      if !self.global_rules.iter().any(|r| {
-        r.name().eq(&rule.name()) && r.replace().eq(&rule.replace()) && r.query().eq(&rule.query())
-      }) {
-        r.add_grep_heuristics_for_global_rules(tag_captures);
+    if let Ok(r) = rule.try_instantiate(tag_captures) {
+      if !self.global_rules.contains(&r){
         #[rustfmt::skip]
-        debug!("{}", format!("Added Global Rule : {:?} - {}", r.name(), r.query()).bright_blue());
+        debug!("{}", format!("Added Global Rule - \n {}", r).bright_blue());
         self.global_rules.push(r);
       }
     }
@@ -141,7 +138,7 @@ impl RuleStore {
     for (scope, to_rule) in self.rule_graph.get_neighbors(rule_name) {
       let to_rule_name = &self.rules_by_name[&to_rule];
       // If the to_rule_name is a dummy rule, skip it and rather return it's next rules.
-      if to_rule_name.is_dummy_rule() {
+      if let Rule::Dummy { .. } = to_rule_name {
         // Call this method recursively on the dummy node
         for (next_next_rules_scope, next_next_rules) in
           self.get_next(&to_rule_name.name(), tag_matches)

--- a/polyglot/piranha/src/models/source_code_unit.rs
+++ b/polyglot/piranha/src/models/source_code_unit.rs
@@ -128,7 +128,7 @@ impl SourceCodeUnit {
     // Update the first match of the rewrite rule
     // Add mappings to the substitution
     // Propagate each applied edit. The next rule will be applied relative to the application of this edit.
-    if let Rule::Rewrite { .. } = rule {
+    if rule.is_rewrite() {
       if let Some(edit) = self.get_edit(rule.clone(), rule_store, scope_node, true) {
         self.rewrites_mut().push(edit.clone());
         query_again = true;
@@ -560,7 +560,7 @@ impl SourceCodeUnit {
           recursive,
           replace_node_tag,
         ),
-      Rule::Dummy { .. } => vec![],
+      _ => vec![],
     };
 
     for p_match in all_query_matches {

--- a/polyglot/piranha/src/models/unit_tests/rule_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/rule_test.rs
@@ -33,10 +33,14 @@ fn test_rule_try_instantiate_positive() {
   ]);
   let instantiated_rule = rule.try_instantiate(&substitutions);
   assert!(instantiated_rule.is_ok());
-  assert_eq!(
-    instantiated_rule.ok().unwrap().query(),
-    "(((assignment_expression left: (_) @a.lhs right: (_) @a.rhs) @abc) (#eq? @a.lhs \"foobar\"))"
-  )
+  if let Rule::Rewrite { query, .. } = instantiated_rule.unwrap() {
+    assert_eq!(
+      query,
+      "(((assignment_expression left: (_) @a.lhs right: (_) @a.rhs) @abc) (#eq? @a.lhs \"foobar\"))"
+    );  
+  } else {
+    assert!(false);
+  }
 }
 
 /// Tests whether a valid rule can be is *not* instantiated given invalid substitutions.

--- a/polyglot/piranha/test-resources/go/structural_find/for_loop/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/go/structural_find/for_loop/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["go"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["go"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["java"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/java/find_and_propagate/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/find_and_propagate/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["java"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/java/insert_field_and_initializer/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/insert_field_and_initializer/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["java"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["java"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/java/structural_find/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/structural_find/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["java"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/kt/feature_flag_system_2/control/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/kt/feature_flag_system_2/control/configurations/rules.toml
@@ -87,7 +87,7 @@ matcher =   """(
 (#eq? @crhs "\\\"@namespace\\\"")
 (#eq? @interface_annotation_name "ParameterDefinition")
 )"""
-queries = [] 
+ 
 
 # For @m_name = `isStaleFeature`, @treated = `true`
 # Before :

--- a/polyglot/piranha/test-resources/kt/feature_flag_system_2/treated/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/kt/feature_flag_system_2/treated/configurations/rules.toml
@@ -87,7 +87,7 @@ matcher =   """(
 (#eq? @crhs "\\\"@namespace\\\"")
 (#eq? @interface_annotation_name "ParameterDefinition")
 )"""
-queries = [] 
+ 
 
 # For @m_name = `isStaleFeature`, @treated = `true`
 # Before :

--- a/polyglot/piranha/test-resources/kt/file_scoped_chain_rules/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/kt/file_scoped_chain_rules/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["kt"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/kt/file_scoped_chain_rules/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/kt/file_scoped_chain_rules/configurations/rules.toml
@@ -32,7 +32,7 @@ matcher = """(
 (function_declaration (simple_identifier) @name) @md
 (#eq? @name "create")
 )"""
-queries = []
+
 
 
 [[rules]]

--- a/polyglot/piranha/test-resources/python/structural_find/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/python/structural_find/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["py"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/strings/rules_with_no_holes/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/strings/rules_with_no_holes/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["strings"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/ts/structural_find/find_fors/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/ts/structural_find/find_fors/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["ts"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/ts/structural_find/find_fors_within_functions/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/ts/structural_find/find_fors_within_functions/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["ts"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/ts/structural_find/find_fors_within_functions_not_within_whiles/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/ts/structural_find/find_fors_within_functions_not_within_whiles/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["ts"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/tsx/structural_find/find_jsx_elements/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/tsx/structural_find/find_jsx_elements/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["tsx"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["tsx"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/rules.toml
@@ -28,4 +28,4 @@ matcher = """
     ) @j
 )
 """
-queries = []
+

--- a/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_variable_declarators_not_within_divs/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_variable_declarators_not_within_divs/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["tsx"]
-substitutions = []
+


### PR DESCRIPTION
This PR does the following : 
1. convert Rules to an enum (Rewrite, MatchOnly, Dummy )
2. Convert fields of type `Option<HashSet<...>>` -> `HashSet<...>`
3. Add `serde default` to fields of type  HashSet/Vec so that folks **don't have to**  define empty lists. 

Real changes for this PR only in `rules.rs`.


#### Why am I doing all of this ? 

I feel in our rapid prototyping days we made choices :| Anyhoo...

We support three kinds of rules - Rewrite Rules, Match Only rules, Dummy Rules (helpers for recurssion)
We also eventually plan to split Rewrite rules into insert/update/delete. 

Currently we just populate the rules object (via deserialization) and check the "type" of rule by evaluating what fields are empty. Now in our core algorithm, we have control paths for each kind of rule (currently guarded under `if-else` conditions). 
This is getting cumbersome, because it gets confusion to track code path of each type of rule (and makes it easier to introduce bugs), and makes it intimidating to add new features. I eventually want to make all of this more typed at rust level. 

Currently : 
```
struct  Rule {
  name: String,
  query: String, 
   ..
}

impl Rule {
    fn isMatchOnly(){ .. }
    fn isRewrite(){ .. }
    ...
}
fn core_algo(rule: Rule){ 
   ..
   if rule.isMatcOnly() {
    ..
   }
   if rule.isRewrite() {
    ..
   }
 }

fn core_algo_helpers(rule: Rule){ .. }
```
Things to note here:
1. We have one single Rule struct
2. At some abstract level the core algorithm accepts a `Rule`, and all its helpers also accept rule.  In each of these functions we have used `if else` to check the kind of rule. Using `if-else`  is voluntary, so it is easy to have unhandled scenarios. 

Now : 

```
enum  Rule {
  Rewrite{
     name: String,
     query: String, 
     replace: String, 
     ..
   }
 MatchOnly {
     name: String,
     query: String, 
     ..
   }
   ..
}

impl Rule {
    ...
}

fn core_algo(rule: Rule){
   
    match rule {
       Rewrite (..) =>
       MatcOnly (..) =>
    }

 }

fn core_algo_helpers(rule: Rule){ .. }
```
Benefits of this: 
1. Everywhere within `core_algo` if we use Rule we (as in I am) are forced to reason about each category of `Rule`. 
-----------
**Eventually  (in follow up PRs)**  I am planning to do something like below:
```
struct Rewrite{
     name: String,
     query: String, 
     replace: String, 
     ..
   }
struct  MatchOnly {
     name: String,
     query: String, 
     ..
   }
...
enum  Rule {
  Rewrite(Rewrite),
 MatchOnly (MatchOnly)
   ..
}
// all rules have a name 
trait PiranhaRule {
      fn name();
}

trait PiranhaMatcher: PiranhaRule {
    fn query(); 
    fn constraints(); 
    fn holes(); 
    ..
}

// All rewrite rules have a matcher 
trait PiranhaRewrite : PiranhaMatcher {
     fn replace();
}  

impl Rule {
    ...
}

fn core_algo<T: PiranhaRule>(rule: T){ .. }

fn core_algo_helpers1<T: PiranhaMatcher>(rule: T){ .. }
fn core_algo_helpers2<T: PiranhaRewrite>(rule: T){ .. }
```

Benefits of doing this: 
1. Reduces awkwardness introduced by repeated pattern matching 
2. Makes code more reusable (because now we will have functions accepting parameters bound by our traits)
3. Will make it easy when we plan to introduce the new operators 









