### PR TITLE
Updated rules and edges in language.rs for swift and added rules to simplify something_and_true

### DIFF
--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -1,0 +1,28 @@
+
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The edges in this file specify the flow between the rules.
+
+[[edges]]
+scope = "Parent"
+from = "replace_expression_with_boolean_literal"
+to = ["boolean_literal_cleanup"]
+
+[[edges]]
+scope = "Parent"
+from = "boolean_literal_cleanup"
+to = ["boolean_expression_simplify"]
+
+[[edges]]
+scope = "Parent"
+from = "boolean_expression_simplify"
+to = ["boolean_literal_cleanup"]

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -1,0 +1,56 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Before 
+#   true && abcd()
+# After 
+#   abcd()
+#
+[[rules]]
+name = "true_and_something"
+query = """(
+(conjunction_expression
+        lhs: (boolean_literal) @true
+        rhs: (_) @rhs
+    ) @conjunction_expression
+(#eq? @true "true")
+)"""
+groups = ["boolean_expression_simplify"]
+replace_node = "conjunction_expression"
+replace = "@rhs"
+
+#
+# Before 
+#   abcd() && true
+# After 
+#   abcd()
+#
+[[rules]]
+name = "something_and_true"
+query = """(
+(conjunction_expression
+        lhs: (_) @lhs
+        rhs: (boolean_literal) @true
+    ) @conjunction_expression
+(#eq? @true "true")
+)"""
+groups = ["boolean_expression_simplify"]
+replace_node = "conjunction_expression"
+replace = "@lhs"
+
+# Dummy rule that acts as a junction for all boolean based cleanups
+# Let's say you want to define rules from A -> B, A -> C, D -> B, D -> C, ... 
+# A pattern here is - if there is an outgoing edge to B there is another to C.
+# In these cases, you can use a dummy rule X as shown below:
+# X -> B, X - C, A -> X, D -> X, ...
+[[rules]]
+name = "boolean_literal_cleanup"

--- a/src/models/language.rs
+++ b/src/models/language.rs
@@ -155,17 +155,23 @@ impl From<&str> for PiranhaLanguage {
         scopes: vec![],
         comment_nodes: vec![],
       },
-      SWIFT => PiranhaLanguage {
-        name: language.to_string(),
-        supported_language: SupportedLanguage::Swift,
-        language: tree_sitter_swift::language(),
-        scopes: parse_toml::<ScopeConfig>(include_str!("../cleanup_rules/swift/scope_config.toml"))
+      SWIFT => {
+        let rules: Rules = parse_toml(include_str!("../cleanup_rules/swift/rules.toml"));
+        let edges: Edges = parse_toml(include_str!("../cleanup_rules/swift/edges.toml"));
+        PiranhaLanguage {
+          name: language.to_string(),
+          supported_language: SupportedLanguage::Swift,
+          language: tree_sitter_swift::language(),
+          scopes: parse_toml::<ScopeConfig>(include_str!(
+            "../cleanup_rules/swift/scope_config.toml"
+          ))
           .scopes()
           .to_vec(),
-        comment_nodes: vec!["comment".to_string(), "multiline_comment".to_string()],
-        rules: None,
-        edges: None,
-      },
+          comment_nodes: vec!["comment".to_string(), "multiline_comment".to_string()],
+          rules: Some(rules),
+          edges: Some(edges),
+        }
+      }
       TYPESCRIPT => PiranhaLanguage {
         name: language.to_string(),
         supported_language: SupportedLanguage::Ts,

--- a/test-resources/swift/cleanup_rules/configurations/rules.toml
+++ b/test-resources/swift/cleanup_rules/configurations/rules.toml
@@ -35,3 +35,4 @@ query = """(
 replace_node = "parameter_access"
 replace = "true"
 holes = ["stale_flag"]
+groups = ["replace_expression_with_boolean_literal"]

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -11,4 +11,8 @@
 
 class SampleClass {
     var isEnabled = true
+    var isEnabled2 = f1()
+    var isEnabled3 = v1
+    var isEnabled4 = f2()
+    var isEnabled5 = v2
 }

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -11,4 +11,8 @@
 
 class SampleClass {
     var isEnabled = TestEnum.stale_flag_one.isEnabled
+    var isEnabled2 = TestEnum.stale_flag_one.isEnabled && f1()
+    var isEnabled3 = TestEnum.stale_flag_one.isEnabled && v1
+    var isEnabled4 = f2() && TestEnum.stale_flag_one.isEnabled 
+    var isEnabled5 = v2 && TestEnum.stale_flag_one.isEnabled 
 }


### PR DESCRIPTION
Added rules and edges for swift language in language.rs
Created cleanup rules for:

1. `true && something` to `something`
2. `something && true` to `something`

Created edges to:
1. run boolean_simplification rules
2.  recursive edge to complete boolean_simplification.

updated test for created rules

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #344
* __->__ #343

