### PR TITLE
Added rule for replacing toggle_disabled with false in test-resources

### DIFF
--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -38,10 +38,12 @@ create_rewrite_tests! {
     global_tag_prefix ="universal_tag.".to_string(),
     cleanup_comments_buffer = 3, delete_file_if_empty= false;
 
-    test_cleanup_rules_file: "cleanup_rules", 1,
-      substitutions = substitutions! {
-        "stale_flag" => "stale_flag_one"
-      },
-      cleanup_comments = true, delete_file_if_empty= false;
+  test_cleanup_rules_file: "cleanup_rules", 1,
+    substitutions = substitutions! {
+      "stale_flag" => "stale_flag_one",
+      "treated" => "true",
+      "treated_complement" => "false"
+    },
+    cleanup_comments = true, delete_file_if_empty= false;
 
 }

--- a/test-resources/swift/cleanup_rules/configurations/rules.toml
+++ b/test-resources/swift/cleanup_rules/configurations/rules.toml
@@ -33,6 +33,33 @@ query = """(
 (#eq? @access_identifier "isEnabled")
 )"""
 replace_node = "parameter_access"
-replace = "true"
-holes = ["stale_flag"]
+replace = "@treated"
+holes = ["stale_flag", "treated"]
+groups = ["replace_expression_with_boolean_literal"]
+
+#
+# For @stale_flag_name = stale_flag and @treated = true
+# Before 
+#   !TestEnum.stale_flag.isEnabled
+# After 
+#   false
+#
+
+[[rules]]
+name = "replace_isToggleDisabled_with_boolean_literal"
+query = """(
+(navigation_expression
+        target: (navigation_expression
+            target: (prefix_expression
+                operation: (bang))
+            suffix: (navigation_suffix
+                suffix: (simple_identifier) @param))
+        suffix: (navigation_suffix
+            suffix: (simple_identifier) @access_identifier)) @parameter_access
+(#eq? @param "@stale_flag")
+(#eq? @access_identifier "isEnabled")
+)"""
+replace_node = "parameter_access"
+replace = "@treated_complement"
+holes = ["stale_flag", "treated_complement"]
 groups = ["replace_expression_with_boolean_literal"]

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -19,5 +19,6 @@ class SampleClass {
         isEnabled = v2
         isEnabled = v2
         isEnabled = v2
+        isEnabled = false
     }
 }

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -19,5 +19,6 @@ class SampleClass {
         isEnabled = v2 && TestEnum.stale_flag_one.isEnabled 
         isEnabled = v2 && (TestEnum.stale_flag_one.isEnabled && true)
         isEnabled = (TestEnum.stale_flag_one.isEnabled && true) && v2
+        isEnabled = !TestEnum.stale_flag_one.isEnabled
     }
 }


### PR DESCRIPTION
Added rule in test-resources

1. Checks for occurances of `!ENUM_NAME.STALE_FLAG.isEnabled` and replace them with false.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #344
* #343

