### PR TITLE
Simplify fields in the Rule and constraint

### DIFF
--- a/polyglot/piranha/demo/match_only/go/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/match_only/go/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["go"]
-substitutions = []
+

--- a/polyglot/piranha/demo/match_only/go/configurations/rules.toml
+++ b/polyglot/piranha/demo/match_only/go/configurations/rules.toml
@@ -18,7 +18,7 @@ query = """
 """
 [[rules.constraints]]
 matcher = "(for_statement) @fs"
-queries=[]
+
 
 [[rules]]
 name = "find_for"

--- a/polyglot/piranha/demo/match_only/ts/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/match_only/ts/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["ts"]
-substitutions = []
+

--- a/polyglot/piranha/demo/match_only/ts/configurations/rules.toml
+++ b/polyglot/piranha/demo/match_only/ts/configurations/rules.toml
@@ -26,7 +26,7 @@ query = """
 """
 [[rules.constraints]]
 matcher = "(function_declaration) @fs"
-queries=[]
+
 
 [[rules]]
 name = "find_fors_within_functions_not_within_whiles"

--- a/polyglot/piranha/demo/match_only/tsx/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/demo/match_only/tsx/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["tsx"]
-substitutions = []
+

--- a/polyglot/piranha/demo/match_only/tsx/configurations/rules.toml
+++ b/polyglot/piranha/demo/match_only/tsx/configurations/rules.toml
@@ -36,7 +36,7 @@ matcher = """
     ) @j
 )
 """
-queries = []
+
 
 [[rules]]
 name = "find_props_identifiers_within_variable_declarators_not_within_divs"

--- a/polyglot/piranha/src/lib.rs
+++ b/polyglot/piranha/src/lib.rs
@@ -144,7 +144,7 @@ impl FlagCleaner {
 
       debug!("\n # Global rules {}", current_rules.len());
       // Iterate over each file containing the usage of the feature flag API
-      for (path, content) in self.get_files_containing_feature_flag_api_usage() {
+      for (path, content) in self.get_relevant_files_containing_hole_substitutions() {
         self
           .relevant_files
           // Get the content of the file for `path` from the cache `relevant_files`
@@ -189,11 +189,13 @@ impl FlagCleaner {
   /// Gets all the files from the code base that (i) have the language appropriate file extension, and (ii) contains the grep pattern.
   /// Note that `WalkDir` traverses the directory with parallelism.
   /// If all the global rules have no holes (i.e. we will have no grep patterns), we will try to find a match for each global rule in every file in the target.
-  fn get_files_containing_feature_flag_api_usage(&self) -> HashMap<PathBuf, String> {
+  fn get_relevant_files_containing_hole_substitutions(&self) -> HashMap<PathBuf, String> {
     let _path_to_codebase = Path::new(self.path_to_codebase.as_str()).to_path_buf();
+
+    //If the path_to_codebase is a file, then execute piranha on it 
     if _path_to_codebase.is_file() {
       return HashMap::from_iter([(
-        _path_to_codebase.to_path_buf(),
+        _path_to_codebase.clone(),
         read_file(&_path_to_codebase).unwrap()
       )]);
     }

--- a/polyglot/piranha/src/models/constraint.rs
+++ b/polyglot/piranha/src/models/constraint.rs
@@ -21,6 +21,7 @@ pub(crate) struct Constraint {
   matcher: String,
   /// The Tree-sitter queries that need to be applied in the `matcher` scope
   #[get = "pub"]
+  #[serde(default)]
   queries: Vec<String>,
 }
 

--- a/polyglot/piranha/src/models/rule.rs
+++ b/polyglot/piranha/src/models/rule.rs
@@ -40,13 +40,17 @@ pub(crate) struct Rule {
   /// Replacement pattern
   replace: Option<String>,
   /// Group(s) to which the rule belongs
-  groups: Option<HashSet<String>>,
+  #[serde(default)]
+  groups: HashSet<String>,
   /// Holes that need to be filled, in order to instantiate a rule
-  holes: Option<HashSet<String>>,
+  #[serde(default)]
+  holes: HashSet<String>,
   /// Additional constraints for matching the rule
-  constraints: Option<HashSet<Constraint>>,
+  #[serde(default)]
+  constraints: HashSet<Constraint>,
   /// Heuristics for identifying potential files containing occurrence of the rule.
-  grep_heuristics: Option<HashSet<String>>,
+  #[serde(default)]
+  grep_heuristics: HashSet<String>,
 }
 
 impl Rule {
@@ -131,7 +135,7 @@ impl Rule {
         gh.insert(x.clone());
       }
     }
-    self.grep_heuristics = Some(gh.clone());
+    self.grep_heuristics = gh.clone();
   }
 
   /// Adds the rule to a new group - "SEED" if applicable.
@@ -139,12 +143,7 @@ impl Rule {
     if self.groups().contains(&CLEAN_UP.to_string()) {
       return;
     }
-    match self.groups.as_mut() {
-      None => self.groups = Some(HashSet::from([SEED.to_string()])),
-      Some(_groups) => {
-        _groups.insert(SEED.to_string());
-      }
-    }
+    self.groups.insert(SEED.to_string());
   }
 
   pub(crate) fn replace_node(&self) -> String {
@@ -169,31 +168,19 @@ impl Rule {
   }
 
   pub(crate) fn constraints(&self) -> HashSet<Constraint> {
-    match &self.constraints {
-      Some(cs) => cs.clone(),
-      None => HashSet::new(),
-    }
+    self.constraints.clone()
   }
 
   pub(crate) fn grep_heuristics(&self) -> HashSet<String> {
-    match &self.grep_heuristics {
-      Some(cs) => cs.clone(),
-      None => HashSet::new(),
-    }
+    self.grep_heuristics.clone()
   }
 
   pub(crate) fn holes(&self) -> HashSet<String> {
-    match &self.holes {
-      Some(cs) => cs.clone(),
-      None => HashSet::new(),
-    }
+    self.holes.clone()
   }
 
   fn groups(&self) -> HashSet<String> {
-    match &self.groups {
-      Some(cs) => cs.clone(),
-      None => HashSet::new(),
-    }
+    self.groups.clone()
   }
 
   pub(crate) fn update_replace(&mut self, substitutions: &HashMap<String, String>) {
@@ -228,14 +215,10 @@ impl Rule {
       query: Some(query.to_string()),
       replace_node: Some(replace_node.to_string()),
       replace: Some(replace.to_string()),
-      groups: None,
-      holes: if holes.is_empty() { None } else { Some(holes) },
-      constraints: if constraints.is_empty() {
-        None
-      } else {
-        Some(constraints)
-      },
-      grep_heuristics: None,
+      groups: HashSet::default(),
+      holes,
+      constraints,
+      grep_heuristics: HashSet::default(),
     }
   }
 }

--- a/polyglot/piranha/test-resources/go/structural_find/for_loop/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/go/structural_find/for_loop/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["go"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["go"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/go/structural_find/go_stmt_for_loop/configurations/rules.toml
@@ -18,4 +18,4 @@ query = """
 """
 [[rules.constraints]]
 matcher = "(for_statement) @fs"
-queries=[]
+

--- a/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/consecutive_scope_level_rules/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["java"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/java/find_and_propagate/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/find_and_propagate/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["java"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/java/insert_field_and_initializer/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/insert_field_and_initializer/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["java"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/new_line_character_used_in_string_literal/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["java"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/java/structural_find/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/java/structural_find/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["java"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/kt/feature_flag_system_2/control/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/kt/feature_flag_system_2/control/configurations/rules.toml
@@ -87,7 +87,7 @@ matcher =   """(
 (#eq? @crhs "\\\"@namespace\\\"")
 (#eq? @interface_annotation_name "ParameterDefinition")
 )"""
-queries = [] 
+ 
 
 # For @m_name = `isStaleFeature`, @treated = `true`
 # Before :

--- a/polyglot/piranha/test-resources/kt/feature_flag_system_2/treated/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/kt/feature_flag_system_2/treated/configurations/rules.toml
@@ -87,7 +87,7 @@ matcher =   """(
 (#eq? @crhs "\\\"@namespace\\\"")
 (#eq? @interface_annotation_name "ParameterDefinition")
 )"""
-queries = [] 
+ 
 
 # For @m_name = `isStaleFeature`, @treated = `true`
 # Before :

--- a/polyglot/piranha/test-resources/kt/file_scoped_chain_rules/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/kt/file_scoped_chain_rules/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["kt"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/kt/file_scoped_chain_rules/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/kt/file_scoped_chain_rules/configurations/rules.toml
@@ -32,7 +32,7 @@ matcher = """(
 (function_declaration (simple_identifier) @name) @md
 (#eq? @name "create")
 )"""
-queries = []
+
 
 
 [[rules]]

--- a/polyglot/piranha/test-resources/python/structural_find/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/python/structural_find/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["py"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/strings/rules_with_no_holes/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/strings/rules_with_no_holes/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["strings"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/ts/structural_find/find_fors/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/ts/structural_find/find_fors/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["ts"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/ts/structural_find/find_fors_within_functions/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/ts/structural_find/find_fors_within_functions/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["ts"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/ts/structural_find/find_fors_within_functions/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/ts/structural_find/find_fors_within_functions/configurations/rules.toml
@@ -18,4 +18,4 @@ query = """
 """
 [[rules.constraints]]
 matcher = "(function_declaration) @fs"
-queries=[]
+

--- a/polyglot/piranha/test-resources/ts/structural_find/find_fors_within_functions_not_within_whiles/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/ts/structural_find/find_fors_within_functions_not_within_whiles/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["ts"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/tsx/structural_find/find_jsx_elements/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/tsx/structural_find/find_jsx_elements/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["tsx"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["tsx"]
-substitutions = []
+

--- a/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/rules.toml
+++ b/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/rules.toml
@@ -28,4 +28,4 @@ matcher = """
     ) @j
 )
 """
-queries = []
+

--- a/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_variable_declarators_not_within_divs/configurations/piranha_arguments.toml
+++ b/polyglot/piranha/test-resources/tsx/structural_find/find_props_identifiers_within_variable_declarators_not_within_divs/configurations/piranha_arguments.toml
@@ -10,4 +10,4 @@
 # limitations under the License.
 
 language = ["tsx"]
-substitutions = []
+


### PR DESCRIPTION
This PR does the following : 
1. convert `Option<Vec<...>>` to `Vec<...>` (and use `serde(default)`) 
* Don't pass `[]` as value in the `toml`.  
2. Rename `get_files_containing_feature_flag_api_usage` to `get_relevant_files_containing_hole_substitutions` 

I am separating a few changes made in #289 into this PR
