### PR TITLE
Add pymethods for better string representation

### DIFF
--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -1,0 +1,146 @@
+def execute_piranha(piranha_argument: PiranhaArguments) -> list[PiranhaOutputSummary]:
+    """
+    Executes piranha for the given `piranha_arguments` and returns `PiranhaOutputSummary` for each file analyzed by Piranha
+    Parameters
+    ------------
+        piranha_arguments: Piranha Arguments
+            Configurations for piranha
+    Returns
+    ------------
+    List of `PiranhaOutPutSummary`
+    """
+    ...
+
+def run_piranha_cli(path_to_codebase: str, path_to_configurations: str, dry_run: bool) -> list[PiranhaOutputSummary]:
+    """
+    [THIS FUNCTION IS DEPRECATED SINCE 0.2.2]
+    Executes piranha for the provided configuration at {path_to_configurations} upon the given {path_to_codebase}.
+
+    Parameters
+    ------------
+        path_to_codebase (str): Path to the root of the code base that Piranha will update
+        path_to_configurations (str): Path to the directory that contains - `piranha_arguments.toml`, `rules.toml` and optionally `edges.toml`
+        dry_run (bool): determines if Piranha should actually update the code.
+
+    Returns:
+    --------------
+        list[PiranhaOutputSummary]:  Piranha Output Summary for each file touched or analyzed by Piranha. 
+        For each file, it reports its content after the rewrite, the list of matches and the list of rewrites.
+    """
+    ...
+
+
+class PiranhaArguments:
+    """
+    A class to capture Piranha's configurations
+    """
+
+    def __init__(
+        self,
+        path_to_codebase: str,
+        path_to_configuration: str,
+        language: str,
+        substitutions: dict,
+        **kwargs
+    ):
+        """
+        Constructs `PiranhaArguments`
+
+        Parameters
+        ------------
+            path_to_codebase: str
+                Path to source code folder or file
+            path_to_configurations: str
+                 Directory containing the configuration files - `piranha_arguments.toml`, `rules.toml`, and  `edges.toml` (optional)
+            language: str
+                the target language
+            substitutions: dict
+                 Substitutions to instantiate the initial set of rules
+            keyword arguments: _
+                 dry_run (bool) : Disables in-place rewriting of code
+                 cleanup_comments (bool) : Enables deletion of associated comments
+                 cleanup_comments_buffer (int): The number of lines to consider for cleaning up the comments
+                 number_of_ancestors_in_parent_scope (int): The number of ancestors considered when PARENT rules
+                 delete_file_if_empty (bool): User option that determines whether an empty file will be deleted
+                 delete_consecutive_new_lines (bool) : Replaces consecutive \ns  with a \n
+        """
+        ...
+
+class PiranhaOutputSummary:
+    """
+    A class to represent Piranha's output
+
+    Attributes
+    ----------
+    path : path to the file
+    content : content of the file after all the rewrites
+    matches : All the occurrences of "match-only" rules
+    rewrites: All the applied edits
+    """
+
+    path: str
+    "path to the file"
+
+    content: str
+    "content of the file after all the rewrites"
+
+    matches: list[tuple[str, Match]]
+    'All the occurrences of "match-only" rules'
+
+    rewrites: list[Edit]
+    "All the applied edits"
+
+class Edit:
+    """
+     A class to represent an edit performed by Piranha
+
+    Attributes
+    ----------
+    p_match : The match representing the target site of the edit
+    replacement_string : The string to replace the substring encompassed by the match
+    matched_rule : The rule used for creating this match-replace
+    """
+
+    p_match: Match
+    "The match representing the target site of the edit"
+
+    matched_rule: str
+    "The rule used for creating this match-replace"
+
+    replacement_string: str
+    "The string to replace the substring encompassed by the match"
+
+class Match:
+    """
+     A class to represent a match
+
+    Attributes
+    ----------
+    matched_sting : Code snippet that matched
+    range : Range of the entire AST node captured by the match
+    matches : The mapping between tags and string representation of the AST captured
+    """
+
+    matched_string: str
+    "Code snippet that matched"
+
+    range: Range
+    "Range of the entire AST node captured by the match"
+
+    matches: dict
+    "The mapping between tags and string representation of the AST captured"
+    ""
+
+class Range:
+    """A range of positions in a multi-line text document,
+    both in terms of bytes and of rows and columns.
+    """
+
+    start_byte: int
+    end_byte: int
+    start_point: Point
+    end_point: Point
+
+class Point:
+    row: int
+    column: int

--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -1,3 +1,14 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
 def execute_piranha(piranha_argument: PiranhaArguments) -> list[PiranhaOutputSummary]:
     """
     Executes piranha for the given `piranha_arguments` and returns `PiranhaOutputSummary` for each file analyzed by Piranha

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ Copyright (c) 2022 Uber Technologies, Inc.
 */
 
 use models::{
-  piranha_arguments::PiranhaArguments, piranha_output::PiranhaOutputSummary,
-  source_code_unit::SourceCodeUnit,
+  edit::Edit, matches::Match, piranha_arguments::PiranhaArguments,
+  piranha_output::PiranhaOutputSummary, source_code_unit::SourceCodeUnit,
 };
 
 pub mod models;
@@ -61,6 +61,9 @@ fn polyglot_piranha(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
   m.add_function(wrap_pyfunction!(run_piranha_cli, m)?)?;
   m.add_function(wrap_pyfunction!(execute_piranha, m)?)?;
   m.add_class::<PiranhaArguments>()?;
+  m.add_class::<PiranhaOutputSummary>()?;
+  m.add_class::<Edit>()?;
+  m.add_class::<Match>()?;
   Ok(())
 }
 

--- a/src/models/edit.rs
+++ b/src/models/edit.rs
@@ -68,7 +68,7 @@ impl fmt::Display for Edit {
     let replace_range: Range = self.p_match().range();
     let replacement = self.replacement_string();
     let replaced_code_snippet = self.p_match().matched_string();
-    let mut edit_kind = "Delete code".red(); //;
+    let mut edit_kind = "Delete code".red();
     let mut replacement_snippet_fmt = format!("{} ", replaced_code_snippet.italic());
     if !replacement.is_empty() {
       edit_kind = "Update code".green();

--- a/src/models/edit.rs
+++ b/src/models/edit.rs
@@ -19,6 +19,7 @@ use serde_derive::Serialize;
 use tree_sitter::Range;
 
 use super::matches::Match;
+use crate::utilities::gen_py_str_methods;
 use pyo3::{prelude::pyclass, pymethods};
 
 #[derive(Serialize, Debug, Clone, Getters)]
@@ -37,6 +38,8 @@ pub(crate) struct Edit {
   #[get = "pub"]
   matched_rule: String,
 }
+
+gen_py_str_methods!(Edit);
 
 impl Edit {
   pub(crate) fn new(p_match: Match, replacement_string: String, matched_rule: String) -> Self {
@@ -76,15 +79,5 @@ impl fmt::Display for Edit {
       "\n {} at ({:?}) -\n {}",
       edit_kind, &replace_range, replacement_snippet_fmt
     )
-  }
-}
-
-#[pymethods]
-impl Edit {
-  fn __repr__(&self) -> String {
-    format!("{:?}", self)
-  }
-  fn __str__(&self) -> String {
-    self.__repr__()
   }
 }

--- a/src/models/matches.rs
+++ b/src/models/matches.rs
@@ -11,7 +11,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use std::{collections::HashMap, fmt};
+use std::collections::HashMap;
 
 use getset::Getters;
 use pyo3::prelude::{pyclass, pymethods};
@@ -34,8 +34,8 @@ pub(crate) struct Match {
   #[get = "pub"]
   matches: HashMap<String, String>,
 }
-
 gen_py_str_methods!(Match);
+
 impl Match {
   pub(crate) fn new(
     matched_string: String, range: tree_sitter::Range, matches: HashMap<String, String>,
@@ -89,6 +89,7 @@ struct Range {
   #[pyo3(get)]
   end_point: Point,
 }
+gen_py_str_methods!(Range);
 
 /// A range of positions in a multi-line text document, both in terms of bytes and of
 /// rows and columns.
@@ -100,15 +101,4 @@ struct Point {
   #[pyo3(get)]
   column: usize,
 }
-
-impl fmt::Display for Match {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(
-      f,
-      "Match matched_string: {:?}\nrange: {:?}\nMatches: {:?}",
-      self.matched_string(),
-      self.range(),
-      self.matches()
-    )
-  }
-}
+gen_py_str_methods!(Point);

--- a/src/models/matches.rs
+++ b/src/models/matches.rs
@@ -14,7 +14,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 use std::collections::HashMap;
 
 use getset::Getters;
-use pyo3::prelude::pyclass;
+use pyo3::prelude::{pyclass, pymethods};
 use serde_derive::Serialize;
 
 #[derive(Serialize, Debug, Clone, Getters)]
@@ -95,4 +95,19 @@ struct Point {
   row: usize,
   #[pyo3(get)]
   column: usize,
+}
+
+#[pymethods]
+impl Match {
+  fn __repr__(&self) -> String {
+    format!(
+      "Match range: {:?}\nMatches: {:?}",
+      self.range(),
+      self.matches()
+    )
+  }
+
+  fn __str__(&self) -> String {
+    self.__repr__()
+  }
 }

--- a/src/models/matches.rs
+++ b/src/models/matches.rs
@@ -11,17 +11,20 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
 use getset::Getters;
 use pyo3::prelude::{pyclass, pymethods};
 use serde_derive::Serialize;
+
+use crate::utilities::gen_py_str_methods;
 
 #[derive(Serialize, Debug, Clone, Getters)]
 #[pyclass]
 pub(crate) struct Match {
   // Code snippet that matched
   #[get = "pub"]
+  #[pyo3(get)]
   matched_string: String,
   // Range of the entire AST node captured by the match
   #[pyo3(get)]
@@ -32,6 +35,7 @@ pub(crate) struct Match {
   matches: HashMap<String, String>,
 }
 
+gen_py_str_methods!(Match);
 impl Match {
   pub(crate) fn new(
     matched_string: String, range: tree_sitter::Range, matches: HashMap<String, String>,
@@ -97,17 +101,14 @@ struct Point {
   column: usize,
 }
 
-#[pymethods]
-impl Match {
-  fn __repr__(&self) -> String {
-    format!(
-      "Match range: {:?}\nMatches: {:?}",
+impl fmt::Display for Match {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+      f,
+      "Match matched_string: {:?}\nrange: {:?}\nMatches: {:?}",
+      self.matched_string(),
       self.range(),
       self.matches()
     )
-  }
-
-  fn __str__(&self) -> String {
-    self.__repr__()
   }
 }

--- a/src/models/piranha_output.rs
+++ b/src/models/piranha_output.rs
@@ -20,15 +20,21 @@ use crate::utilities::gen_py_str_methods;
 
 use super::{edit::Edit, matches::Match, source_code_unit::SourceCodeUnit};
 use pyo3::{prelude::pyclass, pymethods};
+
+/// A class to represent Piranha's output
 #[derive(Serialize, Debug, Clone, Default)]
 #[pyclass]
 pub struct PiranhaOutputSummary {
+  /// path to the file
   #[pyo3(get)]
   path: String,
+  ///content of the file after all the rewrites
   #[pyo3(get)]
   content: String,
+  /// All the occurrences of "match-only" rules
   #[pyo3(get)]
   matches: Vec<(String, Match)>,
+  /// All the applied edits
   #[pyo3(get)]
   rewrites: Vec<Edit>,
 }

--- a/src/models/piranha_output.rs
+++ b/src/models/piranha_output.rs
@@ -11,10 +11,12 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use std::path::PathBuf;
+use std::{fmt, path::PathBuf};
 
 use itertools::Itertools;
 use serde_derive::Serialize;
+
+use crate::utilities::gen_py_str_methods;
 
 use super::{edit::Edit, matches::Match, source_code_unit::SourceCodeUnit};
 use pyo3::{prelude::pyclass, pymethods};
@@ -30,6 +32,8 @@ pub struct PiranhaOutputSummary {
   #[pyo3(get)]
   rewrites: Vec<Edit>,
 }
+
+gen_py_str_methods!(PiranhaOutputSummary);
 
 impl PiranhaOutputSummary {
   pub(crate) fn new(source_code_unit: &SourceCodeUnit) -> PiranhaOutputSummary {
@@ -58,18 +62,14 @@ impl PiranhaOutputSummary {
   }
 }
 
-#[pymethods]
-impl PiranhaOutputSummary {
-  fn __repr__(&self) -> String {
-    format!(
+impl fmt::Display for PiranhaOutputSummary {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+      f,
       "path: {:?}\nMatches: {}\nRewrites: {}\n",
       self.path(),
       self.matches().len(),
       self.rewrites().len()
     )
-  }
-
-  fn __str__(&self) -> String {
-    self.__repr__()
   }
 }

--- a/src/models/piranha_output.rs
+++ b/src/models/piranha_output.rs
@@ -25,7 +25,7 @@ use pyo3::{prelude::pyclass, pymethods};
 #[derive(Serialize, Debug, Clone, Default)]
 #[pyclass]
 pub struct PiranhaOutputSummary {
-  /// path to the file
+  /// Path to the file
   #[pyo3(get)]
   path: String,
   ///content of the file after all the rewrites

--- a/src/models/piranha_output.rs
+++ b/src/models/piranha_output.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 use serde_derive::Serialize;
 
 use super::{edit::Edit, matches::Match, source_code_unit::SourceCodeUnit};
-use pyo3::prelude::pyclass;
+use pyo3::{prelude::pyclass, pymethods};
 #[derive(Serialize, Debug, Clone, Default)]
 #[pyclass]
 pub struct PiranhaOutputSummary {
@@ -55,5 +55,21 @@ impl PiranhaOutputSummary {
 
   pub fn content(&self) -> &str {
     self.content.as_ref()
+  }
+}
+
+#[pymethods]
+impl PiranhaOutputSummary {
+  fn __repr__(&self) -> String {
+    format!(
+      "path: {:?}\nMatches: {}\nRewrites: {}\n",
+      self.path(),
+      self.matches().len(),
+      self.rewrites().len()
+    )
+  }
+
+  fn __str__(&self) -> String {
+    self.__repr__()
   }
 }

--- a/src/models/piranha_output.rs
+++ b/src/models/piranha_output.rs
@@ -11,7 +11,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use std::{fmt, path::PathBuf};
+use std::path::PathBuf;
 
 use itertools::Itertools;
 use serde_derive::Serialize;
@@ -59,17 +59,5 @@ impl PiranhaOutputSummary {
 
   pub fn content(&self) -> &str {
     self.content.as_ref()
-  }
-}
-
-impl fmt::Display for PiranhaOutputSummary {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(
-      f,
-      "path: {:?}\nMatches: {}\nRewrites: {}\n",
-      self.path(),
-      self.matches().len(),
-      self.rewrites().len()
-    )
   }
 }

--- a/src/models/piranha_output.rs
+++ b/src/models/piranha_output.rs
@@ -28,7 +28,7 @@ pub struct PiranhaOutputSummary {
   /// Path to the file
   #[pyo3(get)]
   path: String,
-  ///content of the file after all the rewrites
+  /// Content of the file after all the rewrites
   #[pyo3(get)]
   content: String,
   /// All the occurrences of "match-only" rules

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -19,7 +19,6 @@ use std::fs::{self, DirEntry};
 use std::hash::Hash;
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
-
 // Reads a file.
 pub(crate) fn read_file(file_path: &PathBuf) -> Result<String, String> {
   File::open(file_path)
@@ -98,6 +97,22 @@ pub(crate) fn find_file(input_dir: &PathBuf, name: &str) -> PathBuf {
     .unwrap()
     .path()
 }
+
+macro_rules! gen_py_str_methods {
+  ($struct_name:ident) => {
+    #[pymethods]
+    impl $struct_name {
+      fn __repr__(&self) -> String {
+        format!("{:?}", self)
+      }
+      fn __str__(&self) -> String {
+        self.__repr__()
+      }
+    }
+  };
+}
+
+pub(crate) use gen_py_str_methods;
 
 #[cfg(test)]
 #[path = "unit_tests/utilities_test.rs"]

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -17,7 +17,6 @@ use crate::{
   models::{edit::Edit, matches::Match},
   utilities::MapOfVec,
 };
-use colored::Colorize;
 use itertools::Itertools;
 use log::debug;
 use std::collections::HashMap;

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -209,15 +209,7 @@ pub(crate) fn get_tree_sitter_edit(code: String, edit: &Edit) -> (String, InputE
   // Log the edit
   let replace_range: Range = edit.p_match().range();
   let replacement = edit.replacement_string();
-  let replaced_code_snippet = edit.p_match().matched_string();
-  let mut edit_kind = "Delete code".red(); //;
-  let mut replacement_snippet_fmt = format!("{} ", replaced_code_snippet.italic());
-  if !replacement.is_empty() {
-    edit_kind = "Update code".green();
-    replacement_snippet_fmt.push_str(&format!("\n to \n{}", replacement.italic()))
-  }
-  #[rustfmt::skip]
-  debug!("\n {} at ({:?}) -\n {}", edit_kind , &replace_range, replacement_snippet_fmt);
+  debug!("{:?}", edit);
   // Create the new source code content by appropriately
   // replacing the range with the replacement string.
   let new_source_code = [

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -208,7 +208,7 @@ pub(crate) fn get_tree_sitter_edit(code: String, edit: &Edit) -> (String, InputE
   // Log the edit
   let replace_range: Range = edit.p_match().range();
   let replacement = edit.replacement_string();
-  debug!("{:?}", edit);
+  debug!("{}", edit);
   // Create the new source code content by appropriately
   // replacing the range with the replacement string.
   let new_source_code = [

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -11,8 +11,7 @@
 
 
 
-from cProfile import run
-from polyglot_piranha import execute_piranha, PiranhaArguments, PiranhaOutputSummary, run_piranha_cli
+from polyglot_piranha import execute_piranha, PiranhaArguments, PiranhaOutputSummary
 from os.path import join, basename
 from os import listdir
 import re
@@ -60,7 +59,6 @@ def test_piranha_match_only():
         {},
         dry_run=True,
     )
-    x = run_piranha_cli("", "", True)
     output_summaries = execute_piranha(args)
     assert len(output_summaries[0].matches) == 20
     for summary in output_summaries:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2022 Uber Technologies, Inc.
-
+#
 # <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 # except in compliance with the License. You may obtain a copy of the License at
 # <p>http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # <p>Unless required by applicable law or agreed to in writing, software distributed under the
 # License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing permissions and

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -11,44 +11,89 @@
 
 
 
-from polyglot_piranha import execute_piranha, PiranhaArguments
+from cProfile import run
+from polyglot_piranha import execute_piranha, PiranhaArguments, PiranhaOutputSummary, run_piranha_cli
 from os.path import join, basename
 from os import listdir
+import re
 
 
 def test_piranha_rewrite():
     args = PiranhaArguments(
-        'test-resources/java/feature_flag_system_1/treated/input',
-        'test-resources/java/feature_flag_system_1/treated/configurations',
+        "test-resources/java/feature_flag_system_1/treated/input",
+        "test-resources/java/feature_flag_system_1/treated/configurations",
         "java",
         {
             "stale_flag_name": "STALE_FLAG",
             "treated": "true",
             "treated_complement": "false",
         },
-        dry_run= True
+        dry_run=True,
     )
-    output_summary = execute_piranha(args)
-    assert is_as_expected('test-resources/java/feature_flag_system_1/treated', output_summary)
+
+    output_summaries = execute_piranha(args)
+    
+    assert len(output_summaries) == 2
+    expected_paths = [
+        "test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java",
+        "test-resources/java/feature_flag_system_1/treated/input/TestEnum.java",
+    ]
+    assert all([o.path in expected_paths for o in output_summaries])
+    summary: PiranhaOutputSummary
+    for summary in output_summaries:
+        assert _is_readable(str(summary))
+        for rewrite in summary.rewrites:
+            assert _is_readable(str(rewrite)) and _is_readable(str(rewrite.p_match))
+            assert rewrite.matched_rule
+            assert rewrite.p_match.matched_string and rewrite.p_match.matches
+
+    assert is_as_expected(
+        "test-resources/java/feature_flag_system_1/treated", output_summaries
+    )
+
 
 def test_piranha_match_only():
     args = PiranhaArguments(
-        'test-resources/java/structural_find/input',
-        'test-resources/java/structural_find/configurations',
+        "test-resources/java/structural_find/input",
+        "test-resources/java/structural_find/configurations",
         "java",
         {},
-        dry_run= True
+        dry_run=True,
     )
-    output_summary = execute_piranha(args)
-    assert len(output_summary[0].matches) == 20
+    x = run_piranha_cli("", "", True)
+    output_summaries = execute_piranha(args)
+    assert len(output_summaries[0].matches) == 20
+    for summary in output_summaries:
+        assert _is_readable(str(summary))
+        for rule, match in summary.matches:
+            assert rule 
+            assert _is_readable(str(match))
 
 def is_as_expected(path_to_scenario, output_summary):
-    expected_output = join(path_to_scenario, 'expected')
+    expected_output = join(path_to_scenario, "expected")
     for file_name in listdir(expected_output):
-        with open(join(expected_output, file_name), 'r') as f:
+        with open(join(expected_output, file_name), "r") as f:
             file_content = f.read()
-            expected_content = ''.join(file_content.split())
-            updated_content = [''.join(o.content.split()) for o in output_summary if basename(o.path) == file_name][0]
+            expected_content = "".join(file_content.split())
+            updated_content = [
+                "".join(o.content.split())
+                for o in output_summary
+                if basename(o.path) == file_name
+            ][0]
             if expected_content != updated_content:
                 return False
     return True
+
+
+def _is_readable(input_str: str) -> bool:
+    """Check if the input string does not look like :
+    `<builtin.PiranhaSummary object at 0x789>`
+
+    Args:
+        input_str (str): 
+            Input string
+
+    Returns:
+        bool: is human readable
+    """
+    return not any(re.findall(r"\<(.*) object at (.*)\>", input_str))


### PR DESCRIPTION
The goal of this PR is to improve the user-experience when developing with piranha's Python API 
* Adds PyO3 getter annotations 
* implements `__str__` and `__repr__` methods (which are called by pyo3 bindings - [ref](https://pyo3.rs/main/class/object#string-representations) )
  * These methods basically call the debug formatter of the object itself. 
      Rust stuff - `format!("{:?}", some_obj)`  triggers `std::fmt::Debug` on `some_obj` - [ref](https://doc.rust-lang.org/std/fmt/index.html)

Added stub file `polyglot_piranha.pyi`. This helps IDEs/editors provide recommendations/completions. 