### PR TITLE
Fix Cargo Clippy problems

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+#![allow(deprecated)] // This prevents cargo clippy throwing warning for deprecated use.
 use models::{
   edit::Edit, matches::Match, piranha_arguments::PiranhaArguments,
   piranha_output::PiranhaOutputSummary, source_code_unit::SourceCodeUnit,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,5 @@ fn write_output_summary(
       return;
     }
   }
-  panic!(
-    "Could not write the output summary to the file - {}",
-    path_to_json
-  );
+  panic!("Could not write the output summary to the file - {path_to_json}");
 }

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -84,7 +84,7 @@ impl Rule {
   fn substitute(&self, substitutions_for_holes: &HashMap<String, String>) -> Rule {
     if substitutions_for_holes.len() != self.holes().len() {
       #[rustfmt::skip]
-      panic!("{}", format!( "Could not instantiate the rule {:?} with substitutions {:?}", self, substitutions_for_holes).red());
+      panic!("{}", format!( "Could not instantiate the rule {self:?} with substitutions {substitutions_for_holes:?}").red());
     }
     let updated_rule = self.clone();
     Rule {

--- a/src/models/rule_graph.rs
+++ b/src/models/rule_graph.rs
@@ -71,7 +71,7 @@ impl RuleGraph {
   /// Get the number of nodes and edges in the rule graph
   pub(crate) fn get_number_of_rules_and_edges(&self) -> (usize, usize) {
     let mut edges = 0;
-    for (_, destinations) in &self.graph {
+    for destinations in self.graph.values() {
       edges += destinations.len();
     }
     (self.graph.len(), edges)

--- a/src/models/rule_store.rs
+++ b/src/models/rule_store.rs
@@ -81,7 +81,7 @@ impl RuleStore {
       "Number of rules and edges loaded : {:?}",
       rule_store.rule_graph.get_number_of_rules_and_edges()
     );
-    trace!("Rule Store {}", format!("{:#?}", rule_store));
+    trace!("Rule Store {}", format!("{rule_store:#?}"));
     rule_store
   }
 

--- a/src/models/source_code_unit.rs
+++ b/src/models/source_code_unit.rs
@@ -370,7 +370,7 @@ impl SourceCodeUnit {
       .ast
       .root_node()
       .descendant_for_byte_range(start_byte, start_byte)
-      .unwrap_or(self.ast.root_node());
+      .unwrap_or_else(|| self.ast.root_node());
 
     for node in traverse(node.walk(), Order::Post) {
       if node.start_position().row == row || node.end_position().row == row {
@@ -522,7 +522,6 @@ impl SourceCodeUnit {
     // Context contains -  the changed node in the previous edit, its's parent, grand parent and great grand parent
     let context = || {
       get_context(
-        self.root_node(),
         changed_node,
         self.code().to_string(),
         number_of_ancestors_in_parent_scope,

--- a/src/models/source_code_unit.rs
+++ b/src/models/source_code_unit.rs
@@ -621,7 +621,7 @@ impl SourceCodeUnit {
         break;
       }
     }
-    panic!("Could not create scope query for {:?}", scope_level);
+    panic!("Could not create scope query for {scope_level:?}");
   }
 
   fn is_satisfied(

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -207,7 +207,7 @@ fn test_persist_delete_file_when_empty() -> Result<(), io::Error> {
   let args = PiranhaArgumentsBuilder::default()
     .delete_consecutive_new_lines(true)
     .build();
-  println!("{:?}", args);
+  println!("{args:?}");
   let source_code = "";
   fn check(temp_dir: &TempDir) -> Result<bool, io::Error> {
     let paths = fs::read_dir(temp_dir)?;

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -44,7 +44,7 @@ where
         T::default()
       } else {
         #[rustfmt::skip]
-      panic!("Could not read file: {:?} \n Error : \n {:?}", file_path, err);
+      panic!("Could not read file: {file_path:?} \n Error : \n {err:?}");
       }
     }
   }

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -162,7 +162,7 @@ fn accumulate_repeated_tags(
           let code_snippet = &capture.node.utf8_text(source_code.as_bytes()).unwrap();
           code_snippet_by_tag
             .entry(tag_name.clone())
-            .and_modify(|x| x.push_str(format!("\n{}", code_snippet).as_str()))
+            .and_modify(|x| x.push_str(format!("\n{code_snippet}").as_str()))
             .or_insert_with(|| code_snippet.to_string());
         }
       }
@@ -287,7 +287,7 @@ pub(crate) fn substitute_tags(
   let mut output = input_string.to_string();
   for (tag, substitute) in substitutions {
     // Before replacing the key, it is transformed to a tree-sitter tag by adding `@` as prefix
-    let key = format!("@{}", tag);
+    let key = format!("@{tag}");
     let substitution_value = if is_tree_sitter_query {
       substitute.replace('\n', "\\n").to_string()
     } else {

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -180,14 +180,14 @@ fn accumulate_repeated_tags(
 // outermost node captured by the query.
 // This function gets the range of the ast corresponding to the `replace_node` tag of the query.
 fn get_range_for_replace_node(
-  query: &Query, query_matches: &Vec<Vec<tree_sitter::QueryCapture>>, replace_node_name: &String,
+  query: &Query, query_matches: &[Vec<tree_sitter::QueryCapture>], replace_node_name: &String,
 ) -> Option<Range> {
   let tag_names_by_index: HashMap<usize, &String> =
     query.capture_names().iter().enumerate().collect();
   // Iterate over each tag name in the query
   for tag_name in query.capture_names().iter() {
     // Iterate over each query match for this range of code snippet
-    for captures in query_matches.clone() {
+    for captures in query_matches.iter().cloned() {
       // Iterate over each capture
       for capture in captures {
         if tag_names_by_index[&(capture.index as usize)].eq(tag_name)
@@ -320,14 +320,12 @@ fn get_non_str_eq_parent(node: Node, source_code: String) -> Option<Node> {
 }
 
 /// Returns the node, its parent, grand parent and great grand parent
-pub(crate) fn get_context<'a>(
-  root_node: Node, prev_node: Node<'a>, source_code: String, count: u8,
-) -> Vec<Node<'a>> {
+pub(crate) fn get_context(prev_node: Node<'_>, source_code: String, count: u8) -> Vec<Node<'_>> {
   let mut output = Vec::new();
   if count > 0 {
     output.push(prev_node);
     if let Some(parent) = get_non_str_eq_parent(prev_node, source_code.to_string()) {
-      output.extend(get_context(root_node, parent, source_code, count - 1));
+      output.extend(get_context(parent, source_code, count - 1));
     }
   }
   output


### PR DESCRIPTION
Our `master` is failing because of some `cargo clippy` issue. `Clippy` is our linter. 
We have set up clippy such that, it fails if there are any linting issues for which `auto-fix` is available. 

When I look at the CI logs it shows that there are 5 warnings and 1 fix. 
When I look run cargo clippy locally i see 6 warnings and no fix. 

I am taking this opportunity to fix all the cargo clippy problems (These are not auto-fixable by cargo clippy). 
Now we have no warnings from this tool 

After I updated my local rust up toolchain, I could see those problems. I fixed them in the second commit. 
