### PR TITLE
User provided rules should be marked as "Cleanup Rules" when necessary

### DIFF
--- a/demo/find_replace_demos.py
+++ b/demo/find_replace_demos.py
@@ -60,8 +60,7 @@ def java_demo():
         cleanup_comments=True,
     )
 
-    _ = run_piranha_cli(file_path, configuration_path, False)
-
+    _ = execute_piranha(args)
     new_mtime = getmtime(file_path)
 
     assert old_mtime < new_mtime
@@ -71,6 +70,5 @@ FORMAT = "%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(messag
 logging.basicConfig(format=FORMAT)
 logging.getLogger().setLevel(logging.INFO)
 swift_demo()
-strings_demo()
 java_demo()
 print("Completed running the Find/Replace demos")

--- a/src/models/rule_store.rs
+++ b/src/models/rule_store.rs
@@ -98,15 +98,14 @@ impl RuleStore {
   pub(crate) fn add_to_global_rules(
     &mut self, rule: &Rule, tag_captures: &HashMap<String, String>,
   ) {
-    if let Ok(mut r) = rule.try_instantiate(tag_captures) {
-      if !self.global_rules.iter().any(|r| {
-        r.name().eq(&rule.name()) && r.replace().eq(&rule.replace()) && r.query().eq(&rule.query())
-      }) {
-        r.add_grep_heuristics_for_global_rules(tag_captures);
-        #[rustfmt::skip]
-        debug!("{}", format!("Added Global Rule : {:?} - {}", r.name(), r.query()).bright_blue());
-        self.global_rules.push(r);
-      }
+    let mut r = rule.instantiate(tag_captures);
+    if !self.global_rules.iter().any(|r| {
+      r.name().eq(&rule.name()) && r.replace().eq(&rule.replace()) && r.query().eq(&rule.query())
+    }) {
+      r.add_grep_heuristics_for_global_rules(tag_captures);
+      #[rustfmt::skip]
+      debug!("{}", format!("Added Global Rule : {:?} - {}", r.name(), r.query()).bright_blue());
+      self.global_rules.push(r);
     }
   }
 

--- a/src/models/unit_tests/rule_test.rs
+++ b/src/models/unit_tests/rule_test.rs
@@ -31,24 +31,23 @@ fn test_rule_try_instantiate_positive() {
     (String::from("variable_name"), String::from("foobar")),
     (String::from("@a.lhs"), String::from("something")), // Should not substitute, since it `a.lhs` is not in `rule.holes`
   ]);
-  let instantiated_rule = rule.try_instantiate(&substitutions);
-  assert!(instantiated_rule.is_ok());
+  let instantiated_rule = rule.instantiate(&substitutions);
   assert_eq!(
-    instantiated_rule.ok().unwrap().query(),
+    instantiated_rule.query(),
     "(((assignment_expression left: (_) @a.lhs right: (_) @a.rhs) @abc) (#eq? @a.lhs \"foobar\"))"
   )
 }
 
-/// Tests whether a valid rule can be is *not* instantiated given invalid substitutions.
+/// Tests whether a valid rule is *not* instantiated given invalid substitutions.
 #[test]
+#[should_panic]
 fn test_rule_try_instantiate_negative() {
   let rule = Rule::new("test","(((assignment_expression left: (_) @a.lhs right: (_) @a.rhs) @abc) (#eq? @a.lhs \"@variable_name\"))",
         "abc", "",HashSet::from([String::from("variable_name")]), HashSet::new());
   let substitutions: HashMap<String, String> = HashMap::from([
     (String::from("@a.lhs"), String::from("something")), // Should not substitute, since it `a.lhs` is not in `rule.holes`
   ]);
-  let instantiated_rule = rule.try_instantiate(&substitutions);
-  assert!(instantiated_rule.is_err());
+  let _ = rule.instantiate(&substitutions);
 }
 
 /// Positive tests for `rule.get_edit` method for given rule and input source code.

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -54,7 +54,7 @@ create_rewrite_tests! {
       "treated_complement" => "true",
       "namespace" => "some_long_name"
     }, cleanup_comments = true , delete_file_if_empty= false;
-  test_scenarios_find_and_propagate:  "find_and_propagate", 2, delete_file_if_empty= false;
+  test_scenarios_find_and_propagate:  "find_and_propagate", 2, substitutions = substitutions! {"super_interface_name" => "SomeInterface"},  delete_file_if_empty= false;
   test_non_seed_user_rule:  "non_seed_user_rule", 1, substitutions = substitutions! {"input_type_name" => "ArrayList"};
   test_new_line_character_used_in_string_literal:  "new_line_character_used_in_string_literal",   1;
   test_insert_field_and_initializer:  "insert_field_and_initializer", 1;
@@ -64,4 +64,24 @@ create_rewrite_tests! {
 create_match_tests! {
   JAVA,
   test_java_match_only: "structural_find", 20;
+}
+
+#[test]
+#[should_panic(
+  expected = "Could not instantiate the rule Rule { name: \"find_interface_extension\""
+)]
+fn test_scenarios_find_and_propagate_panic() {
+  initialize();
+  let _path = PathBuf::from("test-resources")
+    .join(JAVA)
+    .join("find_and_propagate");
+  let path_to_codebase = _path.join("input").to_str().unwrap().to_string();
+  let path_to_configurations = _path.join("configurations").to_str().unwrap().to_string();
+  let piranha_arguments = piranha_arguments! {
+    path_to_codebase = path_to_codebase,
+    path_to_configurations = path_to_configurations,
+    language= JAVA.to_string(),
+  };
+
+  let _ = execute_piranha(&piranha_arguments);
 }

--- a/test-resources/go/feature_flag/system_1/const_same_file/configurations/rules.toml
+++ b/test-resources/go/feature_flag/system_1/const_same_file/configurations/rules.toml
@@ -44,5 +44,5 @@ query = """
 """
 replace = "@treated"
 replace_node = "call_exp"
-groups = ["replace_expression_with_boolean_literal"]
+groups = ["replace_expression_with_boolean_literal", "Cleanup Rule"]
 holes = ["const_id", "treated"]

--- a/test-resources/java/feature_flag_system_2/control/configurations/rules.toml
+++ b/test-resources/java/feature_flag_system_2/control/configurations/rules.toml
@@ -130,7 +130,7 @@ query = """
 )"""
 replace_node = "method_invocation"
 replace = "@treated"
-groups = ["replace_expression_with_boolean_literal"]
+groups = ["replace_expression_with_boolean_literal", "Cleanup Rule"]
 holes = ["m_name", "treated"]
 
 # For @m_name = `isStaleFeature`, @treated = `true`
@@ -158,6 +158,7 @@ query = """
 """
 replace_node = "expression_statement"
 replace = ""
+groups = ["Cleanup Rule"]
 holes = ["m_name"]
 
 #

--- a/test-resources/java/feature_flag_system_2/treated/configurations/rules.toml
+++ b/test-resources/java/feature_flag_system_2/treated/configurations/rules.toml
@@ -131,7 +131,7 @@ query = """
 )"""
 replace_node = "method_invocation"
 replace = "@treated"
-groups = ["replace_expression_with_boolean_literal"]
+groups = ["replace_expression_with_boolean_literal", "Cleanup Rule"]
 holes = ["m_name", "treated"]
 
 # For @m_name = `isStaleFeature`, @treated = `true`
@@ -159,6 +159,7 @@ query = """
 """
 replace_node = "expression_statement"
 replace = ""
+groups = ["Cleanup Rule"]
 holes = ["m_name"]
 
 #

--- a/test-resources/java/find_and_propagate/configurations/rules.toml
+++ b/test-resources/java/find_and_propagate/configurations/rules.toml
@@ -37,4 +37,5 @@ query = """
 """
 replace_node = "prg"
 replace = ""
+groups = ["Cleanup Rule"]
 holes = ["class_name"]

--- a/test-resources/java/find_and_propagate/configurations/rules.toml
+++ b/test-resources/java/find_and_propagate/configurations/rules.toml
@@ -24,8 +24,10 @@ query = """(
 (class_declaration name: (_)@class_name 
     interfaces: (super_interfaces (_) @t) 
  ) @cd
-(#eq? @t "SomeInterface")
+(#eq? @t "@super_interface_name")
 )"""
+holes = ["super_interface_name"]
+
 
 [[rules]]
 name = "delete_class"

--- a/test-resources/kt/feature_flag_system_2/control/configurations/rules.toml
+++ b/test-resources/kt/feature_flag_system_2/control/configurations/rules.toml
@@ -108,7 +108,7 @@ query = """
 )"""
 replace_node = "navigation_expression"
 replace = "@treated"
-groups = ["replace_expression_with_boolean_literal"]
+groups = ["replace_expression_with_boolean_literal", "Cleanup Rule"]
 holes = ["m_name", "treated"]
 
 # For @m_name = `isStaleFeature`, @treated = `true`
@@ -135,4 +135,5 @@ query = """
 """
 replace_node = "expression_statement"
 replace = ""
+groups = ["Cleanup Rule"]
 holes = ["m_name"]

--- a/test-resources/kt/feature_flag_system_2/treated/configurations/rules.toml
+++ b/test-resources/kt/feature_flag_system_2/treated/configurations/rules.toml
@@ -108,7 +108,7 @@ query = """
 )"""
 replace_node = "navigation_expression"
 replace = "@treated"
-groups = ["replace_expression_with_boolean_literal"]
+groups = ["replace_expression_with_boolean_literal", "Cleanup Rule"]
 holes = ["m_name", "treated"]
 
 # For @m_name = `isStaleFeature`, @treated = `true`
@@ -135,4 +135,5 @@ query = """
 """
 replace_node = "expression_statement"
 replace = ""
+groups = ["Cleanup Rule"]
 holes = ["m_name"]

--- a/test-resources/swift/cascade_file_delete/configurations/rules.toml
+++ b/test-resources/swift/cascade_file_delete/configurations/rules.toml
@@ -21,6 +21,7 @@ class_declaration name: (type_identifier) @enum_declaration_name
 replace_node = "ee"
 replace = ""
 holes = ["GLOBAL_TAG.enum_entry_name"]
+groups = ["Cleanup Rule"]
 
 # Matches a switch case that returns the "stale_flag_name" string literal.
 [[rules]]
@@ -48,6 +49,7 @@ query = """
 (#eq? @type_arg "@enum_declaration_name")
 )
 """
+groups = ["Cleanup Rule"]
 holes = ["enum_declaration_name"]
 
 # Deletes factory class that uses the GLOBAL_TAG.enum_entry_name and inherits the relevant type alias.
@@ -68,4 +70,5 @@ query = """
 """
 replace_node = "source_file"
 replace = ""
+groups = ["Cleanup Rule"]
 holes = ["GLOBAL_TAG.enum_entry_name", "inherits_plugin_switch"]

--- a/test-resources/swift/cascade_file_delete_custom_global_tag/configurations/rules.toml
+++ b/test-resources/swift/cascade_file_delete_custom_global_tag/configurations/rules.toml
@@ -20,7 +20,9 @@ class_declaration name: (type_identifier) @enum_declaration_name
 )"""
 replace_node = "ee"
 replace = ""
+groups = ["Cleanup Rule"]
 holes = ["universal_tag.enum_entry_name"]
+
 
 # Matches a switch case that returns the "stale_flag_name" string literal.
 [[rules]]
@@ -48,6 +50,7 @@ query = """
 (#eq? @type_arg "@enum_declaration_name")
 )
 """
+groups = ["Cleanup Rule"]
 holes = ["enum_declaration_name"]
 
 # Deletes factory calss that uses the universal_tag.enum_entry_name and inherits the relevant type alias.
@@ -68,4 +71,5 @@ query = """
 """
 replace_node = "source_file"
 replace = ""
+groups = ["Cleanup Rule"]
 holes = ["universal_tag.enum_entry_name", "inherits_plugin_switch"]


### PR DESCRIPTION
User has to mark rules as "Cleanup Rules" which prevents it from being considered a "Seed Rule". A Seed rule has to be instantiable using the substitutions provided in piranha arguments. 

Moving forward, we will not allow developers to declare seed rules that are not initializable with piranha arguments. Piranha will panic in these cases. 

Note we were already following this practice in demos and also internally. 

---------------
"A Seed rule has to be instantiable using the substitutions provided in piranha arguments." means is that the provided rules in the rules.toml files, unless marked as cleanup, must either a) have no holes, or b) have holes whose names match piranha arguments. I was actually missing that case (a) was a possibility from that description, until I saw the "before" code for the test change.
While try_instantiate is being removed from rule.rs, we also had instantiate, which threw an error even before this change. That try_instantiate function was only being called from a few places, and in most of them (tests), whether it succeeded or failed was being immediately checked. However, in add_to_global_rules inside rules_store.rs, before this change, we were silently ignoring any rule for which try_instantiate failed, whereas now we panic in that case. 