### PR TITLE
Add support to execute Piranha only on a specific file

### DIFF
--- a/polyglot/piranha/README.md
+++ b/polyglot/piranha/README.md
@@ -155,11 +155,11 @@ Polyglot Piranha
 A refactoring tool that eliminates dead code related to stale feature flags.
 
 USAGE:
-    polyglot_piranha --path-to-codebase <PATH_TO_CODEBASE> --path-to-configurations <PATH_TO_CONFIGURATIONS>
+    polyglot_piranha [OPTIONS] --path-to-codebase <PATH_TO_CODEBASE> --path-to-configurations <PATH_TO_CONFIGURATIONS>
 
 OPTIONS:
     -c, --path-to-codebase <PATH_TO_CODEBASE>
-            Path to source code folder
+            Path to source code folder or file
 
     -d, --dry-run <DRY_RUN>
             Disables in-place rewriting of code [default: false]
@@ -172,7 +172,7 @@ OPTIONS:
             Print help information
 
     -j, --path-to-output-summary <PATH_TO_OUTPUT_SUMMARY>
-            Path to output summary json
+            Path to output summary json file
 ```
 
 The output JSON is the serialization of- [`PiranhaOutputSummary`](/polyglot/piranha/src/models/piranha_output.rs) produced for each file touched or analyzed by Piranha.

--- a/polyglot/piranha/src/lib.rs
+++ b/polyglot/piranha/src/lib.rs
@@ -190,11 +190,11 @@ impl FlagCleaner {
   /// Note that `WalkDir` traverses the directory with parallelism.
   /// If all the global rules have no holes (i.e. we will have no grep patterns), we will try to find a match for each global rule in every file in the target.
   fn get_files_containing_feature_flag_api_usage(&self) -> HashMap<PathBuf, String> {
-    let _path_to_code_base = Path::new(self.path_to_codebase.as_str()).to_path_buf();
-    if _path_to_code_base.is_file() {
+    let _path_to_codebase = Path::new(self.path_to_codebase.as_str()).to_path_buf();
+    if _path_to_codebase.is_file() {
       return HashMap::from_iter([(
-        _path_to_code_base.to_path_buf(),
-        read_file(&_path_to_code_base).unwrap()
+        _path_to_codebase.to_path_buf(),
+        read_file(&_path_to_codebase).unwrap()
       )]);
     }
     let mut files: HashMap<PathBuf, String> = WalkDir::new(&self.path_to_codebase)
@@ -238,7 +238,7 @@ impl FlagCleaner {
     let graph_rule_store = RuleStore::new(args);
     Self {
       rule_store: graph_rule_store,
-      path_to_codebase: String::from(args.path_to_code_base()),
+      path_to_codebase: String::from(args.path_to_codebase()),
       relevant_files: HashMap::new(),
     }
   }

--- a/polyglot/piranha/src/lib.rs
+++ b/polyglot/piranha/src/lib.rs
@@ -21,7 +21,10 @@ pub mod models;
 mod tests;
 pub mod utilities;
 
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+  collections::HashMap,
+  path::{Path, PathBuf},
+};
 
 use colored::Colorize;
 use itertools::Itertools;
@@ -31,7 +34,7 @@ use regex::Regex;
 use tree_sitter::Parser;
 
 use crate::{
-  models::{rule_store::RuleStore, piranha_input::PiranhaInput},
+  models::{piranha_input::PiranhaInput, rule_store::RuleStore},
   utilities::read_file,
 };
 
@@ -173,39 +176,61 @@ impl FlagCleaner {
     }
   }
 
+  fn any_global_rules_has_holes(&self) -> bool {
+    self
+      .rule_store
+      .global_rules()
+      .iter()
+      .any(|x| !x.holes().is_empty())
+  }
+
+  // fn does_file_extension_match(dir_en)
+
   /// Gets all the files from the code base that (i) have the language appropriate file extension, and (ii) contains the grep pattern.
   /// Note that `WalkDir` traverses the directory with parallelism.
   /// If all the global rules have no holes (i.e. we will have no grep patterns), we will try to find a match for each global rule in every file in the target.
   fn get_files_containing_feature_flag_api_usage(&self) -> HashMap<PathBuf, String> {
-    let no_global_rules_with_holes = self
-      .rule_store
-      .global_rules()
-      .iter()
-      .any(|x| x.holes().is_empty());
-    let pattern = self.get_grep_heuristics();
-    let files: HashMap<PathBuf, String> = WalkDir::new(&self.path_to_codebase)
+    let _path_to_code_base = Path::new(self.path_to_codebase.as_str()).to_path_buf();
+    if _path_to_code_base.is_file() {
+      return HashMap::from_iter([(
+        _path_to_code_base.to_path_buf(),
+        read_file(&_path_to_code_base).unwrap()
+      )]);
+    }
+    let mut files: HashMap<PathBuf, String> = WalkDir::new(&self.path_to_codebase)
       // Walk over the entire code base
       .into_iter()
       // Ignore errors
       .filter_map(|e| e.ok())
       // Filter files with the desired extension
-      .filter(|de| {
-        de.path()
-          .extension()
-          .and_then(|e| {
-            e.to_str()
-              .filter(|x| x.eq(&self.rule_store.piranha_args().get_language()))
-          })
-          .is_some()
-      })
+      .filter(|de| self.does_file_extension_match(de))
       // Read the file
       .map(|f| (f.path(), read_file(&f.path()).unwrap()))
-      // Filter the files containing the desired regex pattern
-      .filter(|x| no_global_rules_with_holes || pattern.is_match(x.1.as_str()))
       .collect();
-    #[rustfmt::skip]
-    debug!("{}", format!("Will parse and analyze {} files.", files.len()).green());
+
+    if self.any_global_rules_has_holes() {
+      let pattern = self.get_grep_heuristics();
+      files = files
+        .iter()
+        .filter(|x| pattern.is_match(x.1.as_str()))
+        .map(|(x, y)| (x.clone(), y.clone()))
+        .collect();
+    }
+    debug!(
+      "{}",
+      format!("{} files will be analyzed.", files.len()).green()
+    );
     files
+  }
+
+  fn does_file_extension_match(&self, de: &jwalk::DirEntry<((), ())>) -> bool {
+    de.path()
+      .extension()
+      .and_then(|e| {
+        e.to_str()
+          .filter(|x| x.eq(&self.rule_store.piranha_args().get_language()))
+      })
+      .is_some()
   }
 
   /// Instantiate Flag-cleaner

--- a/polyglot/piranha/src/lib.rs
+++ b/polyglot/piranha/src/lib.rs
@@ -176,6 +176,8 @@ impl FlagCleaner {
     }
   }
 
+
+  /// Checks if any global rule has a hole
   fn any_global_rules_has_holes(&self) -> bool {
     self
       .rule_store
@@ -183,8 +185,6 @@ impl FlagCleaner {
       .iter()
       .any(|x| !x.holes().is_empty())
   }
-
-  // fn does_file_extension_match(dir_en)
 
   /// Gets all the files from the code base that (i) have the language appropriate file extension, and (ii) contains the grep pattern.
   /// Note that `WalkDir` traverses the directory with parallelism.
@@ -212,6 +212,7 @@ impl FlagCleaner {
       let pattern = self.get_grep_heuristics();
       files = files
         .iter()
+        // Filter the files containing the desired regex pattern
         .filter(|x| pattern.is_match(x.1.as_str()))
         .map(|(x, y)| (x.clone(), y.clone()))
         .collect();

--- a/polyglot/piranha/src/main.rs
+++ b/polyglot/piranha/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
   debug!("Piranha Arguments are \n{:#?}", args);
   let piranha_output_summaries = execute_piranha(&args);
 
-  if let Some(path) = args.path_to_output_summaries() {
+  if let Some(path) = args.path_to_output_summary() {
     write_output_summary(piranha_output_summaries, path);
   }
 

--- a/polyglot/piranha/src/models/default_configs.rs
+++ b/polyglot/piranha/src/models/default_configs.rs
@@ -42,7 +42,7 @@ pub fn default_name_of_piranha_argument_toml() -> String {
   "piranha_arguments.toml".to_string()
 }
 
-pub fn default_path_to_code_base() -> String {
+pub fn default_path_to_codebase() -> String {
   String::new()
 }
 

--- a/polyglot/piranha/src/models/piranha_arguments.rs
+++ b/polyglot/piranha/src/models/piranha_arguments.rs
@@ -18,7 +18,7 @@ use super::{
     default_cleanup_comments, default_cleanup_comments_buffer,
     default_delete_consecutive_new_lines, default_delete_file_if_empty, default_dry_run,
     default_global_tag_prefix, default_input_substitutions, default_languages,
-    default_number_of_ancestors_in_parent_scope, default_path_to_code_base,
+    default_number_of_ancestors_in_parent_scope, default_path_to_codebase,
     default_path_to_configurations, default_path_to_output_summaries, default_piranha_language,
     default_substitutions,
   },
@@ -30,19 +30,19 @@ use getset::{CopyGetters, Getters};
 use serde_derive::Deserialize;
 use std::{collections::HashMap, path::PathBuf};
 
-/// A refactoring tool that eliminates dead code related to stale feature flags.
+/// A refactoring tool that eliminates dead code related to stale feature flags
 #[derive(Deserialize, Clone, Builder, Getters, CopyGetters, Debug, Parser, Default)]
-#[clap(name = "Piranha")]
+#[clap(name = "Polyglot Piranha")]
 pub struct PiranhaArguments {
-  /// Path to source code folder/file.
+  /// Path to source code folder or file
   #[get = "pub"]
-  #[builder(default = "default_path_to_code_base()")]
-  #[clap(short = 'c', long = "path_to_code_base")]
+  #[builder(default = "default_path_to_codebase()")]
+  #[clap(short = 'c', long)]
   #[serde(skip)]
-  path_to_code_base: String,
+  path_to_codebase: String,
   // Input arguments provided to Piranha, mapped to tag names -
   // @stale_flag_name, @namespace, @treated, @treated_complement
-  // These substitutions instantiate the initial set of feature flag rules.
+  // These substitutions instantiate the initial set of feature flag rules
   #[get = "pub"]
   #[builder(default = "default_input_substitutions()")]
   #[clap(skip)]
@@ -54,18 +54,19 @@ pub struct PiranhaArguments {
   #[serde(default = "default_substitutions")]
   substitutions: Vec<Vec<String>>,
 
-  /// Folder containing the API specific rules
+  /// Directory containing the configuration files - `piranha_arguments.toml`, `rules.toml`,
+  /// and  `edges.toml` (optional)
   #[get = "pub"]
   #[builder(default = "default_path_to_configurations()")]
-  #[clap(short = 'f', long = "path_to_configurations")]
+  #[clap(short = 'f', long)]
   #[serde(skip)]
   path_to_configurations: String,
   /// Path to output summary json file
   #[get = "pub"]
   #[builder(default = "default_path_to_output_summaries()")]
-  #[clap(short = 'j', long = "path_to_output_summaries")]
+  #[clap(short = 'j', long)]
   #[serde(skip)]
-  path_to_output_summaries: Option<String>,
+  path_to_output_summary: Option<String>,
 
   // a list of file extensions
   // #[get = "pub"]
@@ -164,10 +165,10 @@ impl PiranhaArguments {
 
   pub(crate) fn merge(&self, other: PiranhaArguments) -> Self {
     Self {
-      path_to_code_base: Self::_merge(
-        self.path_to_code_base.clone(),
-        other.path_to_code_base,
-        default_path_to_code_base(),
+      path_to_codebase: Self::_merge(
+        self.path_to_codebase.clone(),
+        other.path_to_codebase,
+        default_path_to_codebase(),
       ),
       input_substitutions: Self::_merge(
         self.input_substitutions.clone(),
@@ -184,9 +185,9 @@ impl PiranhaArguments {
         other.path_to_configurations,
         default_path_to_configurations(),
       ),
-      path_to_output_summaries: Self::_merge(
-        self.path_to_output_summaries.clone(),
-        other.path_to_output_summaries,
+      path_to_output_summary: Self::_merge(
+        self.path_to_output_summary.clone(),
+        other.path_to_output_summary,
         default_path_to_output_summaries(),
       ),
       language: Self::_merge(self.language.clone(), other.language, default_languages()),

--- a/polyglot/piranha/src/models/piranha_arguments.rs
+++ b/polyglot/piranha/src/models/piranha_arguments.rs
@@ -34,7 +34,7 @@ use std::{collections::HashMap, path::PathBuf};
 #[derive(Deserialize, Clone, Builder, Getters, CopyGetters, Debug, Parser, Default)]
 #[clap(name = "Piranha")]
 pub struct PiranhaArguments {
-  /// Path to source code folder.
+  /// Path to source code folder/file.
   #[get = "pub"]
   #[builder(default = "default_path_to_code_base()")]
   #[clap(short = 'c', long = "path_to_code_base")]

--- a/polyglot/piranha/src/models/piranha_input.rs
+++ b/polyglot/piranha/src/models/piranha_input.rs
@@ -25,9 +25,9 @@ impl From<PiranhaInput> for PiranhaArguments {
         path_to_configurations,
         dry_run,
       } => PiranhaArgumentsBuilder::default()
-        .path_to_code_base(path_to_codebase)
+        .path_to_codebase(path_to_codebase)
         .path_to_configurations(path_to_configurations)
-        .path_to_output_summaries(None)
+        .path_to_output_summary(None)
         .dry_run(dry_run)
         .build()
         .unwrap(),

--- a/polyglot/piranha/src/tests/mod.rs
+++ b/polyglot/piranha/src/tests/mod.rs
@@ -42,29 +42,36 @@ fn initialize() {
   });
 }
 
+fn run_match_test_for_file(relative_path_to_tests:&str, file_name: &str, number_of_matches: usize) {
+  let path_to_configurations = format!("test-resources/{relative_path_to_tests}/configurations/");
+  let path_to_codebase = format!("test-resources/{relative_path_to_tests}/input/{file_name}");
+  _run_match_test(path_to_codebase, path_to_configurations, number_of_matches);
+}
+
 // Runs a piranha over the target `<relative_path_to_tests>/input` (using configurations `<relative_path_to_tests>/configuration`)
 // and checks if the number of matches == `number_of_matches`.
 fn run_match_test(relative_path_to_tests: &str, number_of_matches: usize) {
   let path_to_configurations = format!("test-resources/{relative_path_to_tests}/configurations/");
   let path_to_codebase = format!("test-resources/{relative_path_to_tests}/input/");
+  _run_match_test(path_to_codebase, path_to_configurations, number_of_matches);
+}
 
-  let piranha_input = PiranhaInput::API {
+fn _run_match_test(path_to_codebase: String, path_to_configurations: String, number_of_matches: usize) {
+    let piranha_input = PiranhaInput::API {
     path_to_codebase,
     path_to_configurations,
     dry_run: true,
-  };
-  let args = PiranhaArguments::from(piranha_input);
-  print!("{:?}", args);
-
-  let output_summaries = execute_piranha(&args);
-
-  assert_eq!(
+      };
+    let args = PiranhaArguments::from(piranha_input);
+    print!("{:?}", args);
+    let output_summaries = execute_piranha(&args);
+    assert_eq!(
     output_summaries
       .iter()
       .flat_map(|os| os.matches().iter())
       .count(),
     number_of_matches
-  );
+      );
 }
 
 // Runs a piranha over the target `<relative_path_to_tests>/input` (using configurations `<relative_path_to_tests>/configuration`)

--- a/polyglot/piranha/src/tests/test_piranha_java.rs
+++ b/polyglot/piranha/src/tests/test_piranha_java.rs
@@ -11,8 +11,6 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-
-use super::{initialize, run_match_test, run_rewrite_test, run_match_test_for_file};
 use crate::models::default_configs::JAVA;
 
 use super::{initialize, run_match_test, run_rewrite_test, run_match_test_for_file};

--- a/polyglot/piranha/src/tests/test_piranha_java.rs
+++ b/polyglot/piranha/src/tests/test_piranha_java.rs
@@ -11,7 +11,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use super::{initialize, run_match_test, run_rewrite_test};
+use super::{initialize, run_match_test, run_rewrite_test, run_match_test_for_file};
 
 static LANGUAGE: &str = "java";
 
@@ -97,5 +97,5 @@ fn test_java_scenarios_consecutive_scope_level_rules() {
 #[test]
 fn test_java_match_only() {
   initialize();
-  run_match_test(&format!("{}/{}", LANGUAGE, "structural_find"), 20);
+  run_match_test_for_file(&format!("{}/{}", LANGUAGE, "structural_find"),"XPFlagCleanerPositiveCases.java",  20);
 }


### PR DESCRIPTION
This PR does two things : 
1. Adds support to allow developers to apply piranha only on file 
2. Renames `PiranhaArgument` fields (so that they do not break the command line interface we provided earlier) 
3. Update readme 