### PR TITLE
Remove unnecessary field `global_tags` from RuleStore 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,10 +136,12 @@ impl Piranha {
   fn perform_cleanup(&mut self) {
     // Setup the parser for the specific language
     let mut parser = Parser::new();
+    let piranha_args = self.rule_store.piranha_args().clone();
     parser
-      .set_language(*self.rule_store.piranha_args().piranha_language().language())
+      .set_language(*piranha_args.piranha_language().language())
       .expect("Could not set the language for the parser.");
 
+    let mut current_global_substitutions = piranha_args.input_substitutions().clone();
     // Keep looping until new `global` rules are added.
     loop {
       let current_rules = self.rule_store.global_rules().clone();
@@ -148,23 +150,26 @@ impl Piranha {
       // Iterate over each file containing the usage of the feature flag API
 
       for (path, content) in self.rule_store.get_relevant_files(&self.path_to_codebase) {
-        self
+        // Get the `SourceCodeUnit` for the file `path` from the cache `relevant_files`.
+        // In case of miss, lazily insert a new `SourceCodeUnit`.
+        let source_code_unit = self
           .relevant_files
-          // Get the content of the file for `path` from the cache `relevant_files`
           .entry(path.to_path_buf())
-          // Populate the cache (`relevant_files`) with the content, in case of cache miss (lazily)
           .or_insert_with(|| {
-            // Create new source code unit
             SourceCodeUnit::new(
               &mut parser,
               content,
-              &self.rule_store.default_substitutions(),
+              &current_global_substitutions,
               path.as_path(),
-              self.rule_store.piranha_args(),
+              &piranha_args,
             )
-          })
-          // Apply the rules to this file
-          .apply_rules(&mut self.rule_store, &current_rules, &mut parser, None);
+          });
+
+        // Apply the rules in this `SourceCodeUnit`
+        source_code_unit.apply_rules(&mut self.rule_store, &current_rules, &mut parser, None);
+
+        // Add the substitutions for the global tags to the `current_global_substitutions`
+        current_global_substitutions.extend(source_code_unit.global_substitutions());
 
         // Break when a new `global` rule is added
         if self.rule_store.global_rules().len() > current_rules.len() {

--- a/src/models/rule_store.rs
+++ b/src/models/rule_store.rs
@@ -51,9 +51,6 @@ pub(crate) struct RuleStore {
   // Command line arguments passed to piranha
   #[get = "pub"]
   piranha_args: PiranhaArguments,
-  // Command line arguments passed to piranha
-  #[get = "pub"]
-  global_tags: HashMap<String, String>,
 }
 
 impl From<PiranhaArguments> for RuleStore {
@@ -86,12 +83,6 @@ impl RuleStore {
     );
     trace!("Rule Store {}", format!("{:#?}", rule_store));
     rule_store
-  }
-
-  pub(crate) fn default_substitutions(&self) -> HashMap<String, String> {
-    let mut default_subs = self.piranha_args.input_substitutions().clone();
-    default_subs.extend(self.global_tags().clone());
-    default_subs
   }
 
   /// Add a new global rule, along with grep heuristics (If it doesn't already exist)
@@ -165,15 +156,6 @@ impl RuleStore {
       .find(|level| level.name().eq(scope_level))
       .map(|scope| scope.rules().to_vec())
       .unwrap_or_else(Vec::new)
-  }
-
-  pub(crate) fn add_global_tags(&mut self, new_entries: &HashMap<String, String>) {
-    let global_substitutions: HashMap<String, String> = new_entries
-      .iter()
-      .filter(|e| e.0.starts_with(self.piranha_args.global_tag_prefix()))
-      .map(|(a, b)| (a.to_string(), b.to_string()))
-      .collect();
-    let _ = &self.global_tags.extend(global_substitutions);
   }
 
   /// To create the current set of global rules, certain substitutions were applied.
@@ -264,7 +246,6 @@ impl Default for RuleStore {
       rule_query_cache: HashMap::default(),
       global_rules: Vec::default(),
       piranha_args: PiranhaArgumentsBuilder::default().build(),
-      global_tags: HashMap::default(),
     }
   }
 }


### PR DESCRIPTION
Earlier we were collecting all `global_tags` (as and when we found them) in a property of `RuleStore`
When we matched a rule, we checked if it contains `global_tags` and added them to the rule store that we are passing around. 

On further investigation I found that, we do not really need to do this.  It can be done more cleverly and cleanly.

Once a source code unit has been processed we simply retain all the substitutions that are "global" i.e. substitutions whose keys start with `global_tag_prefix`. Lol, idk why i did not think of this before. :\

Removed the functions `add_global_tags` and `add_to_substitutions`. Moved the"logic" that identifies global tags from `add_global_tags` to `global_substitutions` inside `source_code_unit.rs`

-----
P.S. I know `source_code_unit.rs` is becoming this gigantic file :|.  It is not that bad.  I will clean it up. 



