### PR TITLE
Move the source_code_unit_tests to e2e tests. 

### DIFF
--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -330,7 +330,7 @@ impl PiranhaArgumentsBuilder {
 ///
 macro_rules! piranha_arguments {
     ($($kw: ident = $value: expr,)*) => {
-      PiranhaArgumentsBuilder::default()
+      $crate::models::piranha_arguments::PiranhaArgumentsBuilder::default()
       $(
         .$kw($value)
        )*

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -20,7 +20,7 @@ use crate::{
     default_configs::{JAVA, SWIFT},
     language::PiranhaLanguage,
     piranha_arguments::PiranhaArgumentsBuilder,
-    rule::Rule,
+    rule::{InstantiatedRule, Rule},
     rule_store::RuleStore,
   },
   utilities::eq_without_whitespace,

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -10,28 +10,24 @@ Copyright (c) 2022 Uber Technologies, Inc.
  express or implied. See the License for the specific language governing permissions and
  limitations under the License.
 */
-use std::{
-  collections::HashSet,
-  fs::{self},
-  io,
-};
-
-use itertools::Itertools;
-use tempdir::TempDir;
+use std::collections::HashSet;
 
 use tree_sitter::Parser;
 
-use crate::models::{
-  constraint::Constraint,
-  default_configs::{JAVA, SWIFT},
-  language::PiranhaLanguage,
-  piranha_arguments::{PiranhaArguments, PiranhaArgumentsBuilder},
-  rule::{InstantiatedRule, Rule},
-  rule_store::RuleStore,
+use crate::{
+  models::{
+    constraint::Constraint,
+    default_configs::{JAVA, SWIFT},
+    language::PiranhaLanguage,
+    piranha_arguments::PiranhaArgumentsBuilder,
+    rule::Rule,
+    rule_store::RuleStore,
+  },
+  utilities::eq_without_whitespace,
 };
 use {
   super::SourceCodeUnit,
-  crate::{models::edit::Edit, utilities::eq_without_whitespace},
+  crate::models::edit::Edit,
   std::{collections::HashMap, path::PathBuf},
   tree_sitter::Range,
 };
@@ -180,133 +176,6 @@ fn test_apply_edit_comma_handling_via_regex() {
     &source_code.replace("name: \"BMX Bike\",", ""),
     source_code_unit.code()
   ));
-}
-fn execute_persist_in_temp_folder(
-  source_code: &str, piranha_arguments: &PiranhaArguments,
-  check_predicate: &dyn Fn(&TempDir) -> Result<bool, io::Error>,
-) -> Result<bool, io::Error> {
-  let java = get_java_tree_sitter_language();
-  let mut parser = java.parser();
-  let tmp_dir = TempDir::new("example")?;
-  let file_path = &tmp_dir.path().join("Sample1.java");
-  _ = fs::write(file_path.as_path(), source_code);
-  let mut source_code_unit = SourceCodeUnit::new(
-    &mut parser,
-    source_code.to_string(),
-    &HashMap::new(),
-    file_path.as_path(),
-    piranha_arguments,
-  );
-  source_code_unit.perform_delete_consecutive_new_lines();
-  source_code_unit.persist(piranha_arguments);
-  check_predicate(&tmp_dir)
-}
-
-#[test]
-fn test_persist_delete_file_when_empty() -> Result<(), io::Error> {
-  let args = PiranhaArgumentsBuilder::default()
-    .delete_consecutive_new_lines(true)
-    .build();
-  println!("{args:?}");
-  let source_code = "";
-  fn check(temp_dir: &TempDir) -> Result<bool, io::Error> {
-    let paths = fs::read_dir(temp_dir)?;
-    Ok(paths.count() == 0)
-  }
-  assert!(execute_persist_in_temp_folder(source_code, &args, &check)?);
-  Ok(())
-}
-
-#[test]
-fn test_persist_do_not_delete_file_when_empty() -> Result<(), io::Error> {
-  let args = PiranhaArgumentsBuilder::default()
-    .delete_consecutive_new_lines(true)
-    .delete_file_if_empty(false)
-    .build();
-  let source_code = "";
-  fn check(temp_dir: &TempDir) -> Result<bool, io::Error> {
-    let paths = fs::read_dir(temp_dir)?;
-    Ok(paths.count() == 1)
-  }
-
-  assert!(execute_persist_in_temp_folder(source_code, &args, &check)?);
-  Ok(())
-}
-
-#[test]
-fn test_persist_delete_consecutive_lines() -> Result<(), io::Error> {
-  let args = PiranhaArgumentsBuilder::default()
-    .delete_consecutive_new_lines(true)
-    .build();
-  let source_code_test_1 = "class Test {
-    public void foobar() {
-
-      System.out.println(\"Hello World!\");
-
-
-      System.out.println();
-    }
-  }";
-  let source_code_test_2 = "class Test {
-    public void foobar() {
-
-      System.out.println(\"Hello World!\");
-
-
-
-
-      System.out.println();
-    }
-  }";
-  fn check(temp_dir: &TempDir) -> Result<bool, io::Error> {
-    let paths = fs::read_dir(temp_dir)?;
-    let path = paths.find_or_first(|_| true).unwrap()?;
-    let expected_str = "class Test {
-    public void foobar() {
-
-      System.out.println(\"Hello World!\");
-
-      System.out.println();
-    }
-  }";
-    let actual_content = fs::read_to_string(path.path().as_path())?;
-    Ok(actual_content.eq(&expected_str))
-  }
-  assert!(execute_persist_in_temp_folder(
-    source_code_test_1,
-    &args,
-    &check
-  )?);
-  assert!(execute_persist_in_temp_folder(
-    source_code_test_2,
-    &args,
-    &check
-  )?);
-  Ok(())
-}
-
-#[test]
-fn test_persist_do_not_delete_consecutive_lines() -> Result<(), io::Error> {
-  let args = PiranhaArgumentsBuilder::default()
-    .delete_consecutive_new_lines(false)
-    .build();
-  let source_code = "class Test {
-    public void foobar() {
-
-      System.out.println(\"Hello World!\");
-
-
-      System.out.println();
-    }
-  }";
-  fn check(temp_dir: &TempDir) -> Result<bool, io::Error> {
-    let paths = fs::read_dir(temp_dir)?;
-    let path = paths.find_or_first(|_| true).unwrap()?;
-    let actual_content = fs::read_to_string(path.path().as_path())?;
-    Ok(actual_content.eq(&actual_content))
-  }
-  assert!(execute_persist_in_temp_folder(source_code, &args, &check)?);
-  Ok(())
 }
 
 #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -88,8 +88,8 @@ fn execute_piranha_and_check_result(
 
   let count_files = |path: &Path| {
     let mut count = 0;
-    for dir_entry in fs::read_dir(path).unwrap() {
-      if dir_entry.unwrap().path().is_file() {
+    for dir_entry in fs::read_dir(path).unwrap().flatten() {
+      if dir_entry.path().is_file() && ".placeholder" != dir_entry.file_name().to_str().unwrap() {
         count += 1;
       }
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -40,7 +40,7 @@ fn initialize() {
   });
 }
 
-// We use a `.placeholder` file because git does not allows us to commit an empty directory
+// We use a `.placeholder` file because git does not allow us to commit an empty directory
 static PLACEHOLDER: &str = ".placeholder";
 
 /// Copies the files under `src` to `dst`.

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -90,9 +90,9 @@ fn execute_piranha_and_check_result(
     let mut count = 0;
     for dir_entry in fs::read_dir(path).unwrap().flatten() {
       if dir_entry.path().is_file() {
-        // If the directory contains a file named `.placeholder` we assume that the directory is empty
+        // If the directory contains a file named `.placeholder` we ignore that file
         if PLACEHOLDER == dir_entry.file_name().to_str().unwrap() {
-          return 0;
+          continue;
         }
         count += 1;
       }

--- a/src/tests/test_piranha_go.rs
+++ b/src/tests/test_piranha_go.rs
@@ -12,15 +12,15 @@ Copyright (c) 2022 Uber Technologies, Inc.
 */
 
 use super::{
-  check_result, copy_folder, create_match_tests, create_rewrite_tests, initialize, substitutions,
+  copy_folder_to_temp_dir, create_match_tests, create_rewrite_tests,
+  execute_piranha_and_check_result, initialize, substitutions,
 };
 use crate::execute_piranha;
 use crate::models::{
   default_configs::GO,
   piranha_arguments::{piranha_arguments, PiranhaArgumentsBuilder},
 };
-use std::path::{Path, PathBuf};
-use tempdir::TempDir;
+use std::path::PathBuf;
 
 create_match_tests! {
   GO,

--- a/src/tests/test_piranha_go.rs
+++ b/src/tests/test_piranha_go.rs
@@ -11,16 +11,9 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use super::{
-  copy_folder_to_temp_dir, create_match_tests, create_rewrite_tests,
-  execute_piranha_and_check_result, initialize, substitutions,
-};
-use crate::execute_piranha;
-use crate::models::{
-  default_configs::GO,
-  piranha_arguments::{piranha_arguments, PiranhaArgumentsBuilder},
-};
-use std::path::PathBuf;
+use super::{create_match_tests, create_rewrite_tests, substitutions};
+
+use crate::models::default_configs::GO;
 
 create_match_tests! {
   GO,

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -97,7 +97,7 @@ fn test_user_option_delete_consecutive_lines() {
 fn test_user_option_do_not_delete_consecutive_lines() {
   let _path = PathBuf::from("test-resources")
     .join(JAVA)
-    .join("user_option_delete_consecutive_lines");
+    .join("user_option_do_not_delete_consecutive_lines");
   _helper_user_option_delete_consecutive_lines(_path, false);
 }
 

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -12,7 +12,8 @@ Copyright (c) 2022 Uber Technologies, Inc.
 */
 
 use super::{
-  check_result, copy_folder, create_match_tests, create_rewrite_tests, initialize, substitutions,
+  copy_folder_to_temp_dir, create_match_tests, create_rewrite_tests,
+  execute_piranha_and_check_result, initialize, substitutions,
 };
 use crate::{
   execute_piranha,
@@ -21,8 +22,7 @@ use crate::{
     piranha_arguments::{piranha_arguments, PiranhaArgumentsBuilder},
   },
 };
-use std::path::{Path, PathBuf};
-use tempdir::TempDir;
+use std::path::PathBuf;
 
 create_rewrite_tests! {
   JAVA,
@@ -59,6 +59,9 @@ create_rewrite_tests! {
   test_new_line_character_used_in_string_literal:  "new_line_character_used_in_string_literal",   1;
   test_insert_field_and_initializer:  "insert_field_and_initializer", 1;
   test_consecutive_scope_level_rules: "consecutive_scope_level_rules",1;
+  test_user_option_delete_if_empty: "user_option_delete_if_empty", 1;
+  test_user_option_do_not_delete_if_empty : "user_option_do_not_delete_if_empty", 1, delete_file_if_empty=false;
+  // test_user_option_delete_consecutive_lines :  "user_option_delete_consecutive_lines", 1, delete_consecutive_new_lines=true;
 }
 
 create_match_tests! {
@@ -84,4 +87,43 @@ fn test_scenarios_find_and_propagate_panic() {
   };
 
   let _ = execute_piranha(&piranha_arguments);
+}
+
+#[test]
+fn test_user_option_delete_consecutive_lines() {
+  initialize();
+  let _path = PathBuf::from("test-resources")
+    .join(JAVA)
+    .join("user_option_delete_consecutive_lines");
+  let temp_dir = copy_folder_to_temp_dir(&_path.join("input"));
+
+  let piranha_arguments = piranha_arguments! {
+    path_to_codebase = temp_dir.path().to_str().unwrap().to_string(),
+    path_to_configurations = _path.join("configurations").to_str().unwrap().to_string(),
+    language= JAVA.to_string(),
+    delete_consecutive_new_lines= true,
+  };
+
+  execute_piranha_and_check_result(&piranha_arguments, &_path.join("expected"), 1, false);
+  // Delete temp_dir
+  temp_dir.close().unwrap();
+}
+
+#[test]
+fn test_user_option_do_not_delete_consecutive_lines() {
+  initialize();
+  let _path = PathBuf::from("test-resources")
+    .join(JAVA)
+    .join("user_option_do_not_delete_consecutive_lines");
+  let temp_dir = copy_folder_to_temp_dir(&_path.join("input"));
+
+  let piranha_arguments = piranha_arguments! {
+    path_to_codebase = temp_dir.path().to_str().unwrap().to_string(),
+    path_to_configurations = _path.join("configurations").to_str().unwrap().to_string(),
+    language= JAVA.to_string(),
+  };
+
+  execute_piranha_and_check_result(&piranha_arguments, &_path.join("expected"), 1, false);
+  // Delete temp_dir
+  temp_dir.close().unwrap();
 }

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -87,34 +87,40 @@ fn test_scenarios_find_and_propagate_panic() {
 
 #[test]
 fn test_user_option_delete_consecutive_lines() {
-  _helper_user_option_delete_consecutive_lines(true);
+  let _path = PathBuf::from("test-resources")
+    .join(JAVA)
+    .join("user_option_delete_consecutive_lines");
+  _helper_user_option_delete_consecutive_lines(_path, true);
 }
 
 #[test]
 fn test_user_option_do_not_delete_consecutive_lines() {
-  _helper_user_option_delete_consecutive_lines(false);
-}
-
-fn _helper_user_option_delete_consecutive_lines(delete_consecutive_new_lines: bool) {
-  initialize();
   let _path = PathBuf::from("test-resources")
     .join(JAVA)
-    .join(if delete_consecutive_new_lines {
-      "user_option_delete_consecutive_lines"
-    } else {
-      "user_option_do_not_delete_consecutive_lines"
-    });
+    .join("user_option_delete_consecutive_lines");
+  _helper_user_option_delete_consecutive_lines(_path, false);
+}
 
-  let temp_dir = copy_folder_to_temp_dir(&_path.join("input"));
+fn _helper_user_option_delete_consecutive_lines(
+  path_to_scenario: PathBuf, delete_consecutive_new_lines: bool,
+) {
+  initialize();
+
+  let temp_dir = copy_folder_to_temp_dir(&path_to_scenario.join("input"));
 
   let piranha_arguments = piranha_arguments! {
     path_to_codebase = temp_dir.path().to_str().unwrap().to_string(),
-    path_to_configurations = _path.join("configurations").to_str().unwrap().to_string(),
+    path_to_configurations = path_to_scenario.join("configurations").to_str().unwrap().to_string(),
     language = JAVA.to_string(),
     delete_consecutive_new_lines = delete_consecutive_new_lines,
   };
 
-  execute_piranha_and_check_result(&piranha_arguments, &_path.join("expected"), 1, false);
+  execute_piranha_and_check_result(
+    &piranha_arguments,
+    &path_to_scenario.join("expected"),
+    1,
+    false,
+  );
   // Delete temp_dir
   temp_dir.close().unwrap();
 }

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -17,10 +17,7 @@ use super::{
 };
 use crate::{
   execute_piranha,
-  models::{
-    default_configs::JAVA,
-    piranha_arguments::{piranha_arguments, PiranhaArgumentsBuilder},
-  },
+  models::{default_configs::JAVA, piranha_arguments::piranha_arguments},
 };
 use std::path::PathBuf;
 
@@ -90,36 +87,31 @@ fn test_scenarios_find_and_propagate_panic() {
 
 #[test]
 fn test_user_option_delete_consecutive_lines() {
-  initialize();
-  let _path = PathBuf::from("test-resources")
-    .join(JAVA)
-    .join("user_option_delete_consecutive_lines");
-  let temp_dir = copy_folder_to_temp_dir(&_path.join("input"));
-
-  let piranha_arguments = piranha_arguments! {
-    path_to_codebase = temp_dir.path().to_str().unwrap().to_string(),
-    path_to_configurations = _path.join("configurations").to_str().unwrap().to_string(),
-    language= JAVA.to_string(),
-    delete_consecutive_new_lines= true,
-  };
-
-  execute_piranha_and_check_result(&piranha_arguments, &_path.join("expected"), 1, false);
-  // Delete temp_dir
-  temp_dir.close().unwrap();
+  _helper_user_option_delete_consecutive_lines(true);
 }
 
 #[test]
 fn test_user_option_do_not_delete_consecutive_lines() {
+  _helper_user_option_delete_consecutive_lines(false);
+}
+
+fn _helper_user_option_delete_consecutive_lines(delete_consecutive_new_lines: bool) {
   initialize();
   let _path = PathBuf::from("test-resources")
     .join(JAVA)
-    .join("user_option_do_not_delete_consecutive_lines");
+    .join(if delete_consecutive_new_lines {
+      "user_option_delete_consecutive_lines"
+    } else {
+      "user_option_do_not_delete_consecutive_lines"
+    });
+
   let temp_dir = copy_folder_to_temp_dir(&_path.join("input"));
 
   let piranha_arguments = piranha_arguments! {
     path_to_codebase = temp_dir.path().to_str().unwrap().to_string(),
     path_to_configurations = _path.join("configurations").to_str().unwrap().to_string(),
-    language= JAVA.to_string(),
+    language = JAVA.to_string(),
+    delete_consecutive_new_lines = delete_consecutive_new_lines,
   };
 
   execute_piranha_and_check_result(&piranha_arguments, &_path.join("expected"), 1, false);

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -61,7 +61,6 @@ create_rewrite_tests! {
   test_consecutive_scope_level_rules: "consecutive_scope_level_rules",1;
   test_user_option_delete_if_empty: "user_option_delete_if_empty", 1;
   test_user_option_do_not_delete_if_empty : "user_option_do_not_delete_if_empty", 1, delete_file_if_empty=false;
-  // test_user_option_delete_consecutive_lines :  "user_option_delete_consecutive_lines", 1, delete_consecutive_new_lines=true;
 }
 
 create_match_tests! {

--- a/src/tests/test_piranha_kt.rs
+++ b/src/tests/test_piranha_kt.rs
@@ -16,11 +16,12 @@ use crate::models::{
   piranha_arguments::{piranha_arguments, PiranhaArgumentsBuilder},
 };
 
-use super::{check_result, copy_folder, create_rewrite_tests, initialize, substitutions};
-use crate::execute_piranha;
+use super::{
+  copy_folder_to_temp_dir, create_rewrite_tests, execute_piranha_and_check_result, initialize,
+  substitutions,
+};
 
-use std::path::{Path, PathBuf};
-use tempdir::TempDir;
+use std::path::PathBuf;
 
 create_rewrite_tests! {
   KOTLIN,

--- a/src/tests/test_piranha_kt.rs
+++ b/src/tests/test_piranha_kt.rs
@@ -11,17 +11,9 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use crate::models::{
-  default_configs::KOTLIN,
-  piranha_arguments::{piranha_arguments, PiranhaArgumentsBuilder},
-};
+use crate::models::default_configs::KOTLIN;
 
-use super::{
-  copy_folder_to_temp_dir, create_rewrite_tests, execute_piranha_and_check_result, initialize,
-  substitutions,
-};
-
-use std::path::PathBuf;
+use super::{create_rewrite_tests, substitutions};
 
 create_rewrite_tests! {
   KOTLIN,

--- a/src/tests/test_piranha_python.rs
+++ b/src/tests/test_piranha_python.rs
@@ -11,16 +11,9 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use super::{
-  copy_folder_to_temp_dir, create_match_tests, create_rewrite_tests,
-  execute_piranha_and_check_result, initialize, substitutions,
-};
-use crate::execute_piranha;
-use crate::models::{
-  default_configs::PYTHON,
-  piranha_arguments::{piranha_arguments, PiranhaArgumentsBuilder},
-};
-use std::path::PathBuf;
+use super::{create_match_tests, create_rewrite_tests, substitutions};
+
+use crate::models::default_configs::PYTHON;
 
 create_rewrite_tests!(
   PYTHON,

--- a/src/tests/test_piranha_python.rs
+++ b/src/tests/test_piranha_python.rs
@@ -12,15 +12,15 @@ Copyright (c) 2022 Uber Technologies, Inc.
 */
 
 use super::{
-  check_result, copy_folder, create_match_tests, create_rewrite_tests, initialize, substitutions,
+  copy_folder_to_temp_dir, create_match_tests, create_rewrite_tests,
+  execute_piranha_and_check_result, initialize, substitutions,
 };
 use crate::execute_piranha;
 use crate::models::{
   default_configs::PYTHON,
   piranha_arguments::{piranha_arguments, PiranhaArgumentsBuilder},
 };
-use std::path::{Path, PathBuf};
-use tempdir::TempDir;
+use std::path::PathBuf;
 
 create_rewrite_tests!(
   PYTHON,

--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -11,16 +11,9 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use super::{
-  copy_folder_to_temp_dir, create_rewrite_tests, execute_piranha_and_check_result, initialize,
-  substitutions,
-};
+use super::{create_rewrite_tests, substitutions};
 
-use crate::models::{
-  default_configs::SWIFT,
-  piranha_arguments::{piranha_arguments, PiranhaArgumentsBuilder},
-};
-use std::path::PathBuf;
+use crate::models::default_configs::SWIFT;
 
 create_rewrite_tests! {
   SWIFT,

--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -11,14 +11,16 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use super::{check_result, copy_folder, create_rewrite_tests, initialize, substitutions};
-use crate::execute_piranha;
+use super::{
+  copy_folder_to_temp_dir, create_rewrite_tests, execute_piranha_and_check_result, initialize,
+  substitutions,
+};
+
 use crate::models::{
   default_configs::SWIFT,
   piranha_arguments::{piranha_arguments, PiranhaArgumentsBuilder},
 };
-use std::path::{Path, PathBuf};
-use tempdir::TempDir;
+use std::path::PathBuf;
 
 create_rewrite_tests! {
   SWIFT,

--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -32,13 +32,4 @@ create_rewrite_tests! {
     cleanup_comments = true,
     global_tag_prefix ="universal_tag.".to_string(),
     cleanup_comments_buffer = 3, delete_file_if_empty= false;
-
-  test_cleanup_rules_file: "cleanup_rules", 1,
-    substitutions = substitutions! {
-      "stale_flag" => "stale_flag_one",
-      "treated" => "true",
-      "treated_complement" => "false"
-    },
-    cleanup_comments = true, delete_file_if_empty= false;
-
 }

--- a/src/tests/test_piranha_ts.rs
+++ b/src/tests/test_piranha_ts.rs
@@ -10,13 +10,9 @@ Copyright (c) 2022 Uber Technologies, Inc.
  express or implied. See the License for the specific language governing permissions and
  limitations under the License.
 */
-use super::{create_match_tests, initialize};
-use crate::execute_piranha;
-use crate::models::{
-  default_configs::TYPESCRIPT, piranha_arguments::piranha_arguments,
-  piranha_arguments::PiranhaArgumentsBuilder,
-};
-use std::path::PathBuf;
+use super::create_match_tests;
+
+use crate::models::default_configs::TYPESCRIPT;
 
 create_match_tests! {
   TYPESCRIPT,

--- a/src/tests/test_piranha_tsx.rs
+++ b/src/tests/test_piranha_tsx.rs
@@ -11,14 +11,9 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use std::path::PathBuf;
+use super::create_match_tests;
 
-use super::{create_match_tests, initialize};
-use crate::execute_piranha;
-use crate::models::{
-  default_configs::TSX, piranha_arguments::piranha_arguments,
-  piranha_arguments::PiranhaArgumentsBuilder,
-};
+use crate::models::default_configs::TSX;
 
 create_match_tests! {
   TSX,

--- a/test-resources/java/user_option_delete_consecutive_lines/configurations/rules.toml
+++ b/test-resources/java/user_option_delete_consecutive_lines/configurations/rules.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+name = "Delete File"
+query = "(((method_declaration name: (_)@name) @md) (#eq? @name \"foobar\"))"
+replace_node = "name"
+replace = "barfoo"

--- a/test-resources/java/user_option_delete_consecutive_lines/expected/Sample.java
+++ b/test-resources/java/user_option_delete_consecutive_lines/expected/Sample.java
@@ -1,0 +1,19 @@
+package foo.bar;
+
+public class Sample {
+
+    public void barfoo() {
+
+        System.out.println("Hello World!");
+  
+        System.out.println();
+    }
+
+    public void foobar1() {
+
+        System.out.println("Hello World!");
+  
+        System.out.println();
+    }
+
+}

--- a/test-resources/java/user_option_delete_consecutive_lines/input/Sample.java
+++ b/test-resources/java/user_option_delete_consecutive_lines/input/Sample.java
@@ -1,0 +1,24 @@
+package foo.bar;
+
+public class Sample {
+
+    public void foobar() {
+
+        System.out.println("Hello World!");
+  
+  
+        System.out.println();
+    }
+
+    public void foobar1() {
+
+        System.out.println("Hello World!");
+  
+  
+  
+  
+        System.out.println();
+    }
+
+
+}

--- a/test-resources/java/user_option_delete_if_empty/configurations/rules.toml
+++ b/test-resources/java/user_option_delete_if_empty/configurations/rules.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+name = "Delete File"
+query = "(program) @program"
+replace_node = "program"
+replace = ""

--- a/test-resources/java/user_option_delete_if_empty/input/Sample.java
+++ b/test-resources/java/user_option_delete_if_empty/input/Sample.java
@@ -1,0 +1,5 @@
+package foo.bar;
+
+public class Sample {
+    
+}

--- a/test-resources/java/user_option_do_not_delete_consecutive_lines/configurations/rules.toml
+++ b/test-resources/java/user_option_do_not_delete_consecutive_lines/configurations/rules.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+name = "Delete File"
+query = "(((method_declaration name: (_)@name) @md) (#eq? @name \"foobar\"))"
+replace_node = "name"
+replace = "barfoo"

--- a/test-resources/java/user_option_do_not_delete_consecutive_lines/expected/Sample.java
+++ b/test-resources/java/user_option_do_not_delete_consecutive_lines/expected/Sample.java
@@ -1,0 +1,24 @@
+package foo.bar;
+
+public class Sample {
+
+    public void barfoo() {
+
+        System.out.println("Hello World!");
+  
+  
+        System.out.println();
+    }
+
+    public void foobar1() {
+
+        System.out.println("Hello World!");
+  
+  
+  
+  
+        System.out.println();
+    }
+
+
+}

--- a/test-resources/java/user_option_do_not_delete_consecutive_lines/input/Sample.java
+++ b/test-resources/java/user_option_do_not_delete_consecutive_lines/input/Sample.java
@@ -1,0 +1,24 @@
+package foo.bar;
+
+public class Sample {
+
+    public void foobar() {
+
+        System.out.println("Hello World!");
+  
+  
+        System.out.println();
+    }
+
+    public void foobar1() {
+
+        System.out.println("Hello World!");
+  
+  
+  
+  
+        System.out.println();
+    }
+
+
+}

--- a/test-resources/java/user_option_do_not_delete_if_empty/configurations/rules.toml
+++ b/test-resources/java/user_option_do_not_delete_if_empty/configurations/rules.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+name = "Delete File"
+query = "(program) @program"
+replace_node = "program"
+replace = ""

--- a/test-resources/java/user_option_do_not_delete_if_empty/input/Sample.java
+++ b/test-resources/java/user_option_do_not_delete_if_empty/input/Sample.java
@@ -1,0 +1,5 @@
+package foo.bar;
+
+public class Sample {
+    
+}


### PR DESCRIPTION
This PR removes the tests in `source_code_unit_test.rs` using `execute_persist_int_temp` and convert them to e2e tests.

This PR has the following changes: 
1. Delete all the tests from `source_code_unit_test.rs` using `execute_persist_int_temp`
2. Added equivalent tests under `test_piranha_java.rs`
* We could not add all tests using the macro (`create_rewrite_test`) because this macro creates a test that compares files ignoring whitespaces difference. 
* the features `delete_consecutive_new_lines` cannot be correctly tested by `create_rewrite_test` macro (because the file comparison in the tests need to account for new line changes) 
   * For this reason I separately implement the +ve and -ve test for `delete_consecutive_new_lines`
      *  I literally copy pasted the macro, instantiated it manually and passed false to `execute_piranha_and_check_result`
3. I do some refactoring of the macro `create_rewrite_test` itself (I know it could have been in another diff :| ) 
    * This refactoring basically extracts some code from this macro into the function `execute_piranha_and_check_result`
    *  this refactoring also adds a functionality which allows file comparison with or without ignoring white spaces.

