### PR TITLE
Handle `default` properly, and extract string literals to constants 

### DIFF
--- a/polyglot/piranha/src/models/default_configs.rs
+++ b/polyglot/piranha/src/models/default_configs.rs
@@ -2,6 +2,16 @@ use std::collections::HashMap;
 
 use super::language::PiranhaLanguage;
 
+
+pub const JAVA: &str = "java";
+pub const KOTLIN: &str = "kt";
+pub const GO: &str = "go";
+pub const PYTHON: &str = "py";
+pub const SWIFT: &str = "swift";
+pub const STRINGS: &str = "strings";
+pub const TYPESCRIPT: &str = "ts"; 
+pub const TSX: &str = "tsx";
+
 pub fn default_number_of_ancestors_in_parent_scope() -> u8 {
   4
 }
@@ -11,7 +21,7 @@ pub fn default_languages() -> Vec<String> {
 }
 
 pub fn default_language() -> String {
-  "java".to_string()
+  JAVA.to_string()
 }
 
 pub fn default_substitutions() -> Vec<Vec<String>> {

--- a/polyglot/piranha/src/models/language.rs
+++ b/polyglot/piranha/src/models/language.rs
@@ -5,7 +5,7 @@ use tree_sitter::{Parser, Query};
 use crate::utilities::parse_toml;
 
 use super::{
-  default_configs::default_language,
+  default_configs::{default_language, GO, JAVA, KOTLIN, PYTHON, STRINGS, SWIFT, TSX, TYPESCRIPT},
   outgoing_edges::Edges,
   rule::Rules,
   scopes::{ScopeConfig, ScopeGenerator},
@@ -75,27 +75,31 @@ impl PiranhaLanguage {
 
 impl Default for PiranhaLanguage {
   fn default() -> Self {
-    let rules: Rules = parse_toml(include_str!("../cleanup_rules/java/rules.toml"));
-    let edges: Edges = parse_toml(include_str!("../cleanup_rules/java/edges.toml"));
-    PiranhaLanguage {
-      name: default_language(),
-      supported_language: SupportedLanguage::default(),
-      language: tree_sitter_java::language(),
-      rules: Some(rules),
-      edges: Some(edges),
-      scopes: parse_toml::<ScopeConfig>(include_str!("../cleanup_rules/java/scope_config.toml"))
-        .scopes()
-        .to_vec(),
-      comment_nodes: vec!["line_comment".to_string(), "block_comment".to_string()],
-    }
+    PiranhaLanguage::from(default_language().as_str())
   }
 }
 
 impl From<&str> for PiranhaLanguage {
   fn from(language: &str) -> Self {
     match language {
-      "java" => PiranhaLanguage::default(),
-      "go" => PiranhaLanguage {
+      JAVA => {
+        let rules: Rules = parse_toml(include_str!("../cleanup_rules/java/rules.toml"));
+        let edges: Edges = parse_toml(include_str!("../cleanup_rules/java/edges.toml"));
+        Self {
+          name: language.to_string(),
+          supported_language: SupportedLanguage::default(),
+          language: tree_sitter_java::language(),
+          rules: Some(rules),
+          edges: Some(edges),
+          scopes: parse_toml::<ScopeConfig>(include_str!(
+            "../cleanup_rules/java/scope_config.toml"
+          ))
+          .scopes()
+          .to_vec(),
+          comment_nodes: vec!["line_comment".to_string(), "block_comment".to_string()],
+        }
+      }
+      GO => PiranhaLanguage {
         name: language.to_string(),
         supported_language: SupportedLanguage::Go,
         language: tree_sitter_go::language(),
@@ -104,7 +108,7 @@ impl From<&str> for PiranhaLanguage {
         scopes: vec![],
         comment_nodes: vec![],
       },
-      "kt" => {
+      KOTLIN => {
         let rules: Rules = parse_toml(include_str!("../cleanup_rules/kt/rules.toml"));
         let edges: Edges = parse_toml(include_str!("../cleanup_rules/kt/edges.toml"));
         PiranhaLanguage {
@@ -119,7 +123,7 @@ impl From<&str> for PiranhaLanguage {
           comment_nodes: vec!["comment".to_string()],
         }
       }
-      "py" => PiranhaLanguage {
+      PYTHON => PiranhaLanguage {
         name: language.to_string(),
         supported_language: SupportedLanguage::Python,
         language: tree_sitter_python::language(),
@@ -128,7 +132,7 @@ impl From<&str> for PiranhaLanguage {
         scopes: vec![],
         comment_nodes: vec![],
       },
-      "swift" => PiranhaLanguage {
+      SWIFT => PiranhaLanguage {
         name: language.to_string(),
         supported_language: SupportedLanguage::Swift,
         language: tree_sitter_swift::language(),
@@ -139,7 +143,7 @@ impl From<&str> for PiranhaLanguage {
         rules: None,
         edges: None,
       },
-      "strings" => PiranhaLanguage {
+      STRINGS => PiranhaLanguage {
         name: language.to_string(),
         supported_language: SupportedLanguage::Strings,
         language: tree_sitter_strings::language(),
@@ -148,7 +152,7 @@ impl From<&str> for PiranhaLanguage {
         scopes: vec![],
         comment_nodes: vec![],
       },
-      "ts" => PiranhaLanguage {
+      TYPESCRIPT => PiranhaLanguage {
         name: language.to_string(),
         supported_language: SupportedLanguage::Ts,
         language: tree_sitter_typescript::language_typescript(),
@@ -157,7 +161,7 @@ impl From<&str> for PiranhaLanguage {
         scopes: vec![],
         comment_nodes: vec![],
       },
-      "tsx" => PiranhaLanguage {
+      TSX => PiranhaLanguage {
         name: language.to_string(),
         supported_language: SupportedLanguage::Tsx,
         language: tree_sitter_typescript::language_tsx(),

--- a/polyglot/piranha/src/models/language.rs
+++ b/polyglot/piranha/src/models/language.rs
@@ -87,7 +87,7 @@ impl From<&str> for PiranhaLanguage {
         let edges: Edges = parse_toml(include_str!("../cleanup_rules/java/edges.toml"));
         Self {
           name: language.to_string(),
-          supported_language: SupportedLanguage::default(),
+          supported_language: SupportedLanguage::Java,
           language: tree_sitter_java::language(),
           rules: Some(rules),
           edges: Some(edges),

--- a/polyglot/piranha/src/models/unit_tests/rule_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/rule_test.rs
@@ -10,7 +10,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
  express or implied. See the License for the specific language governing permissions and
  limitations under the License.
 */
-use crate::models::language::PiranhaLanguage;
+use crate::models::{language::PiranhaLanguage, default_configs::JAVA};
 use std::collections::HashSet;
 use {
   super::Rule,
@@ -82,7 +82,7 @@ fn test_get_edit_positive_recursive() {
 
   let mut rule_store = RuleStore::default();
 
-  let mut parser = PiranhaLanguage::from("java").parser();
+  let mut parser = PiranhaLanguage::from(JAVA).parser();
 
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
@@ -129,7 +129,7 @@ fn test_get_edit_negative_recursive() {
         }";
 
   let mut rule_store = RuleStore::default();
-  let mut parser = PiranhaLanguage::from("java").parser();
+  let mut parser = PiranhaLanguage::from(JAVA).parser();
 
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
@@ -169,7 +169,7 @@ fn test_get_edit_for_context_positive() {
 
   let mut rule_store = RuleStore::default();
 
-  let mut parser = PiranhaLanguage::from("java").parser();
+  let mut parser = PiranhaLanguage::from(JAVA).parser();
 
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
@@ -209,7 +209,7 @@ fn test_get_edit_for_context_negative() {
 
   let mut rule_store = RuleStore::default();
 
-  let mut parser = PiranhaLanguage::from("java").parser();
+  let mut parser = PiranhaLanguage::from(JAVA).parser();
 
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,

--- a/polyglot/piranha/src/models/unit_tests/scopes_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/scopes_test.rs
@@ -1,4 +1,4 @@
-use crate::models::language::PiranhaLanguage;
+use crate::models::{language::PiranhaLanguage, default_configs::JAVA};
 
 /*
 Copyright (c) 2022 Uber Technologies, Inc.
@@ -98,7 +98,7 @@ fn test_get_scope_query_positive() {
     }";
   
   let mut rule_store =  _get_rule_store();
-  let mut parser = PiranhaLanguage::from("java").parser();
+  let mut parser = PiranhaLanguage::from(JAVA).parser();
 
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
@@ -160,7 +160,7 @@ fn test_get_scope_query_negative() {
       }
     }";
   let mut rule_store = _get_rule_store();
-  let mut parser = PiranhaLanguage::from("java").parser();
+  let mut parser = PiranhaLanguage::from(JAVA).parser();
 
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,

--- a/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
+++ b/polyglot/piranha/src/models/unit_tests/source_code_unit_test.rs
@@ -20,7 +20,7 @@ use tempdir::TempDir;
 
 use tree_sitter::Parser;
 
-use crate::models::{piranha_arguments::{PiranhaArguments, PiranhaArgumentsBuilder}, rule::Rule, constraint::Constraint, rule_store::RuleStore, language::PiranhaLanguage};
+use crate::models::{piranha_arguments::{PiranhaArguments, PiranhaArgumentsBuilder}, rule::Rule, constraint::Constraint, rule_store::RuleStore, language::PiranhaLanguage, default_configs::{JAVA, SWIFT}};
 use {
   super::SourceCodeUnit,
   crate::{
@@ -64,7 +64,7 @@ fn range(
 }
 
 fn get_java_tree_sitter_language() -> PiranhaLanguage {
-   PiranhaLanguage::from("java")
+   PiranhaLanguage::from(JAVA)
 }
 
 /// Positive test of an edit being applied  given replacement range  and replacement string.
@@ -157,7 +157,7 @@ fn test_apply_edit_comma_handling_via_regex() {
   }
 }";
 
-  let swift = PiranhaLanguage::from("swift");
+  let swift = PiranhaLanguage::from(SWIFT);
 
   let mut parser = swift.parser();
 

--- a/polyglot/piranha/src/tests/test_piranha_go.rs
+++ b/polyglot/piranha/src/tests/test_piranha_go.rs
@@ -11,9 +11,11 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+use crate::models::default_configs::GO;
+
 use super::{initialize, run_match_test};
 
-static LANGUAGE: &str = "go";
+static LANGUAGE: &str = GO;
 
 #[test]
 fn test_go_match_only_go_expr_for_loop() {

--- a/polyglot/piranha/src/tests/test_piranha_java.rs
+++ b/polyglot/piranha/src/tests/test_piranha_java.rs
@@ -11,9 +11,11 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+use crate::models::default_configs::JAVA;
+
 use super::{initialize, run_match_test, run_rewrite_test};
 
-static LANGUAGE: &str = "java";
+static LANGUAGE: &str = JAVA;
 
 #[test]
 fn test_java_scenarios_treated_ff1() {

--- a/polyglot/piranha/src/tests/test_piranha_swift.rs
+++ b/polyglot/piranha/src/tests/test_piranha_swift.rs
@@ -11,9 +11,11 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+use crate::models::default_configs::SWIFT;
+
 use super::{initialize, run_rewrite_test};
 
-static LANGUAGE: &str = "swift";
+static LANGUAGE: &str = SWIFT;
 
 // Tests cascading file delete based on enum and type alias.
 // This scenario is "derived" from plugin cleanup.

--- a/polyglot/piranha/src/tests/test_piranha_ts.rs
+++ b/polyglot/piranha/src/tests/test_piranha_ts.rs
@@ -11,9 +11,11 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+use crate::models::default_configs::TYPESCRIPT;
+
 use super::{initialize, run_match_test};
 
-static LANGUAGE: &str = "ts";
+static LANGUAGE: &str = TYPESCRIPT;
 
 #[test]
 fn test_ts_match_only_find_fors() {

--- a/polyglot/piranha/src/tests/test_piranha_tsx.rs
+++ b/polyglot/piranha/src/tests/test_piranha_tsx.rs
@@ -11,9 +11,11 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+use crate::models::default_configs::TSX;
+
 use super::{initialize, run_match_test};
 
-static LANGUAGE: &str = "tsx";
+static LANGUAGE: &str = TSX;
 
 #[test]
 fn test_ts_match_only_find_fors() {

--- a/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
+++ b/polyglot/piranha/src/utilities/unit_tests/tree_sitter_utilities_test.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 
 use tree_sitter::Query;
 
-use crate::models::language::PiranhaLanguage;
+use crate::models::{language::PiranhaLanguage, default_configs::JAVA};
 
 use super::{substitute_tags, PiranhaHelpers};
 
@@ -34,7 +34,7 @@ fn test_get_all_matches_for_query_positive() {
         }
       }
     "#;
-  let language = PiranhaLanguage::from("java");
+  let language = PiranhaLanguage::from(JAVA);
   let query = Query::new(
     *language.language(),
     r#"((
@@ -54,7 +54,7 @@ fn test_get_all_matches_for_query_positive() {
   )
   .unwrap();
 
-  let mut parser = PiranhaLanguage::from("java").parser();
+  let mut parser = PiranhaLanguage::from(JAVA).parser();
   let ast = parser
     .parse(&source_code, None)
     .expect("Could not parse code");
@@ -85,7 +85,7 @@ fn test_get_all_matches_for_query_negative() {
         }
       }
     "#;
-  let language = PiranhaLanguage::from("java");
+  let language = PiranhaLanguage::from(JAVA);
   let query = Query::new(
     *language.language(),
     r#"((
@@ -105,7 +105,7 @@ fn test_get_all_matches_for_query_negative() {
   )
   .unwrap();
 
-  let mut parser = PiranhaLanguage::from("java").parser();
+  let mut parser = PiranhaLanguage::from(JAVA).parser();
   let ast = parser
     .parse(&source_code, None)
     .expect("Could not parse code");


### PR DESCRIPTION
Addresses the comments from #283 . 
Extract string literal as constants