### PR TITLE
Seperate out logic related to reading user rules and built-in rules

### DIFF
--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -94,3 +94,7 @@ pub fn default_replace_node() -> String {
 pub fn default_replace() -> String {
   String::new()
 }
+
+pub fn default_rule_graph() -> HashMap<String, Vec<(String, String)>> {
+  HashMap::new()
+}

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -94,22 +94,6 @@ impl Rule {
     }
   }
 
-  /// Groups the rules based on the field `rule.groups`
-  /// Note: a rule can belong to more than one group.
-  pub(crate) fn group_rules(
-    rules: &Vec<Rule>,
-  ) -> (HashMap<String, Rule>, HashMap<&String, Vec<&String>>) {
-    let mut rules_by_name = HashMap::new();
-    let mut rules_by_group = HashMap::new();
-    for rule in rules {
-      rules_by_name.insert(rule.name().to_string(), rule.clone());
-      for tag in rule.groups() {
-        rules_by_group.collect(tag, rule.name());
-      }
-    }
-    (rules_by_name, rules_by_group)
-  }
-
   /// Adds the rule to a new group - "SEED" if applicable.
   pub(crate) fn add_to_seed_rules_group(&mut self) {
     if self.groups().contains(&CLEAN_UP.to_string()) {

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -17,7 +17,7 @@ use colored::Colorize;
 use getset::Getters;
 use serde_derive::Deserialize;
 
-use crate::utilities::{tree_sitter_utilities::substitute_tags, MapOfVec};
+use crate::utilities::tree_sitter_utilities::substitute_tags;
 
 use super::{
   constraint::Constraint,

--- a/src/models/rule_graph.rs
+++ b/src/models/rule_graph.rs
@@ -101,4 +101,13 @@ impl RuleGraph {
       .map(|x| x.name())
       .collect_vec()
   }
+
+  pub(crate) fn merge(&self, rule_graph: &RuleGraph) -> Self {
+    let all_rules = [rule_graph.rules().clone(), self.rules().clone()].concat();
+    let all_edges = [rule_graph.edges().clone(), self.edges().clone()].concat();
+    RuleGraphBuilder::default()
+      .rules(all_rules)
+      .edges(all_edges)
+      .build()
+  }
 }

--- a/src/models/rule_graph.rs
+++ b/src/models/rule_graph.rs
@@ -110,5 +110,4 @@ impl RuleGraph {
       .edges(all_edges)
       .build()
   }
-
 }

--- a/src/models/rule_store.rs
+++ b/src/models/rule_store.rs
@@ -27,7 +27,6 @@ use tree_sitter::Query;
 use crate::{
   models::piranha_arguments::{PiranhaArguments, PiranhaArgumentsBuilder},
   models::{
-    rule::Rule,
     rule_graph::{RuleGraph, RuleGraphBuilder},
     scopes::ScopeQueryGenerator,
   },
@@ -35,7 +34,7 @@ use crate::{
 };
 
 use super::{
-  outgoing_edges::{Edges, OutgoingEdges},
+  outgoing_edges::Edges,
   rule::{InstantiatedRule, Rules},
 };
 
@@ -68,11 +67,7 @@ impl From<PiranhaArguments> for RuleStore {
 
 impl RuleStore {
   pub(crate) fn new(args: &PiranhaArguments) -> RuleStore {
-    let (rules, edges) = read_config_files(args);
-    let rule_graph = RuleGraphBuilder::default()
-      .rules(rules)
-      .edges(edges)
-      .build();
+    let rule_graph = read_config_files(args);
     let mut rule_store = RuleStore {
       rule_graph,
       piranha_args: args.clone(),
@@ -257,22 +252,29 @@ impl Default for RuleStore {
   }
 }
 
-fn read_config_files(args: &PiranhaArguments) -> (Vec<Rule>, Vec<OutgoingEdges>) {
-  let path_to_config = Path::new(args.path_to_configurations());
-  // Read the language specific cleanup rules and edges
-  let language_rules: Rules = args.piranha_language().rules().clone().unwrap_or_default();
-  let language_edges: Edges = args.piranha_language().edges().clone().unwrap_or_default();
+fn read_config_files(args: &PiranhaArguments) -> RuleGraph {
+  let piranha_language = args.piranha_language();
 
+  let built_in_rules = RuleGraphBuilder::default()
+    .edges(piranha_language.edges().clone().unwrap_or_default().edges)
+    .rules(piranha_language.rules().clone().unwrap_or_default().rules)
+    .build();
+
+  let user_defined_rules = read_user_config_files(args.path_to_configurations());
+
+  built_in_rules.merge(&user_defined_rules)
+}
+
+pub(crate) fn read_user_config_files(path_to_configurations: &String) -> RuleGraph {
+  let path_to_config = Path::new(path_to_configurations);
   // Read the API specific cleanup rules and edges
   let mut input_rules: Rules = read_toml(&path_to_config.join("rules.toml"), true);
   let input_edges: Edges = read_toml(&path_to_config.join("edges.toml"), true);
-
   for r in input_rules.rules.iter_mut() {
     r.add_to_seed_rules_group();
   }
-
-  let all_rules = [language_rules.rules, input_rules.rules].concat();
-  let all_edges = [language_edges.edges, input_edges.edges].concat();
-
-  (all_rules, all_edges)
+  RuleGraphBuilder::default()
+    .rules(input_rules.rules)
+    .edges(input_edges.edges)
+    .build()
 }

--- a/src/models/rule_store.rs
+++ b/src/models/rule_store.rs
@@ -267,7 +267,7 @@ fn read_config_files(args: &PiranhaArguments) -> RuleGraph {
 
 pub(crate) fn read_user_config_files(path_to_configurations: &String) -> RuleGraph {
   let path_to_config = Path::new(path_to_configurations);
-  // Read the API specific cleanup rules and edges
+  // Read the rules and edges provided by the user
   let mut input_rules: Rules = read_toml(&path_to_config.join("rules.toml"), true);
   let input_edges: Edges = read_toml(&path_to_config.join("edges.toml"), true);
   for r in input_rules.rules.iter_mut() {


### PR DESCRIPTION
Earlier we had this one function `read_config_files` which read language specific (built-in) and user provided rules/edges. We now split it into two - `read_config_files` and `read_user_config_files` and implement a merge method for `RuleGraph`.

----
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #354
* #353

