### PR TITLE
[Refactoring] Do not use traits unnecessarily

### DIFF
--- a/src/models/constraint.rs
+++ b/src/models/constraint.rs
@@ -18,7 +18,7 @@ use serde_derive::Deserialize;
 use tree_sitter::Node;
 
 use crate::utilities::tree_sitter_utilities::{
-  get_node_for_range, substitute_tags, PiranhaHelpers,
+  get_match_for_query, get_node_for_range, substitute_tags,
 };
 
 use super::{rule::InstantiatedRule, rule_store::RuleStore, source_code_unit::SourceCodeUnit};
@@ -72,9 +72,12 @@ impl SourceCodeUnit {
     let mut matched_matcher = false;
     while let Some(parent) = current_node.parent() {
       let matcher_query_str = substitute_tags(constraint.matcher(), substitutions, true);
-      if let Some(p_match) =
-        parent.get_match_for_query(self.code(), rule_store.query(&matcher_query_str), false)
-      {
+      if let Some(p_match) = get_match_for_query(
+        &parent,
+        self.code(),
+        rule_store.query(&matcher_query_str),
+        false,
+      ) {
         matched_matcher = true;
         let scope_node = get_node_for_range(
           self.root_node(),
@@ -85,10 +88,7 @@ impl SourceCodeUnit {
           let query_str = substitute_tags(query_with_holes, substitutions, true);
           let query = &rule_store.query(&query_str);
           // If this query matches anywhere within the scope, return false.
-          if scope_node
-            .get_match_for_query(self.code(), query, true)
-            .is_some()
-          {
+          if get_match_for_query(&scope_node, self.code(), query, true).is_some() {
             return false;
           }
         }

--- a/src/models/matches.rs
+++ b/src/models/matches.rs
@@ -21,7 +21,7 @@ use tree_sitter::Node;
 
 use crate::utilities::{
   gen_py_str_methods,
-  tree_sitter_utilities::{get_node_for_range, PiranhaHelpers},
+  tree_sitter_utilities::{get_all_matches_for_query, get_node_for_range},
 };
 
 use super::{rule::InstantiatedRule, rule_store::RuleStore, source_code_unit::SourceCodeUnit};
@@ -122,7 +122,8 @@ impl SourceCodeUnit {
     } else {
       Some(rule.replace_node())
     };
-    let all_query_matches = node.get_all_matches_for_query(
+    let all_query_matches = get_all_matches_for_query(
+      &node,
       self.code().to_string(),
       rule_store.query(&rule.query()),
       recursive,

--- a/src/models/scopes.rs
+++ b/src/models/scopes.rs
@@ -17,7 +17,7 @@ use log::trace;
 use serde_derive::Deserialize;
 
 use crate::utilities::tree_sitter_utilities::{
-  get_node_for_range, substitute_tags, PiranhaHelpers,
+  get_match_for_query, get_node_for_range, substitute_tags,
 };
 
 use super::{rule_store::RuleStore, source_code_unit::SourceCodeUnit};
@@ -65,9 +65,12 @@ impl SourceCodeUnit {
         changed_node.kind()
       );
       for m in &scope_matchers {
-        if let Some(p_match) =
-          changed_node.get_match_for_query(self.code(), rules_store.query(m.matcher()), false)
-        {
+        if let Some(p_match) = get_match_for_query(
+          &changed_node,
+          self.code(),
+          rules_store.query(m.matcher()),
+          false,
+        ) {
           // Generate the scope query for the specific context by substituting the
           // the tags with code snippets appropriately in the `generator` query.
           return substitute_tags(m.generator(), p_match.matches(), true);

--- a/src/models/source_code_unit.rs
+++ b/src/models/source_code_unit.rs
@@ -25,7 +25,7 @@ use tree_sitter_traversal::{traverse, Order};
 use crate::{
   models::rule_store::{GLOBAL, PARENT},
   utilities::tree_sitter_utilities::{
-    get_node_for_range, get_replace_range, get_tree_sitter_edit, PiranhaHelpers,
+    get_match_for_query, get_node_for_range, get_replace_range, get_tree_sitter_edit,
   },
 };
 
@@ -283,11 +283,12 @@ impl SourceCodeUnit {
     if let Some(query_str) = scope_query {
       // Apply the scope query in the source code and get the appropriate node
       let tree_sitter_scope_query = rules_store.query(query_str);
-      if let Some(p_match) =
-        &self
-          .root_node()
-          .get_match_for_query(self.code(), tree_sitter_scope_query, true)
-      {
+      if let Some(p_match) = get_match_for_query(
+        &self.root_node(),
+        self.code(),
+        tree_sitter_scope_query,
+        true,
+      ) {
         return get_node_for_range(
           self.root_node(),
           p_match.range().start_byte,

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -24,121 +24,108 @@ use tree_sitter::{InputEdit, Node, Point, Query, QueryCapture, QueryCursor, Rang
 
 use super::eq_without_whitespace;
 
-#[rustfmt::skip]
-pub(crate) trait PiranhaHelpers {
-
-     /// Applies the query upon `self`, and gets the first match
-    /// # Arguments
-    /// * `source_code` - the corresponding source code string for the node.
-    /// * `query` - the query to be applied
-    ///
-    /// # Returns
-    /// List of matches (list of captures), grouped by the outermost tag of the query
-    fn get_query_capture_groups(&self, source_code: &str, query: &Query) -> HashMap<Range, Vec<Vec<QueryCapture>>> ;
-
-    /// Applies the query upon `self`, and gets the first match
-    /// # Arguments
-    /// * `source_code` - the corresponding source code string for the node.
-    /// * `query` - the query to be applied
-    /// * `recursive` - if `true` it matches the query to `self` and `self`'s sub-ASTs, else it matches the `query` only to `self`.
-    ///
-    /// # Returns
-    /// The range of the match in the source code and the corresponding mapping from tags to code snippets.
-    fn get_all_matches_for_query(&self, source_code: String, query: &Query, recursive: bool, replace_node_tag: Option<String>) -> Vec<Match> ;
-
-    /// Applies the query upon `self`, and gets all the matches
-    /// # Arguments
-    /// * `source_code` - the corresponding source code string for the node.
-    /// * `query` - the query to be applied
-    /// * `recursive` - if `true` it matches the query to `self` and `self`'s sub-ASTs, else it matches the `query` only to `self`.
-    ///
-    /// # Returns
-    /// A vector of `tuples` containing the range of the matches in the source code and the corresponding mapping for the tags (to code snippets).
-    /// By default it returns the range of the outermost node for each query match.
-    /// If `replace_node` is provided in the rule, it returns the range of the node corresponding to that tag.
-    fn get_match_for_query(&self, source_code: &str, query: &Query, recursive: bool) -> Option<Match>;
+/// Applies the query upon `self`, and gets all the matches
+/// # Arguments
+/// * `source_code` - the corresponding source code string for the node.
+/// * `query` - the query to be applied
+/// * `recursive` - if `true` it matches the query to `self` and `self`'s sub-ASTs, else it matches the `query` only to `self`.
+///
+/// # Returns
+/// A vector of `tuples` containing the range of the matches in the source code and the corresponding mapping for the tags (to code snippets).
+/// By default it returns the range of the outermost node for each query match.
+/// If `replace_node` is provided in the rule, it returns the range of the node corresponding to that tag.
+pub(crate) fn get_match_for_query(
+  node: &Node, source_code: &str, query: &Query, recursive: bool,
+) -> Option<Match> {
+  if let Some(m) =
+    get_all_matches_for_query(node, source_code.to_string(), query, recursive, None).first()
+  {
+    return Some(m.clone());
+  }
+  None
 }
 
-impl PiranhaHelpers for Node<'_> {
-  fn get_match_for_query(
-    &self, source_code: &str, query: &Query, recursive: bool,
-  ) -> Option<Match> {
-    if let Some(m) = self
-      .get_all_matches_for_query(source_code.to_string(), query, recursive, None)
-      .first()
-    {
-      return Some(m.clone());
+/// Applies the query upon `self`, and gets the first match
+/// # Arguments
+/// * `source_code` - the corresponding source code string for the node.
+/// * `query` - the query to be applied
+/// * `recursive` - if `true` it matches the query to `self` and `self`'s sub-ASTs, else it matches the `query` only to `self`.
+///
+/// # Returns
+/// The range of the match in the source code and the corresponding mapping from tags to code snippets.
+pub(crate) fn get_all_matches_for_query(
+  node: &Node, source_code: String, query: &Query, recursive: bool, replace_node: Option<String>,
+) -> Vec<Match> {
+  let query_capture_groups = _get_query_capture_groups(node, &source_code, query);
+  // In the below code, we get the code snippet corresponding to each tag for each QueryMatch.
+  // It could happen that we have multiple occurrences of the same tag (in queries
+  // that use the quantifier operator (*/+)). Therefore for each query match, we have to group (join) the codes snippets
+  // corresponding to the same tag.
+  let mut output = vec![];
+  for (captured_node_range, query_matches) in query_capture_groups {
+    // This ensures that each query pattern in rule.query matches the same node.
+    if query_matches.len() != query.pattern_count() {
+      continue;
     }
-    None
-  }
 
-  fn get_all_matches_for_query(
-    &self, source_code: String, query: &Query, recursive: bool, replace_node: Option<String>,
-  ) -> Vec<Match> {
-    let query_capture_groups = self.get_query_capture_groups(&source_code, query);
-    // In the below code, we get the code snippet corresponding to each tag for each QueryMatch.
-    // It could happen that we have multiple occurrences of the same tag (in queries
-    // that use the quantifier operator (*/+)). Therefore for each query match, we have to group (join) the codes snippets
-    // corresponding to the same tag.
-    let mut output = vec![];
-    for (captured_node_range, query_matches) in query_capture_groups {
-      // This ensures that each query pattern in rule.query matches the same node.
-      if query_matches.len() != query.pattern_count() {
-        continue;
-      }
+    // Check if the range of the self (node), and the range of outermost node captured by the query are equal.
+    let range_matches_self = node.start_byte() == captured_node_range.start_byte
+      && node.end_byte() == captured_node_range.end_byte;
 
-      // Check if the range of the self (node), and the range of outermost node captured by the query are equal.
-      let range_matches_self = self.start_byte() == captured_node_range.start_byte
-        && self.end_byte() == captured_node_range.end_byte;
+    // If `recursive` it allows matches to the subtree of self (Node)
+    // Else it ensure that the query perfectly matches the node (`self`).
+    if recursive || range_matches_self {
+      let mut replace_node_range = captured_node_range;
 
-      // If `recursive` it allows matches to the subtree of self (Node)
-      // Else it ensure that the query perfectly matches the node (`self`).
-      if recursive || range_matches_self {
-        let mut replace_node_range = captured_node_range;
-
-        if let Some(replace_node_name) = &replace_node {
-          if let Some(r) = get_range_for_replace_node(query, &query_matches, replace_node_name) {
-            replace_node_range = r;
-          }
+      if let Some(replace_node_name) = &replace_node {
+        if let Some(r) = get_range_for_replace_node(query, &query_matches, replace_node_name) {
+          replace_node_range = r;
         }
-        let code_snippet_by_tag = accumulate_repeated_tags(query, query_matches, &source_code);
-        output.push(Match::new(
-          source_code[replace_node_range.start_byte..replace_node_range.end_byte].to_string(),
-          replace_node_range,
-          code_snippet_by_tag,
-        ));
       }
+      let code_snippet_by_tag = accumulate_repeated_tags(query, query_matches, &source_code);
+      output.push(Match::new(
+        source_code[replace_node_range.start_byte..replace_node_range.end_byte].to_string(),
+        replace_node_range,
+        code_snippet_by_tag,
+      ));
     }
-    // This sorts the matches from bottom to top
-    output.sort_by(|a, b| a.range().start_byte.cmp(&b.range().start_byte));
-    output.reverse();
-    output
   }
+  // This sorts the matches from bottom to top
+  output.sort_by(|a, b| a.range().start_byte.cmp(&b.range().start_byte));
+  output.reverse();
+  output
+}
 
-  fn get_query_capture_groups(
-    &self, source_code: &str, query: &Query,
-  ) -> HashMap<Range, Vec<Vec<QueryCapture>>> {
-    let mut cursor = QueryCursor::new();
+/// Applies the query upon `self`, and gets the first match
+/// # Arguments
+/// * `source_code` - the corresponding source code string for the node.
+/// * `query` - the query to be applied
+///
+/// # Returns
+/// List of matches (list of captures), grouped by the outermost tag of the query
+fn _get_query_capture_groups<'a>(
+  node: &'a Node<'a>, source_code: &'a str, query: &'a Query,
+) -> HashMap<Range, Vec<Vec<QueryCapture<'a>>>> {
+  let mut cursor = QueryCursor::new();
 
-    // Match the query to the node get list of QueryMatch instances.
-    // a QueryMatch is like a Map<tag, Node>
-    let query_matches = cursor.matches(query, *self, source_code.as_bytes());
+  // Match the query to the node get list of QueryMatch instances.
+  // a QueryMatch is like a Map<tag, Node>
+  let query_matches = cursor.matches(query, *node, source_code.as_bytes());
 
-    // Since a node can be a part of multiple QueryMatch instances,
-    // we group the query match instances based on the range of the outermost node they matched.
-    let mut query_matches_by_node_range: HashMap<Range, Vec<Vec<QueryCapture>>> = HashMap::new();
-    for query_match in query_matches {
-      // The first capture in any query match is it's outermost tag.
-      // Ensure the outermost s-expression for is tree-sitter query is tagged.
-      if let Some(captured_node) = query_match.captures.first() {
-        query_matches_by_node_range.collect(
-          captured_node.node.range(),
-          query_match.captures.iter().cloned().collect_vec(),
-        );
-      }
+  // Since a node can be a part of multiple QueryMatch instances,
+  // we group the query match instances based on the range of the outermost node they matched.
+  let mut query_matches_by_node_range: HashMap<Range, Vec<Vec<QueryCapture>>> = HashMap::new();
+  for query_match in query_matches {
+    // The first capture in any query match is it's outermost tag.
+    // Ensure the outermost s-expression for is tree-sitter query is tagged.
+    if let Some(captured_node) = query_match.captures.first() {
+      query_matches_by_node_range.collect(
+        captured_node.node.range(),
+        query_match.captures.iter().cloned().collect_vec(),
+      );
     }
-    query_matches_by_node_range
   }
+  query_matches_by_node_range
 }
 
 // Join code snippets corresponding to the corresponding to the same tag with `\n`.

--- a/src/utilities/unit_tests/tree_sitter_utilities_test.rs
+++ b/src/utilities/unit_tests/tree_sitter_utilities_test.rs
@@ -14,9 +14,12 @@ use std::collections::HashMap;
 
 use tree_sitter::Query;
 
-use crate::models::{default_configs::JAVA, language::PiranhaLanguage};
+use crate::{
+  models::{default_configs::JAVA, language::PiranhaLanguage},
+  utilities::tree_sitter_utilities::get_all_matches_for_query,
+};
 
-use super::{substitute_tags, PiranhaHelpers};
+use super::substitute_tags;
 
 #[test]
 fn test_get_all_matches_for_query_positive() {
@@ -60,7 +63,8 @@ fn test_get_all_matches_for_query_positive() {
     .expect("Could not parse code");
   let node = ast.root_node();
 
-  let matches = node.get_all_matches_for_query(
+  let matches = get_all_matches_for_query(
+    &node,
     source_code.to_string(),
     &query,
     true,
@@ -111,7 +115,8 @@ fn test_get_all_matches_for_query_negative() {
     .expect("Could not parse code");
   let node = ast.root_node();
 
-  let matches = node.get_all_matches_for_query(
+  let matches = get_all_matches_for_query(
+    &node,
     source_code.to_string(),
     &query,
     true,


### PR DESCRIPTION
I have no clue why was I using `PiranhaHelper` trait.  It adds indirection (documentation is near the trait declaration, and implementation is elsewhere). 
Maybe, one benefit was using it as an associated method. But I don't see the `PiranhaHelper` behavior being shared with any other struct, so I guess using it as a trait has no real benefit. Other than the fact that _associated methods_ are cool. I guess these were the initial days when I was kinda learning rust. 

Anyhoo,  this PR basically removes the traits and implements stuff as just standalone functions.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #356
* #355

