### PR TITLE
Add python formatting as pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,9 +44,9 @@ repos:
           - --comment-style
           - /*| | */
 
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
+  - repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: 'v2.0.1' 
     hooks:
-      - id: black
+    -   id: autopep8
         files: demo/
         exclude: only_lists.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,10 @@ repos:
           - license_header.txt
           - --comment-style
           - /*| | */
+
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+      - id: black
+        files: demo/
+        exclude: only_lists.py

--- a/demo/find_replace_custom_cleanup_demos.py
+++ b/demo/find_replace_custom_cleanup_demos.py
@@ -1,18 +1,19 @@
 from collections import Counter
 from os.path import join, dirname, getmtime
 from polyglot_piranha import run_piranha_cli, execute_piranha, PiranhaArguments
-import logging 
-from logging import info 
+import logging
+from logging import info
 
-find_Replace_dir = join(dirname(__file__), 'find_replace_custom_cleanup')
+find_Replace_dir = join(dirname(__file__), "find_replace_custom_cleanup")
+
 
 def java_demo():
     """
     Replace new `new ArrayList<>()` with `Collections.emptyList()`
     Also add the import for Collections.
-    The purpose of having `AnotherClass.java` is to demonstrate that the import statement is only added 
+    The purpose of having `AnotherClass.java` is to demonstrate that the import statement is only added
     as a consequence of the seed expression update.
-    """    
+    """
     info("Running the Find/Replace Custom Cleanup demo for Java")
 
     directory_path = join(find_Replace_dir, "java")
@@ -59,7 +60,8 @@ def python_demo():
 
     assert old_mtime < new_mtime
 
-FORMAT = '%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s'
+
+FORMAT = "%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
 logging.basicConfig(format=FORMAT)
 logging.getLogger().setLevel(logging.INFO)
 

--- a/demo/find_replace_demos.py
+++ b/demo/find_replace_demos.py
@@ -4,13 +4,14 @@ from polyglot_piranha import run_piranha_cli, execute_piranha, PiranhaArguments
 import logging
 from logging import info
 
-find_Replace_dir = join(dirname(__file__), 'find_replace')
+find_Replace_dir = join(dirname(__file__), "find_replace")
+
 
 def swift_demo():
     """
-    This shows how we can use Piranha to execute structural find/replace that hook on the the 
+    This shows how we can use Piranha to execute structural find/replace that hook on the the
     pre-built rules.
-    """    
+    """
     info("Running the Find/Replace demo for Swift")
 
     file_path = join(find_Replace_dir, "swift", "Sample.swift")
@@ -25,7 +26,7 @@ def swift_demo():
         {
             "stale_flag_name": "test_second_experiment",
         },
-        cleanup_comments = True
+        cleanup_comments=True,
     )
 
     _ = execute_piranha(args)
@@ -37,11 +38,11 @@ def swift_demo():
 
 def java_demo():
     """
-    This shows how we can use Piranha to execute structural find/replace that hook on the the 
+    This shows how we can use Piranha to execute structural find/replace that hook on the the
     pre-built rules.
-    Note how it deletes the enum declaration and consequently the file. 
+    Note how it deletes the enum declaration and consequently the file.
     Deletion of the file can be disabled by setting the `delete_file_if_empty` flag to False.
-    """    
+    """
     info("Running the Find/Replace demo for Java")
 
     file_path = join(find_Replace_dir, "java", "TestEnum.java")
@@ -66,7 +67,7 @@ def java_demo():
     assert old_mtime < new_mtime
 
 
-FORMAT = '%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s'
+FORMAT = "%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
 logging.basicConfig(format=FORMAT)
 logging.getLogger().setLevel(logging.INFO)
 swift_demo()

--- a/demo/find_replace_demos.py
+++ b/demo/find_replace_demos.py
@@ -57,7 +57,7 @@ def java_demo():
         {
             "stale_flag_name": "STALE_FLAG",
         },
-        cleanup_comments = True
+        cleanup_comments=True,
     )
 
     _ = run_piranha_cli(file_path, configuration_path, False)

--- a/demo/match_only_demos.py
+++ b/demo/match_only_demos.py
@@ -4,7 +4,8 @@ from polyglot_piranha import run_piranha_cli, execute_piranha, PiranhaArguments
 import logging
 from logging import info
 
-match_only_dir = join(dirname(__file__), 'match_only')
+match_only_dir = join(dirname(__file__), "match_only")
+
 
 def java_demo():
     info("Running the Match-only demo for Java")
@@ -12,51 +13,46 @@ def java_demo():
         join(match_only_dir, "java"),
         join(match_only_dir, "java/configurations"),
         "java",
-        {}
+        {},
     )
     output_summary_java = execute_piranha(args)
 
     rule_match_counter = Counter([m[0] for m in output_summary_java[0].matches])
 
-    assert rule_match_counter['find_fooBar_anywhere'] == 2
+    assert rule_match_counter["find_fooBar_anywhere"] == 2
 
+    assert rule_match_counter["find_barFoo_in_non_static_method"] == 1
 
-    assert rule_match_counter['find_barFoo_in_non_static_method'] == 1
 
 def go_demo():
     info("Running the Match-only demo for go")
 
     args = PiranhaArguments(
-        join(match_only_dir, "go"),
-        join(match_only_dir, "go/configurations"),
-        "go",
-        {}
+        join(match_only_dir, "go"), join(match_only_dir, "go/configurations"), "go", {}
     )
     output_summary_go = execute_piranha(args)
 
     rule_match_counter = Counter([m[0] for m in output_summary_go[0].matches])
 
-    assert rule_match_counter['find_go_stmt_for_loop'] == 1
+    assert rule_match_counter["find_go_stmt_for_loop"] == 1
 
-    assert rule_match_counter['find_for'] == 4
+    assert rule_match_counter["find_for"] == 4
+
 
 def ts_demo():
     info("Running the Match-only demo for TypeScript")
 
     args = PiranhaArguments(
-        join(match_only_dir, "ts"),
-        join(match_only_dir, "ts/configurations"),
-        "ts",
-        {}
+        join(match_only_dir, "ts"), join(match_only_dir, "ts/configurations"), "ts", {}
     )
     output_summary_typescript = execute_piranha(args)
 
-
     rule_match_counter = Counter([m[0] for m in output_summary_typescript[0].matches])
 
-    assert rule_match_counter['find_fors'] == 3
-    assert rule_match_counter['find_fors_within_functions'] == 2
-    assert rule_match_counter['find_fors_within_functions_not_within_whiles'] == 1
+    assert rule_match_counter["find_fors"] == 3
+    assert rule_match_counter["find_fors_within_functions"] == 2
+    assert rule_match_counter["find_fors_within_functions_not_within_whiles"] == 1
+
 
 def tsx_demo():
     info("Running the Match-only demo for TypeScript with React")
@@ -64,18 +60,23 @@ def tsx_demo():
         join(match_only_dir, "tsx"),
         join(match_only_dir, "tsx/configurations"),
         "tsx",
-        {}
+        {},
     )
     output_summary_typescript = execute_piranha(args)
 
     rule_match_counter = Counter([m[0] for m in output_summary_typescript[0].matches])
 
-    assert rule_match_counter['find_jsx_elements'] == 4
-    assert rule_match_counter['find_props_identifiers_within_b_jsx_elements'] == 2
-    assert rule_match_counter['find_props_identifiers_within_variable_declarators_not_within_divs'] == 2
+    assert rule_match_counter["find_jsx_elements"] == 4
+    assert rule_match_counter["find_props_identifiers_within_b_jsx_elements"] == 2
+    assert (
+        rule_match_counter[
+            "find_props_identifiers_within_variable_declarators_not_within_divs"
+        ]
+        == 2
+    )
 
 
-FORMAT = '%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s'
+FORMAT = "%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
 logging.basicConfig(format=FORMAT)
 logging.getLogger().setLevel(logging.INFO)
 

--- a/demo/match_only_demos.py
+++ b/demo/match_only_demos.py
@@ -17,7 +17,8 @@ def java_demo():
     )
     output_summary_java = execute_piranha(args)
 
-    rule_match_counter = Counter([m[0] for m in output_summary_java[0].matches])
+    rule_match_counter = Counter(
+        [m[0] for m in output_summary_java[0].matches])
 
     assert rule_match_counter["find_fooBar_anywhere"] == 2
 
@@ -28,7 +29,8 @@ def go_demo():
     info("Running the Match-only demo for go")
 
     args = PiranhaArguments(
-        join(match_only_dir, "go"), join(match_only_dir, "go/configurations"), "go", {}
+        join(match_only_dir, "go"), join(
+            match_only_dir, "go/configurations"), "go", {}
     )
     output_summary_go = execute_piranha(args)
 
@@ -43,11 +45,13 @@ def ts_demo():
     info("Running the Match-only demo for TypeScript")
 
     args = PiranhaArguments(
-        join(match_only_dir, "ts"), join(match_only_dir, "ts/configurations"), "ts", {}
+        join(match_only_dir, "ts"), join(
+            match_only_dir, "ts/configurations"), "ts", {}
     )
     output_summary_typescript = execute_piranha(args)
 
-    rule_match_counter = Counter([m[0] for m in output_summary_typescript[0].matches])
+    rule_match_counter = Counter(
+        [m[0] for m in output_summary_typescript[0].matches])
 
     assert rule_match_counter["find_fors"] == 3
     assert rule_match_counter["find_fors_within_functions"] == 2
@@ -64,7 +68,8 @@ def tsx_demo():
     )
     output_summary_typescript = execute_piranha(args)
 
-    rule_match_counter = Counter([m[0] for m in output_summary_typescript[0].matches])
+    rule_match_counter = Counter(
+        [m[0] for m in output_summary_typescript[0].matches])
 
     assert rule_match_counter["find_jsx_elements"] == 4
     assert rule_match_counter["find_props_identifiers_within_b_jsx_elements"] == 2


### PR DESCRIPTION
We have quite a few `py` files .
This PR adds `black` formatter as a pre-commit hook for python file formatting. 
https://github.com/psf/black
