### PR TITLE
Enhance match struct with the `matched_string` field 

### DIFF
--- a/src/models/edit.rs
+++ b/src/models/edit.rs
@@ -46,9 +46,13 @@ impl Edit {
     }
   }
 
-  pub(crate) fn delete_range(replacement_range: Range) -> Self {
+  pub(crate) fn delete_range(code: &str, replacement_range: Range) -> Self {
     Self {
-      p_match: Match::new(replacement_range, HashMap::new()),
+      p_match: Match::new(
+        code[replacement_range.start_byte..replacement_range.end_byte].to_string(),
+        replacement_range,
+        HashMap::new(),
+      ),
       replacement_string: String::new(),
       matched_rule: "Delete Range".to_string(),
     }

--- a/src/models/matches.rs
+++ b/src/models/matches.rs
@@ -20,6 +20,9 @@ use serde_derive::Serialize;
 #[derive(Serialize, Debug, Clone, Getters)]
 #[pyclass]
 pub(crate) struct Match {
+  // Code snippet that matched
+  #[get = "pub"]
+  matched_string: String,
   // Range of the entire AST node captured by the match
   #[pyo3(get)]
   range: Range,
@@ -30,8 +33,11 @@ pub(crate) struct Match {
 }
 
 impl Match {
-  pub(crate) fn new(range: tree_sitter::Range, matches: HashMap<String, String>) -> Self {
+  pub(crate) fn new(
+    matched_string: String, range: tree_sitter::Range, matches: HashMap<String, String>,
+  ) -> Self {
     Self {
+      matched_string,
       range: Range {
         start_byte: range.start_byte,
         end_byte: range.end_byte,

--- a/src/models/source_code_unit.rs
+++ b/src/models/source_code_unit.rs
@@ -337,7 +337,7 @@ impl SourceCodeUnit {
         edit.p_match().range().start_byte,
       ) {
         debug!("Deleting an associated comment");
-        applied_edit = self._apply_edit(&Edit::delete_range(comment_range), parser);
+        applied_edit = self._apply_edit(&Edit::delete_range(self.code(), comment_range), parser);
       }
     }
     applied_edit
@@ -468,7 +468,11 @@ impl SourceCodeUnit {
       }
     }
     return Edit::new(
-      Match::new(new_deleted_range, edit.p_match().matches().clone()),
+      Match::new(
+        self.code()[new_deleted_range.start_byte..new_deleted_range.end_byte].to_string(),
+        new_deleted_range,
+        edit.p_match().matches().clone(),
+      ),
       edit.replacement_string().to_string(),
       edit.matched_rule().to_string(),
     );

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -91,7 +91,10 @@ fn test_apply_edit_positive() {
   let mut source_code_unit =
     SourceCodeUnit::default(source_code, &mut parser, java.name().to_string());
 
-  let _ = source_code_unit.apply_edit(&Edit::delete_range(range(49, 78, 3, 9, 3, 38)), &mut parser);
+  let _ = source_code_unit.apply_edit(
+    &Edit::delete_range(source_code, range(49, 78, 3, 9, 3, 38)),
+    &mut parser,
+  );
   assert!(eq_without_whitespace(
     &source_code.replace("boolean isFlagTreated = true;", ""),
     source_code_unit.code()
@@ -118,7 +121,7 @@ fn test_apply_edit_negative() {
     SourceCodeUnit::default(source_code, &mut parser, java.name().to_string());
 
   let _ = source_code_unit.apply_edit(
-    &Edit::delete_range(range(1000, 2000, 0, 0, 0, 0)),
+    &Edit::delete_range(source_code, range(1000, 2000, 0, 0, 0, 0)),
     &mut parser,
   );
 }
@@ -141,7 +144,7 @@ fn test_apply_edit_comma_handling_via_grammar() {
     SourceCodeUnit::default(source_code, &mut parser, java.name().to_string());
 
   let _ = source_code_unit.apply_edit(
-    &Edit::delete_range(range(37, 47, 2, 26, 2, 36)),
+    &Edit::delete_range(source_code, range(37, 47, 2, 26, 2, 36)),
     &mut parser,
   );
   assert!(eq_without_whitespace(
@@ -170,7 +173,7 @@ fn test_apply_edit_comma_handling_via_regex() {
     SourceCodeUnit::default(source_code, &mut parser, swift.name().to_string());
 
   let _ = source_code_unit.apply_edit(
-    &Edit::delete_range(range(59, 75, 3, 23, 3, 41)),
+    &Edit::delete_range(source_code, range(59, 75, 3, 23, 3, 41)),
     &mut parser,
   );
   assert!(eq_without_whitespace(

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -103,7 +103,11 @@ impl PiranhaHelpers for Node<'_> {
           }
         }
         let code_snippet_by_tag = accumulate_repeated_tags(query, query_matches, &source_code);
-        output.push(Match::new(replace_node_range, code_snippet_by_tag));
+        output.push(Match::new(
+          source_code[replace_node_range.start_byte..replace_node_range.end_byte].to_string(),
+          replace_node_range,
+          code_snippet_by_tag,
+        ));
       }
     }
     // This sorts the matches from bottom to top
@@ -205,7 +209,7 @@ pub(crate) fn get_tree_sitter_edit(code: String, edit: &Edit) -> (String, InputE
   // Log the edit
   let replace_range: Range = edit.p_match().range();
   let replacement = edit.replacement_string();
-  let replaced_code_snippet = &code[replace_range.start_byte..replace_range.end_byte];
+  let replaced_code_snippet = edit.p_match().matched_string();
   let mut edit_kind = "Delete code".red(); //;
   let mut replacement_snippet_fmt = format!("{} ", replaced_code_snippet.italic());
   if !replacement.is_empty() {


### PR DESCRIPTION
Add the field `matched_string` to `Match` struct. This field will store the code snippet matched by the rule. 
