### PR TITLE
Use `Edit` object instead of passing around range and replacement

### DIFF
--- a/src/models/edit.rs
+++ b/src/models/edit.rs
@@ -45,14 +45,12 @@ impl Edit {
       matched_rule,
     }
   }
-}
 
-impl From<Range> for Edit {
-  fn from(replacement_range: Range) -> Self {
+  pub(crate) fn delete_range(replacement_range: Range) -> Self {
     Self {
       p_match: Match::new(replacement_range, HashMap::new()),
       replacement_string: String::new(),
-      matched_rule: String::new(),
+      matched_rule: "Delete Range".to_string(),
     }
   }
 }

--- a/src/models/source_code_unit.rs
+++ b/src/models/source_code_unit.rs
@@ -438,7 +438,6 @@ impl SourceCodeUnit {
   /// IF this closest node is a comma, extend the {new_delete_range} to include the comma.
   fn delete_trailing_comma(&self, edit: &Edit) -> Edit {
     let deleted_range: Range = edit.p_match().range();
-
     let mut new_deleted_range = deleted_range;
 
     // Get the node immediately after the to-be-deleted code
@@ -473,7 +472,6 @@ impl SourceCodeUnit {
       edit.replacement_string().to_string(),
       edit.matched_rule().to_string(),
     );
-    // new_deleted_range
   }
 
   // Replaces the content of the current file with the new content and re-parses the AST

--- a/src/models/source_code_unit.rs
+++ b/src/models/source_code_unit.rs
@@ -327,8 +327,7 @@ impl SourceCodeUnit {
 
   pub(crate) fn apply_edit(&mut self, edit: &Edit, parser: &mut Parser) -> InputEdit {
     // Get the tree_sitter's input edit representation
-    let mut applied_edit =
-      self._apply_edit(edit.p_match().range(), edit.replacement_string(), parser);
+    let mut applied_edit = self._apply_edit(edit, parser);
     // Check if the edit kind is "DELETE something"
     if *self.piranha_arguments.cleanup_comments() && edit.replacement_string().is_empty() {
       let deleted_at = edit.p_match().range().start_point.row;
@@ -338,7 +337,7 @@ impl SourceCodeUnit {
         edit.p_match().range().start_byte,
       ) {
         debug!("Deleting an associated comment");
-        applied_edit = self._apply_edit(comment_range, "", parser);
+        applied_edit = self._apply_edit(&Edit::delete_range(comment_range), parser);
       }
     }
     applied_edit
@@ -404,18 +403,14 @@ impl SourceCodeUnit {
   /// The `edit:InputEdit` performed.
   ///
   /// Note - Causes side effect. - Updates `self.ast` and `self.code`
-  pub(crate) fn _apply_edit(
-    &mut self, range: Range, replacement_string: &str, parser: &mut Parser,
-  ) -> InputEdit {
+  pub(crate) fn _apply_edit(&mut self, edit: &Edit, parser: &mut Parser) -> InputEdit {
+    let mut edit_to_apply = edit.clone();
     // Check if the edit is a `Delete` operation then delete trailing comma
-    let replace_range = if replacement_string.trim().is_empty() {
-      self.delete_trailing_comma(range)
-    } else {
-      range
-    };
+    if edit.replacement_string().trim().is_empty() {
+      edit_to_apply = self.delete_trailing_comma(edit);
+    }
     // Get the tree_sitter's input edit representation
-    let (new_source_code, ts_edit) =
-      get_tree_sitter_edit(self.code.clone(), replace_range, replacement_string);
+    let (new_source_code, ts_edit) = get_tree_sitter_edit(self.code.clone(), &edit_to_apply);
     // Apply edit to the tree
     self.ast.edit(&ts_edit);
     self._replace_file_contents_and_re_parse(&new_source_code, parser, true);
@@ -441,7 +436,9 @@ impl SourceCodeUnit {
   /// Get the node after the {deleted_range}'s end byte (heuristic 5 characters)
   /// Traverse this node and get the node closest to the range {deleted_range}'s end byte
   /// IF this closest node is a comma, extend the {new_delete_range} to include the comma.
-  fn delete_trailing_comma(&mut self, deleted_range: Range) -> Range {
+  fn delete_trailing_comma(&self, edit: &Edit) -> Edit {
+    let deleted_range: Range = edit.p_match().range();
+
     let mut new_deleted_range = deleted_range;
 
     // Get the node immediately after the to-be-deleted code
@@ -471,7 +468,12 @@ impl SourceCodeUnit {
         }
       }
     }
-    new_deleted_range
+    return Edit::new(
+      Match::new(new_deleted_range, edit.p_match().matches().clone()),
+      edit.replacement_string().to_string(),
+      edit.matched_rule().to_string(),
+    );
+    // new_deleted_range
   }
 
   // Replaces the content of the current file with the new content and re-parses the AST

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -91,7 +91,7 @@ fn test_apply_edit_positive() {
   let mut source_code_unit =
     SourceCodeUnit::default(source_code, &mut parser, java.name().to_string());
 
-  let _ = source_code_unit.apply_edit(&Edit::from(range(49, 78, 3, 9, 3, 38)), &mut parser);
+  let _ = source_code_unit.apply_edit(&Edit::delete_range(range(49, 78, 3, 9, 3, 38)), &mut parser);
   assert!(eq_without_whitespace(
     &source_code.replace("boolean isFlagTreated = true;", ""),
     source_code_unit.code()
@@ -117,7 +117,10 @@ fn test_apply_edit_negative() {
   let mut source_code_unit =
     SourceCodeUnit::default(source_code, &mut parser, java.name().to_string());
 
-  let _ = source_code_unit.apply_edit(&Edit::from(range(1000, 2000, 0, 0, 0, 0)), &mut parser);
+  let _ = source_code_unit.apply_edit(
+    &Edit::delete_range(range(1000, 2000, 0, 0, 0, 0)),
+    &mut parser,
+  );
 }
 
 /// Positive test of an edit being applied  given replacement range  and replacement string.
@@ -137,7 +140,10 @@ fn test_apply_edit_comma_handling_via_grammar() {
   let mut source_code_unit =
     SourceCodeUnit::default(source_code, &mut parser, java.name().to_string());
 
-  let _ = source_code_unit.apply_edit(&Edit::from(range(37, 47, 2, 26, 2, 36)), &mut parser);
+  let _ = source_code_unit.apply_edit(
+    &Edit::delete_range(range(37, 47, 2, 26, 2, 36)),
+    &mut parser,
+  );
   assert!(eq_without_whitespace(
     &source_code.replace("\"NullAway\",", ""),
     source_code_unit.code()
@@ -163,7 +169,10 @@ fn test_apply_edit_comma_handling_via_regex() {
   let mut source_code_unit =
     SourceCodeUnit::default(source_code, &mut parser, swift.name().to_string());
 
-  let _ = source_code_unit.apply_edit(&Edit::from(range(59, 75, 3, 23, 3, 41)), &mut parser);
+  let _ = source_code_unit.apply_edit(
+    &Edit::delete_range(range(59, 75, 3, 23, 3, 41)),
+    &mut parser,
+  );
   assert!(eq_without_whitespace(
     &source_code.replace("name: \"BMX Bike\",", ""),
     source_code_unit.code()

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -13,7 +13,10 @@ Copyright (c) 2022 Uber Technologies, Inc.
 
 //! Defines the traits containing with utility functions that interface with tree-sitter.
 
-use crate::{models::matches::Match, utilities::MapOfVec};
+use crate::{
+  models::{edit::Edit, matches::Match},
+  utilities::MapOfVec,
+};
 use colored::Colorize;
 use itertools::Itertools;
 use log::debug;
@@ -198,10 +201,10 @@ fn get_range_for_replace_node(
 /// Replaces the given byte range (`replace_range`) with the `replacement`.
 /// Returns tree-sitter's edit representation along with updated source code.
 /// Note: This method does not update `self`.
-pub(crate) fn get_tree_sitter_edit(
-  code: String, replace_range: Range, replacement: &str,
-) -> (String, InputEdit) {
+pub(crate) fn get_tree_sitter_edit(code: String, edit: &Edit) -> (String, InputEdit) {
   // Log the edit
+  let replace_range: Range = edit.p_match().range();
+  let replacement = edit.replacement_string();
   let replaced_code_snippet = &code[replace_range.start_byte..replace_range.end_byte];
   let mut edit_kind = "Delete code".red(); //;
   let mut replacement_snippet_fmt = format!("{} ", replaced_code_snippet.italic());

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -222,15 +222,24 @@ pub(crate) fn get_tree_sitter_edit(code: String, edit: &Edit) -> (String, InputE
     &code[replace_range.end_byte..],
   ]
   .concat();
+
+  let len_of_replacement = replacement.as_bytes().len();
+  let old_source_code_bytes = code.as_bytes();
+  let new_source_code_bytes = new_source_code.as_bytes();
+  let start_byte = replace_range.start_byte;
+  let old_end_byte = replace_range.end_byte;
+  let new_end_byte = start_byte + len_of_replacement;
   (
     new_source_code.to_string(),
     // Tree-sitter edit
-    _get_tree_sitter_edit(
-      replace_range,
-      replacement.as_bytes().len(),
-      code.as_bytes(),
-      new_source_code.as_bytes(),
-    ),
+    InputEdit {
+      start_byte,
+      old_end_byte,
+      new_end_byte,
+      start_position: position_for_offset(old_source_code_bytes, start_byte),
+      old_end_position: position_for_offset(old_source_code_bytes, old_end_byte),
+      new_end_position: position_for_offset(new_source_code_bytes, new_end_byte),
+    },
   )
 }
 


### PR DESCRIPTION
In stead of passing around `replacement_string` and `range` pass the `edit` object (that contains this information)