### PR TITLE
Introduce `InstantiatedRule` 

### DIFF
--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -82,3 +82,15 @@ pub fn default_piranha_language() -> PiranhaLanguage {
 pub fn default_delete_consecutive_new_lines() -> bool {
   false
 }
+
+pub fn default_query() -> String {
+  String::new()
+}
+
+pub fn default_replace_node() -> String {
+  String::new()
+}
+
+pub fn default_replace() -> String {
+  String::new()
+}

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -26,7 +26,7 @@ use crate::models::{
   default_configs::{JAVA, SWIFT},
   language::PiranhaLanguage,
   piranha_arguments::{PiranhaArguments, PiranhaArgumentsBuilder},
-  rule::Rule,
+  rule::{InstantiatedRule, Rule},
   rule_store::RuleStore,
 };
 use {
@@ -311,7 +311,7 @@ fn test_persist_do_not_delete_consecutive_lines() -> Result<(), io::Error> {
 
 #[test]
 fn test_satisfies_constraints_positive() {
-  let rule = Rule::new(
+  let _rule = Rule::new(
     "test",
     "(
       ((local_variable_declaration
@@ -335,6 +335,7 @@ fn test_satisfies_constraints_positive() {
       )],
     )]),
   );
+  let rule = InstantiatedRule::new(&_rule, &HashMap::new());
   let source_code = "class Test {
       pub void foobar(){
         boolean isFlagTreated = true;
@@ -377,7 +378,7 @@ fn test_satisfies_constraints_positive() {
 
 #[test]
 fn test_satisfies_constraints_negative() {
-  let rule = Rule::new(
+  let _rule = Rule::new(
     "test",
     "(
       ((local_variable_declaration
@@ -401,6 +402,7 @@ fn test_satisfies_constraints_negative() {
       )],
     )]),
   );
+  let rule = InstantiatedRule::new(&_rule, &HashMap::new());
   let source_code = "class Test {
       pub void foobar(){
         boolean isFlagTreated = true;

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -282,9 +282,9 @@ fn _get_tree_sitter_edit(
 ///
 /// Note that,  it escapes newline characters for tree-sitter-queries.
 pub(crate) fn substitute_tags(
-  input_string: String, substitutions: &HashMap<String, String>, is_tree_sitter_query: bool,
+  input_string: &str, substitutions: &HashMap<String, String>, is_tree_sitter_query: bool,
 ) -> String {
-  let mut output = input_string;
+  let mut output = input_string.to_string();
   for (tag, substitute) in substitutions {
     // Before replacing the key, it is transformed to a tree-sitter tag by adding `@` as prefix
     let key = format!("@{}", tag);

--- a/src/utilities/unit_tests/tree_sitter_utilities_test.rs
+++ b/src/utilities/unit_tests/tree_sitter_utilities_test.rs
@@ -127,11 +127,7 @@ fn test_substitute_tags() {
     ("init".to_string(), "true".to_string()),
   ]);
   assert_eq!(
-    substitute_tags(
-      "@variable_name foo bar @init".to_string(),
-      &substitutions,
-      false
-    ),
+    substitute_tags("@variable_name foo bar @init", &substitutions, false),
     "isFlagTreated foo bar true"
   )
 }


### PR DESCRIPTION
Based on #329 

Introduce `InstantiatedRule` which is composed of `Rule` and `substitutions` (previously `grep_heuristics`).
An `InstantiatedRule` is constructed when a `Rule` is instantiated with `substitutions`. 
* Removed `grep_heuristics` property from `Rule` 
* Change type of `query`, `replace` and `replace_node` from `Option<String>` -> `String` from Rule . This change required updating the methods `is_dummy`, is_match_only`. (This is an un-related refactoring 😢 , but its small so its alright ? 😵‍💫 ) 
* Use `InstantiatedRule` throughout `source_code_unit` 

Earlier, we were updating `grep_heursitic` property of the Rule. This made it ambiguous at a type-level whether the rule is instantiated or contains holes.


-------
I am open to rename `InstantiatedRule`. Maybe it sounds a bit awkward. `ResolvedRule` ? `FilledRules` ? 