### PR TITLE
Fix the CLI problem

### DIFF
--- a/.github/workflows/polyglot_build.yml
+++ b/.github/workflows/polyglot_build.yml
@@ -32,7 +32,7 @@ jobs:
           cargo install taplo-cli --locked
           pre-commit run --all-files
       - name: Run unit and integration tests
-        run: cargo test
+        run: cargo build && cargo test
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Murali Krishna Ramanathan",
   "Uber Technologies Inc.",
 ]
-name = "piranha"
+name = "polyglot_piranha"
 description = "Polyglot Piranha is a library for performing structural find and replace with deep cleanup."
 version = "0.2.1"
 edition = "2021"
@@ -64,3 +64,8 @@ pyo3-log = "0.7.0"
 [features]
 extension-module = ["pyo3/extension-module"]
 default = ["extension-module"]
+
+
+[dev-dependencies]
+assert_cmd = "2.0.7"
+predicates = "2.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Murali Krishna Ramanathan",
   "Uber Technologies Inc.",
 ]
-name = "polyglot_piranha"
+name = "piranha"
 description = "Polyglot Piranha is a library for performing structural find and replace with deep cleanup."
 version = "0.2.1"
 edition = "2021"

--- a/POLYGLOT_README.md
+++ b/POLYGLOT_README.md
@@ -164,21 +164,21 @@ Get platform-specific binary from [releases](https://github.com/uber/piranha/rel
 
 ```
 Polyglot Piranha
-A refactoring tool that eliminates dead code related to stale feature flags.
+A refactoring tool that eliminates dead code related to stale feature flags
 
 Usage: polyglot_piranha [OPTIONS] --path-to-codebase <PATH_TO_CODEBASE> --path-to-configurations <PATH_TO_CONFIGURATIONS> -l <LANGUAGE>
 
 Options:
   -c, --path-to-codebase <PATH_TO_CODEBASE>
           Path to source code folder or file
-  -S <SUBSTITUTIONS>
+  -s <SUBSTITUTIONS>
           These substitutions instantiate the initial set of rules. Usage : -s stale_flag_name=SOME_FLAG -s namespace=SOME_NS1
   -f, --path-to-configurations <PATH_TO_CONFIGURATIONS>
           Directory containing the configuration files -  `rules.toml` and  `edges.toml` (optional)
   -j, --path-to-output-summary <PATH_TO_OUTPUT_SUMMARY>
           Path to output summary json file
-  -p <LANGUAGE>
-          [possible values: java, swift, py, kt, go, tsx, ts]
+  -l <LANGUAGE>
+          The target language [possible values: java, swift, py, kt, go, tsx, ts]
       --delete-file-if-empty
           User option that determines whether an empty file will be deleted
       --delete-consecutive-new-lines
@@ -194,6 +194,7 @@ Options:
       --dry-run
           Disables in-place rewriting of code
   -h, --help
+          Print help
 ```
 
 The output JSON is the serialization of- [`PiranhaOutputSummary`](/src/models/piranha_output.rs) produced for each file touched or analyzed by Piranha.

--- a/POLYGLOT_README.md
+++ b/POLYGLOT_README.md
@@ -166,15 +166,19 @@ Get platform-specific binary from [releases](https://github.com/uber/piranha/rel
 Polyglot Piranha
 A refactoring tool that eliminates dead code related to stale feature flags.
 
-Usage: polyglot_piranha [OPTIONS] --path-to-codebase <PATH_TO_CODEBASE> --path-to-configurations <PATH_TO_CONFIGURATIONS>
+Usage: polyglot_piranha [OPTIONS] --path-to-codebase <PATH_TO_CODEBASE> --path-to-configurations <PATH_TO_CONFIGURATIONS> -l <LANGUAGE>
 
 Options:
   -c, --path-to-codebase <PATH_TO_CODEBASE>
           Path to source code folder or file
+  -S <SUBSTITUTIONS>
+          These substitutions instantiate the initial set of rules. Usage : -s stale_flag_name=SOME_FLAG -s namespace=SOME_NS1
   -f, --path-to-configurations <PATH_TO_CONFIGURATIONS>
-          Directory containing the configuration files - `piranha_arguments.toml`, `rules.toml`, and  `edges.toml` (optional)
+          Directory containing the configuration files -  `rules.toml` and  `edges.toml` (optional)
   -j, --path-to-output-summary <PATH_TO_OUTPUT_SUMMARY>
           Path to output summary json file
+  -p <LANGUAGE>
+          [possible values: java, swift, py, kt, go, tsx, ts]
       --delete-file-if-empty
           User option that determines whether an empty file will be deleted
       --delete-consecutive-new-lines
@@ -190,7 +194,6 @@ Options:
       --dry-run
           Disables in-place rewriting of code
   -h, --help
-          Print help information
 ```
 
 The output JSON is the serialization of- [`PiranhaOutputSummary`](/src/models/piranha_output.rs) produced for each file touched or analyzed by Piranha.

--- a/POLYGLOT_README.md
+++ b/POLYGLOT_README.md
@@ -171,14 +171,14 @@ Usage: polyglot_piranha [OPTIONS] --path-to-codebase <PATH_TO_CODEBASE> --path-t
 Options:
   -c, --path-to-codebase <PATH_TO_CODEBASE>
           Path to source code folder or file
-  -S <SUBSTITUTIONS>
+  -s <SUBSTITUTIONS>
           These substitutions instantiate the initial set of rules. Usage : -s stale_flag_name=SOME_FLAG -s namespace=SOME_NS1
   -f, --path-to-configurations <PATH_TO_CONFIGURATIONS>
           Directory containing the configuration files -  `rules.toml` and  `edges.toml` (optional)
   -j, --path-to-output-summary <PATH_TO_OUTPUT_SUMMARY>
           Path to output summary json file
-  -p <LANGUAGE>
-          [possible values: java, swift, py, kt, go, tsx, ts]
+  -l <LANGUAGE>
+          The target language [possible values: java, swift, py, kt, go, tsx, ts]
       --delete-file-if-empty
           User option that determines whether an empty file will be deleted
       --delete-consecutive-new-lines
@@ -194,6 +194,7 @@ Options:
       --dry-run
           Disables in-place rewriting of code
   -h, --help
+          Print help
 ```
 
 The output JSON is the serialization of- [`PiranhaOutputSummary`](/src/models/piranha_output.rs) produced for each file touched or analyzed by Piranha.

--- a/POLYGLOT_README.md
+++ b/POLYGLOT_README.md
@@ -164,21 +164,21 @@ Get platform-specific binary from [releases](https://github.com/uber/piranha/rel
 
 ```
 Polyglot Piranha
-A refactoring tool that eliminates dead code related to stale feature flags
+A refactoring tool that eliminates dead code related to stale feature flags.
 
 Usage: polyglot_piranha [OPTIONS] --path-to-codebase <PATH_TO_CODEBASE> --path-to-configurations <PATH_TO_CONFIGURATIONS> -l <LANGUAGE>
 
 Options:
   -c, --path-to-codebase <PATH_TO_CODEBASE>
           Path to source code folder or file
-  -s <SUBSTITUTIONS>
+  -S <SUBSTITUTIONS>
           These substitutions instantiate the initial set of rules. Usage : -s stale_flag_name=SOME_FLAG -s namespace=SOME_NS1
   -f, --path-to-configurations <PATH_TO_CONFIGURATIONS>
           Directory containing the configuration files -  `rules.toml` and  `edges.toml` (optional)
   -j, --path-to-output-summary <PATH_TO_OUTPUT_SUMMARY>
           Path to output summary json file
-  -l <LANGUAGE>
-          The target language [possible values: java, swift, py, kt, go, tsx, ts]
+  -p <LANGUAGE>
+          [possible values: java, swift, py, kt, go, tsx, ts]
       --delete-file-if-empty
           User option that determines whether an empty file will be deleted
       --delete-consecutive-new-lines
@@ -194,7 +194,6 @@ Options:
       --dry-run
           Disables in-place rewriting of code
   -h, --help
-          Print help
 ```
 
 The output JSON is the serialization of- [`PiranhaOutputSummary`](/src/models/piranha_output.rs) produced for each file touched or analyzed by Piranha.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,10 +139,10 @@ impl Piranha {
     let mut parser = Parser::new();
     let piranha_args = self.rule_store.piranha_args().clone();
     parser
-      .set_language(*piranha_args.piranha_language().language())
+      .set_language(*piranha_args.language().language())
       .expect("Could not set the language for the parser.");
 
-    let mut current_global_substitutions = piranha_args.input_substitutions().clone();
+    let mut current_global_substitutions = piranha_args.input_substitutions();
     // Keep looping until new `global` rules are added.
     loop {
       let current_rules = self.rule_store.global_rules().clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022 Uber Technologies, Inc.
+ Copyright (c) 2022 Uber Technologies, Inc.
 
  <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  except in compliance with the License. You may obtain a copy of the License at
@@ -14,11 +14,9 @@ Copyright (c) 2022 Uber Technologies, Inc.
 //! Defines the entry-point for Piranha.
 use std::{fs, time::Instant};
 
-use clap::Parser;
 use log::{debug, info};
 use polyglot_piranha::{
-  execute_piranha,
-  models::piranha_arguments::{PiranhaArguments, PiranhaArgumentsBuilder},
+  execute_piranha, models::piranha_arguments::PiranhaArguments,
   models::piranha_output::PiranhaOutputSummary,
 };
 
@@ -28,7 +26,7 @@ fn main() {
 
   info!("Executing Polyglot Piranha");
 
-  let args = PiranhaArguments::parse().merge(PiranhaArgumentsBuilder::default().build());
+  let args = PiranhaArguments::from_cli();
 
   debug!("Piranha Arguments are \n{:#?}", args);
   let piranha_output_summaries = execute_piranha(&args);

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -31,7 +31,7 @@ pub fn default_language() -> String {
   JAVA.to_string()
 }
 
-pub fn default_substitutions() -> Vec<Vec<String>> {
+pub fn default_substitutions() -> Vec<(String, String)> {
   vec![]
 }
 
@@ -61,10 +61,6 @@ pub fn default_path_to_codebase() -> String {
 
 pub fn default_name_of_piranha_argument_toml() -> String {
   "piranha_arguments.toml".to_string()
-}
-
-pub fn default_input_substitutions() -> HashMap<String, String> {
-  HashMap::new()
 }
 
 pub fn default_path_to_configurations() -> String {

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -13,7 +13,7 @@
 
 use std::collections::HashMap;
 
-use super::{language::PiranhaLanguage, piranha_arguments::Substitution};
+use super::language::PiranhaLanguage;
 
 pub const JAVA: &str = "java";
 pub const KOTLIN: &str = "kt";
@@ -31,7 +31,7 @@ pub fn default_language() -> String {
   JAVA.to_string()
 }
 
-pub fn default_substitutions() -> Vec<Substitution> {
+pub fn default_substitutions() -> Vec<(String, String)> {
   vec![]
 }
 

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -13,7 +13,7 @@
 
 use std::collections::HashMap;
 
-use super::language::PiranhaLanguage;
+use super::{language::PiranhaLanguage, piranha_arguments::Substitution};
 
 pub const JAVA: &str = "java";
 pub const KOTLIN: &str = "kt";
@@ -31,7 +31,7 @@ pub fn default_language() -> String {
   JAVA.to_string()
 }
 
-pub fn default_substitutions() -> Vec<(String, String)> {
+pub fn default_substitutions() -> Vec<Substitution> {
   vec![]
 }
 

--- a/src/models/edit.rs
+++ b/src/models/edit.rs
@@ -15,14 +15,14 @@ use std::{collections::HashMap, fmt};
 
 use colored::Colorize;
 use getset::Getters;
-use serde_derive::Serialize;
+use serde_derive::{Deserialize, Serialize};
 use tree_sitter::Range;
 
 use super::matches::Match;
 use crate::utilities::gen_py_str_methods;
 use pyo3::{prelude::pyclass, pymethods};
 
-#[derive(Serialize, Debug, Clone, Getters)]
+#[derive(Serialize, Debug, Clone, Getters, Deserialize)]
 #[pyclass]
 pub(crate) struct Edit {
   // The match representing the target site of the edit

--- a/src/models/language.rs
+++ b/src/models/language.rs
@@ -11,6 +11,8 @@
  limitations under the License.
 */
 
+use std::str::FromStr;
+
 use getset::Getters;
 use serde_derive::Deserialize;
 use tree_sitter::{Parser, Query};
@@ -51,13 +53,6 @@ pub enum SupportedLanguage {
   Ts,
   Tsx,
   Python,
-}
-
-impl std::str::FromStr for PiranhaLanguage {
-  type Err = String;
-  fn from_str(language: &str) -> Result<Self, Self::Err> {
-    Ok(PiranhaLanguage::from(language))
-  }
 }
 
 impl Default for SupportedLanguage {
@@ -105,11 +100,18 @@ impl Default for PiranhaLanguage {
 
 impl From<&str> for PiranhaLanguage {
   fn from(language: &str) -> Self {
+    PiranhaLanguage::from_str(language).unwrap()
+  }
+}
+
+impl std::str::FromStr for PiranhaLanguage {
+  type Err = &'static str;
+  fn from_str(language: &str) -> Result<Self, Self::Err> {
     match language {
       JAVA => {
         let rules: Rules = parse_toml(include_str!("../cleanup_rules/java/rules.toml"));
         let edges: Edges = parse_toml(include_str!("../cleanup_rules/java/edges.toml"));
-        Self {
+        Ok(Self {
           name: language.to_string(),
           supported_language: SupportedLanguage::Java,
           language: tree_sitter_java::language(),
@@ -121,12 +123,12 @@ impl From<&str> for PiranhaLanguage {
           .scopes()
           .to_vec(),
           comment_nodes: vec!["line_comment".to_string(), "block_comment".to_string()],
-        }
+        })
       }
       GO => {
         let rules: Rules = parse_toml(include_str!("../cleanup_rules/go/rules.toml"));
         let edges: Edges = parse_toml(include_str!("../cleanup_rules/go/edges.toml"));
-        PiranhaLanguage {
+        Ok(PiranhaLanguage {
           name: language.to_string(),
           supported_language: SupportedLanguage::Go,
           language: tree_sitter_go::language(),
@@ -136,12 +138,12 @@ impl From<&str> for PiranhaLanguage {
             .scopes()
             .to_vec(),
           comment_nodes: vec!["comment".to_string()],
-        }
+        })
       }
       KOTLIN => {
         let rules: Rules = parse_toml(include_str!("../cleanup_rules/kt/rules.toml"));
         let edges: Edges = parse_toml(include_str!("../cleanup_rules/kt/edges.toml"));
-        PiranhaLanguage {
+        Ok(PiranhaLanguage {
           name: language.to_string(),
           supported_language: SupportedLanguage::Kotlin,
           language: tree_sitter_kotlin::language(),
@@ -151,9 +153,9 @@ impl From<&str> for PiranhaLanguage {
             .scopes()
             .to_vec(),
           comment_nodes: vec!["comment".to_string()],
-        }
+        })
       }
-      PYTHON => PiranhaLanguage {
+      PYTHON => Ok(PiranhaLanguage {
         name: language.to_string(),
         supported_language: SupportedLanguage::Python,
         language: tree_sitter_python::language(),
@@ -161,11 +163,11 @@ impl From<&str> for PiranhaLanguage {
         edges: None,
         scopes: vec![],
         comment_nodes: vec![],
-      },
+      }),
       SWIFT => {
         let rules: Rules = parse_toml(include_str!("../cleanup_rules/swift/rules.toml"));
         let edges: Edges = parse_toml(include_str!("../cleanup_rules/swift/edges.toml"));
-        PiranhaLanguage {
+        Ok(PiranhaLanguage {
           name: language.to_string(),
           supported_language: SupportedLanguage::Swift,
           language: tree_sitter_swift::language(),
@@ -177,9 +179,9 @@ impl From<&str> for PiranhaLanguage {
           comment_nodes: vec!["comment".to_string(), "multiline_comment".to_string()],
           rules: Some(rules),
           edges: Some(edges),
-        }
+        })
       }
-      TYPESCRIPT => PiranhaLanguage {
+      TYPESCRIPT => Ok(PiranhaLanguage {
         name: language.to_string(),
         supported_language: SupportedLanguage::Ts,
         language: tree_sitter_typescript::language_typescript(),
@@ -187,8 +189,8 @@ impl From<&str> for PiranhaLanguage {
         edges: None,
         scopes: vec![],
         comment_nodes: vec![],
-      },
-      TSX => PiranhaLanguage {
+      }),
+      TSX => Ok(PiranhaLanguage {
         name: language.to_string(),
         supported_language: SupportedLanguage::Tsx,
         language: tree_sitter_typescript::language_tsx(),
@@ -196,8 +198,8 @@ impl From<&str> for PiranhaLanguage {
         edges: None,
         scopes: vec![],
         comment_nodes: vec![],
-      },
-      _ => panic!("Language not supported"),
+      }),
+      _ => Err("Language not supported"),
     }
   }
 }

--- a/src/models/language.rs
+++ b/src/models/language.rs
@@ -106,6 +106,8 @@ impl From<&str> for PiranhaLanguage {
 
 impl std::str::FromStr for PiranhaLanguage {
   type Err = &'static str;
+  /// This method is leveraged by `clap` to parse the command line
+  /// argument into PiranhaLanguage
   fn from_str(language: &str) -> Result<Self, Self::Err> {
     match language {
       JAVA => {

--- a/src/models/language.rs
+++ b/src/models/language.rs
@@ -53,6 +53,13 @@ pub enum SupportedLanguage {
   Python,
 }
 
+impl std::str::FromStr for PiranhaLanguage {
+  type Err = String;
+  fn from_str(language: &str) -> Result<Self, Self::Err> {
+    Ok(PiranhaLanguage::from(language))
+  }
+}
+
 impl Default for SupportedLanguage {
   fn default() -> Self {
     SupportedLanguage::Java

--- a/src/models/matches.rs
+++ b/src/models/matches.rs
@@ -15,11 +15,11 @@ use std::collections::HashMap;
 
 use getset::Getters;
 use pyo3::prelude::{pyclass, pymethods};
-use serde_derive::Serialize;
+use serde_derive::{Deserialize, Serialize};
 
 use crate::utilities::gen_py_str_methods;
 
-#[derive(Serialize, Debug, Clone, Getters)]
+#[derive(Serialize, Debug, Clone, Getters, Deserialize)]
 #[pyclass]
 pub(crate) struct Match {
   // Code snippet that matched
@@ -77,7 +77,9 @@ impl Match {
 /// A range of positions in a multi-line text document, both in terms of bytes and of
 /// rows and columns.
 /// Note `LocalRange` derives serialize.
-#[derive(serde_derive::Serialize, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+  serde_derive::Serialize, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize,
+)]
 #[pyclass]
 struct Range {
   #[pyo3(get)]
@@ -93,7 +95,9 @@ gen_py_str_methods!(Range);
 
 /// A range of positions in a multi-line text document, both in terms of bytes and of
 /// rows and columns.
-#[derive(serde_derive::Serialize, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+  serde_derive::Serialize, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize,
+)]
 #[pyclass]
 struct Point {
   #[pyo3(get)]

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -49,7 +49,7 @@ pub struct PiranhaArguments {
   /// These substitutions instantiate the initial set of rules.
   /// Usage : -s stale_flag_name=SOME_FLAG -s namespace=SOME_NS1
   #[builder(default = "default_substitutions()")]
-  #[clap(short= 'S',value_parser = parse_key_val)]
+  #[clap(short= 's',value_parser = parse_key_val)]
   #[serde(default = "default_substitutions")]
   substitutions: Vec<(String, String)>,
 
@@ -69,7 +69,7 @@ pub struct PiranhaArguments {
   // the target language
   #[get = "pub"]
   #[builder(default = "default_piranha_language()")]
-  #[clap(short= 'p', value_parser = clap::builder::PossibleValuesParser::new([JAVA, SWIFT, PYTHON, KOTLIN, GO, TSX, TYPESCRIPT])
+  #[clap(short= 'l', value_parser = clap::builder::PossibleValuesParser::new([JAVA, SWIFT, PYTHON, KOTLIN, GO, TSX, TYPESCRIPT])
   .map(|s| s.parse::<PiranhaLanguage>().unwrap()))]
   #[serde(skip)]
   language: PiranhaLanguage,

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -11,19 +11,19 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use crate::utilities::read_toml;
-
 use super::{
   default_configs::{
     default_cleanup_comments, default_cleanup_comments_buffer,
     default_delete_consecutive_new_lines, default_delete_file_if_empty, default_dry_run,
-    default_global_tag_prefix, default_input_substitutions, default_language,
-    default_name_of_piranha_argument_toml, default_number_of_ancestors_in_parent_scope,
-    default_path_to_codebase, default_path_to_configurations, default_path_to_output_summaries,
-    default_piranha_language, default_substitutions,
+    default_global_tag_prefix, default_name_of_piranha_argument_toml,
+    default_number_of_ancestors_in_parent_scope, default_path_to_codebase,
+    default_path_to_configurations, default_path_to_output_summaries, default_piranha_language,
+    default_substitutions, GO, JAVA, KOTLIN, PYTHON, SWIFT, TSX, TYPESCRIPT,
   },
   language::PiranhaLanguage,
 };
+use crate::utilities::{parse_key_val, read_toml};
+use clap::builder::TypedValueParser as _;
 use clap::Parser;
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters};
@@ -46,23 +46,14 @@ pub struct PiranhaArguments {
   #[serde(skip)]
   path_to_codebase: String,
 
-  // Input arguments provided to Piranha, mapped to tag names -
-  // @stale_flag_name, @namespace, @treated, @treated_complement
-  // These substitutions instantiate the initial set of feature flag rules
-  #[get = "pub"]
-  #[builder(default = "default_input_substitutions()")]
-  #[clap(skip)]
-  #[serde(skip)]
-  input_substitutions: HashMap<String, String>,
-
-  // Substitutions to instantiate the initial set of feature flag rules
+  /// These substitutions instantiate the initial set of rules.
+  /// Usage : -s stale_flag_name=SOME_FLAG -s namespace=SOME_NS1
   #[builder(default = "default_substitutions()")]
-  #[clap(skip)]
+  #[clap(short= 'S',value_parser = parse_key_val)]
   #[serde(default = "default_substitutions")]
-  substitutions: Vec<Vec<String>>,
+  substitutions: Vec<(String, String)>,
 
-  /// Directory containing the configuration files - `piranha_arguments.toml`, `rules.toml`,
-  /// and  `edges.toml` (optional)
+  /// Directory containing the configuration files -  `rules.toml` and  `edges.toml` (optional)
   #[get = "pub"]
   #[builder(default = "default_path_to_configurations()")]
   #[clap(short = 'f', long)]
@@ -75,18 +66,13 @@ pub struct PiranhaArguments {
   #[clap(short = 'j', long)]
   #[serde(skip)]
   path_to_output_summary: Option<String>,
-
   // the target language
-  #[builder(default = "default_language()")]
-  #[clap(skip)]
-  #[serde(default = "default_language")]
-  language: String,
-
   #[get = "pub"]
   #[builder(default = "default_piranha_language()")]
-  #[clap(skip)]
+  #[clap(short= 'p', value_parser = clap::builder::PossibleValuesParser::new([JAVA, SWIFT, PYTHON, KOTLIN, GO, TSX, TYPESCRIPT])
+  .map(|s| s.parse::<PiranhaLanguage>().unwrap()))]
   #[serde(skip)]
-  piranha_language: PiranhaLanguage,
+  language: PiranhaLanguage,
 
   /// User option that determines whether an empty file will be deleted
   #[get = "pub"]
@@ -162,7 +148,7 @@ impl PiranhaArguments {
   ) -> Self {
     let subs = substitutions
       .iter()
-      .map(|(k, v)| vec![k.to_string(), v.to_string()])
+      .map(|(k, v)| (k.to_string(), v.to_string()))
       .collect_vec();
 
     // gets `$arg_name` from `keyword_arguments` else invokes `$default_fn`
@@ -193,7 +179,7 @@ impl PiranhaArguments {
     piranha_arguments! {
       path_to_codebase= path_to_codebase,
       path_to_configurations = path_to_configurations,
-      language= language,
+      language= PiranhaLanguage::from(language.as_str()),
       substitutions= subs,
       dry_run= get_keyword_arg!("dry_run", default_dry_run, "bool"),
       cleanup_comments= get_keyword_arg!("cleanup_comments", default_cleanup_comments, "bool"),
@@ -229,7 +215,25 @@ impl PiranhaArguments {
 
 impl PiranhaArguments {
   pub fn get_language(&self) -> String {
-    self.language.clone()
+    self.language.name().to_string()
+  }
+
+  pub fn from_cli() -> Self {
+    let p = PiranhaArguments::parse();
+    piranha_arguments! {
+      path_to_codebase= p.path_to_codebase().to_string(),
+      substitutions = p.substitutions.clone(),
+      language = p.language().clone(),
+      path_to_configurations = p.path_to_configurations().to_string(),
+      path_to_output_summary = p.path_to_output_summary().clone(),
+      delete_file_if_empty= *p.delete_file_if_empty(),
+      delete_consecutive_new_lines= *p.delete_consecutive_new_lines(),
+      global_tag_prefix= p.global_tag_prefix().to_string(),
+      number_of_ancestors_in_parent_scope= *p.number_of_ancestors_in_parent_scope(),
+      cleanup_comments_buffer= *p.cleanup_comments_buffer(),
+      cleanup_comments= *p.cleanup_comments(),
+      dry_run= *p.dry_run(),
+    }
   }
 
   pub fn merge(&self, other: PiranhaArguments) -> Self {
@@ -249,11 +253,9 @@ impl PiranhaArguments {
     Self {
       path_to_codebase: merge!(path_to_codebase, default_path_to_codebase),
       substitutions: merge!(substitutions, default_substitutions),
-      input_substitutions: merge!(input_substitutions, default_input_substitutions),
       path_to_configurations: merge!(path_to_configurations, default_path_to_configurations),
       path_to_output_summary: merge!(path_to_output_summary, default_path_to_output_summaries),
-      language: merge!(language, default_language),
-      piranha_language: merge!(piranha_language, default_piranha_language),
+      language: merge!(language, default_piranha_language),
       delete_file_if_empty: merge!(delete_file_if_empty, default_delete_file_if_empty),
       delete_consecutive_new_lines: merge!(
         delete_consecutive_new_lines,
@@ -269,6 +271,10 @@ impl PiranhaArguments {
       dry_run: merge!(dry_run, default_dry_run),
     }
   }
+
+  pub(crate) fn input_substitutions(&self) -> HashMap<String, String> {
+    self.substitutions.iter().cloned().collect()
+  }
 }
 
 impl PiranhaArgumentsBuilder {
@@ -278,29 +284,14 @@ impl PiranhaArgumentsBuilder {
   /// * merge the two PiranhaArguments
   pub fn build(&self) -> PiranhaArguments {
     let _arg = &self.create().unwrap();
-    let input_substitutions = _arg
-      .substitutions
-      .iter()
-      .map(|x| (x[0].clone(), x[1].clone()))
-      .collect();
 
-    let piranha_language = PiranhaLanguage::from(_arg.language.as_str());
-
-    let created_args = _arg.merge(
-      PiranhaArgumentsBuilder::default()
-        .input_substitutions(input_substitutions)
-        .piranha_language(piranha_language)
-        .create()
-        .unwrap(),
-    );
-
-    let path_to_toml = PathBuf::from(created_args.path_to_configurations())
-      .join(default_name_of_piranha_argument_toml());
+    let path_to_toml =
+      PathBuf::from(_arg.path_to_configurations()).join(default_name_of_piranha_argument_toml());
     if path_to_toml.exists() {
       let args_from_file = read_toml::<PiranhaArguments>(&path_to_toml, false);
-      return created_args.merge(args_from_file);
+      return _arg.merge(args_from_file);
     }
-    created_args
+    _arg.clone()
   }
 }
 

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -66,7 +66,7 @@ pub struct PiranhaArguments {
   #[clap(short = 'j', long)]
   #[serde(skip)]
   path_to_output_summary: Option<String>,
-  // the target language
+  /// The target language
   #[get = "pub"]
   #[builder(default = "default_piranha_language()")]
   #[clap(short= 'l', value_parser = clap::builder::PossibleValuesParser::new([JAVA, SWIFT, PYTHON, KOTLIN, GO, TSX, TYPESCRIPT])

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -23,7 +23,7 @@ use super::{
   language::PiranhaLanguage,
 };
 use crate::utilities::{parse_key_val, read_toml};
-use clap::builder::TypedValueParser as _;
+use clap::builder::TypedValueParser;
 use clap::Parser;
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters};
@@ -49,7 +49,7 @@ pub struct PiranhaArguments {
   /// These substitutions instantiate the initial set of rules.
   /// Usage : -s stale_flag_name=SOME_FLAG -s namespace=SOME_NS1
   #[builder(default = "default_substitutions()")]
-  #[clap(short= 's',value_parser = parse_key_val)]
+  #[clap(short = 's',value_parser = parse_key_val)]
   #[serde(default = "default_substitutions")]
   substitutions: Vec<(String, String)>,
 
@@ -69,7 +69,7 @@ pub struct PiranhaArguments {
   /// The target language
   #[get = "pub"]
   #[builder(default = "default_piranha_language()")]
-  #[clap(short= 'l', value_parser = clap::builder::PossibleValuesParser::new([JAVA, SWIFT, PYTHON, KOTLIN, GO, TSX, TYPESCRIPT])
+  #[clap(short = 'l', value_parser = clap::builder::PossibleValuesParser::new([JAVA, SWIFT, PYTHON, KOTLIN, GO, TSX, TYPESCRIPT])
   .map(|s| s.parse::<PiranhaLanguage>().unwrap()))]
   #[serde(skip)]
   language: PiranhaLanguage,
@@ -177,34 +177,34 @@ impl PiranhaArguments {
     }
 
     piranha_arguments! {
-      path_to_codebase= path_to_codebase,
+      path_to_codebase = path_to_codebase,
       path_to_configurations = path_to_configurations,
-      language= PiranhaLanguage::from(language.as_str()),
-      substitutions= subs,
-      dry_run= get_keyword_arg!("dry_run", default_dry_run, "bool"),
-      cleanup_comments= get_keyword_arg!("cleanup_comments", default_cleanup_comments, "bool"),
-      cleanup_comments_buffer= get_keyword_arg!(
+      language = PiranhaLanguage::from(language.as_str()),
+      substitutions = subs,
+      dry_run = get_keyword_arg!("dry_run", default_dry_run, "bool"),
+      cleanup_comments = get_keyword_arg!("cleanup_comments", default_cleanup_comments, "bool"),
+      cleanup_comments_buffer = get_keyword_arg!(
         "cleanup_comments_buffer",
         default_cleanup_comments_buffer,
         "num"
       ),
-      number_of_ancestors_in_parent_scope= get_keyword_arg!(
+      number_of_ancestors_in_parent_scope = get_keyword_arg!(
         "number_of_ancestors_in_parent_scope",
         default_number_of_ancestors_in_parent_scope,
         "num"
       ),
-      delete_consecutive_new_lines= get_keyword_arg!(
+      delete_consecutive_new_lines = get_keyword_arg!(
         "delete_consecutive_new_lines",
         default_delete_consecutive_new_lines,
         "bool"
       ),
-      global_tag_prefix= get_keyword_arg!("global_tag_prefix", default_global_tag_prefix, "string"),
-      delete_file_if_empty= get_keyword_arg!(
+      global_tag_prefix = get_keyword_arg!("global_tag_prefix", default_global_tag_prefix, "string"),
+      delete_file_if_empty = get_keyword_arg!(
         "delete_file_if_empty",
         default_delete_file_if_empty,
         "bool"
       ),
-      path_to_output_summary= get_keyword_arg!(
+      path_to_output_summary = get_keyword_arg!(
         "path_to_output_summary",
         default_path_to_output_summaries,
         "option"
@@ -221,18 +221,18 @@ impl PiranhaArguments {
   pub fn from_cli() -> Self {
     let p = PiranhaArguments::parse();
     piranha_arguments! {
-      path_to_codebase= p.path_to_codebase().to_string(),
+      path_to_codebase = p.path_to_codebase().to_string(),
       substitutions = p.substitutions.clone(),
       language = p.language().clone(),
       path_to_configurations = p.path_to_configurations().to_string(),
       path_to_output_summary = p.path_to_output_summary().clone(),
-      delete_file_if_empty= *p.delete_file_if_empty(),
-      delete_consecutive_new_lines= *p.delete_consecutive_new_lines(),
-      global_tag_prefix= p.global_tag_prefix().to_string(),
-      number_of_ancestors_in_parent_scope= *p.number_of_ancestors_in_parent_scope(),
-      cleanup_comments_buffer= *p.cleanup_comments_buffer(),
-      cleanup_comments= *p.cleanup_comments(),
-      dry_run= *p.dry_run(),
+      delete_file_if_empty = *p.delete_file_if_empty(),
+      delete_consecutive_new_lines = *p.delete_consecutive_new_lines(),
+      global_tag_prefix = p.global_tag_prefix().to_string(),
+      number_of_ancestors_in_parent_scope = *p.number_of_ancestors_in_parent_scope(),
+      cleanup_comments_buffer = *p.cleanup_comments_buffer(),
+      cleanup_comments = *p.cleanup_comments(),
+      dry_run = *p.dry_run(),
     }
   }
 

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -49,9 +49,9 @@ pub struct PiranhaArguments {
   /// These substitutions instantiate the initial set of rules.
   /// Usage : -s stale_flag_name=SOME_FLAG -s namespace=SOME_NS1
   #[builder(default = "default_substitutions()")]
-  #[clap(short= 's',value_parser = parse_key_val, default_values_t=default_substitutions())]
+  #[clap(short= 's',value_parser = parse_key_val)]
   #[serde(default = "default_substitutions")]
-  substitutions: Vec<Substitution>,
+  substitutions: Vec<(String, String)>,
 
   /// Directory containing the configuration files -  `rules.toml` and  `edges.toml` (optional)
   #[get = "pub"]
@@ -66,8 +66,7 @@ pub struct PiranhaArguments {
   #[clap(short = 'j', long)]
   #[serde(skip)]
   path_to_output_summary: Option<String>,
-
-  /// The target language
+  // the target language
   #[get = "pub"]
   #[builder(default = "default_piranha_language()")]
   #[clap(short= 'l', value_parser = clap::builder::PossibleValuesParser::new([JAVA, SWIFT, PYTHON, KOTLIN, GO, TSX, TYPESCRIPT])
@@ -149,10 +148,7 @@ impl PiranhaArguments {
   ) -> Self {
     let subs = substitutions
       .iter()
-      .map(|(key, value)| Substitution {
-        key: key.to_string(),
-        value: value.to_string(),
-      })
+      .map(|(k, v)| (k.to_string(), v.to_string()))
       .collect_vec();
 
     // gets `$arg_name` from `keyword_arguments` else invokes `$default_fn`
@@ -277,11 +273,7 @@ impl PiranhaArguments {
   }
 
   pub(crate) fn input_substitutions(&self) -> HashMap<String, String> {
-    self
-      .substitutions
-      .iter()
-      .map(|s| (s.key.to_string(), s.value.to_string()))
-      .collect()
+    self.substitutions.iter().cloned().collect()
   }
 }
 
@@ -338,15 +330,3 @@ macro_rules! piranha_arguments {
 }
 
 pub use piranha_arguments;
-
-#[derive(Deserialize, Clone, Debug, Parser, Default, PartialEq)]
-pub struct Substitution {
-  pub key: String,
-  pub value: String,
-}
-
-impl std::fmt::Display for Substitution {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{0} => {1}", self.key, self.key)
-  }
-}

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -49,9 +49,9 @@ pub struct PiranhaArguments {
   /// These substitutions instantiate the initial set of rules.
   /// Usage : -s stale_flag_name=SOME_FLAG -s namespace=SOME_NS1
   #[builder(default = "default_substitutions()")]
-  #[clap(short= 's',value_parser = parse_key_val)]
+  #[clap(short= 's',value_parser = parse_key_val, default_values_t=default_substitutions())]
   #[serde(default = "default_substitutions")]
-  substitutions: Vec<(String, String)>,
+  substitutions: Vec<Substitution>,
 
   /// Directory containing the configuration files -  `rules.toml` and  `edges.toml` (optional)
   #[get = "pub"]
@@ -66,7 +66,8 @@ pub struct PiranhaArguments {
   #[clap(short = 'j', long)]
   #[serde(skip)]
   path_to_output_summary: Option<String>,
-  // the target language
+
+  /// The target language
   #[get = "pub"]
   #[builder(default = "default_piranha_language()")]
   #[clap(short= 'l', value_parser = clap::builder::PossibleValuesParser::new([JAVA, SWIFT, PYTHON, KOTLIN, GO, TSX, TYPESCRIPT])
@@ -148,7 +149,10 @@ impl PiranhaArguments {
   ) -> Self {
     let subs = substitutions
       .iter()
-      .map(|(k, v)| (k.to_string(), v.to_string()))
+      .map(|(key, value)| Substitution {
+        key: key.to_string(),
+        value: value.to_string(),
+      })
       .collect_vec();
 
     // gets `$arg_name` from `keyword_arguments` else invokes `$default_fn`
@@ -273,7 +277,11 @@ impl PiranhaArguments {
   }
 
   pub(crate) fn input_substitutions(&self) -> HashMap<String, String> {
-    self.substitutions.iter().cloned().collect()
+    self
+      .substitutions
+      .iter()
+      .map(|s| (s.key.to_string(), s.value.to_string()))
+      .collect()
   }
 }
 
@@ -330,3 +338,15 @@ macro_rules! piranha_arguments {
 }
 
 pub use piranha_arguments;
+
+#[derive(Deserialize, Clone, Debug, Parser, Default, PartialEq)]
+pub struct Substitution {
+  pub key: String,
+  pub value: String,
+}
+
+impl std::fmt::Display for Substitution {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{0} => {1}", self.key, self.key)
+  }
+}

--- a/src/models/piranha_output.rs
+++ b/src/models/piranha_output.rs
@@ -14,7 +14,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 use std::path::PathBuf;
 
 use itertools::Itertools;
-use serde_derive::Serialize;
+use serde_derive::{Deserialize, Serialize};
 
 use crate::utilities::gen_py_str_methods;
 
@@ -22,7 +22,7 @@ use super::{edit::Edit, matches::Match, source_code_unit::SourceCodeUnit};
 use pyo3::{prelude::pyclass, pymethods};
 
 /// A class to represent Piranha's output
-#[derive(Serialize, Debug, Clone, Default)]
+#[derive(Serialize, Debug, Clone, Default, Deserialize)]
 #[pyclass]
 pub struct PiranhaOutputSummary {
   /// Path to the file

--- a/src/models/rule_store.rs
+++ b/src/models/rule_store.rs
@@ -76,7 +76,7 @@ impl RuleStore {
 
     for rule in rule_store.rule_graph().rules().clone() {
       if rule.is_seed_rule() {
-        rule_store.add_to_global_rules(&InstantiatedRule::new(&rule, args.input_substitutions()));
+        rule_store.add_to_global_rules(&InstantiatedRule::new(&rule, &args.input_substitutions()));
       }
     }
     info!(
@@ -108,7 +108,7 @@ impl RuleStore {
       .or_insert_with(|| {
         self
           .piranha_args
-          .piranha_language()
+          .language()
           .create_query(query_str.to_string())
       })
   }
@@ -152,7 +152,7 @@ impl RuleStore {
   pub(crate) fn get_scope_query_generators(&self, scope_level: &str) -> Vec<ScopeQueryGenerator> {
     self
       .piranha_args()
-      .piranha_language()
+      .language()
       .scopes()
       .iter()
       .find(|level| level.name().eq(scope_level))
@@ -253,7 +253,7 @@ impl Default for RuleStore {
 }
 
 fn read_config_files(args: &PiranhaArguments) -> RuleGraph {
-  let piranha_language = args.piranha_language();
+  let piranha_language = args.language();
 
   let built_in_rules = RuleGraphBuilder::default()
     .edges(piranha_language.edges().clone().unwrap_or_default().edges)

--- a/src/models/source_code_unit.rs
+++ b/src/models/source_code_unit.rs
@@ -377,7 +377,7 @@ impl SourceCodeUnit {
         relevant_nodes_found = true;
         let is_comment: bool = self
           .piranha_arguments
-          .piranha_language()
+          .language()
           .is_comment(node.kind().to_string());
         relevant_nodes_are_comments = relevant_nodes_are_comments && is_comment;
         if is_comment {
@@ -628,7 +628,7 @@ impl SourceCodeUnit {
     &self, node: Node, rule: &InstantiatedRule, substitutions: &HashMap<String, String>,
     rule_store: &mut RuleStore,
   ) -> bool {
-    let mut updated_substitutions = rule_store.piranha_args().input_substitutions().clone();
+    let mut updated_substitutions = rule_store.piranha_args().input_substitutions();
     updated_substitutions.extend(substitutions.clone());
     rule.constraints().iter().all(|constraint| {
       self._is_satisfied(constraint.clone(), node, rule_store, &updated_substitutions)

--- a/src/models/unit_tests/scopes_test.rs
+++ b/src/models/unit_tests/scopes_test.rs
@@ -86,8 +86,7 @@ fn _get_rule_store() -> RuleStore {
   let mut piranha_language = PiranhaLanguage::from(JAVA);
   piranha_language.set_scopes(vec![_get_method_scope(), _get_class_scope()]);
   let piranha_args = PiranhaArgumentsBuilder::default()
-    .language(JAVA.to_string())
-    .piranha_language(piranha_language)
+    .language(piranha_language)
     .create()
     .unwrap();
   RuleStore::from(piranha_args)

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -40,7 +40,7 @@ impl SourceCodeUnit {
       &HashMap::new(),
       PathBuf::new().as_path(),
       &PiranhaArgumentsBuilder::default()
-        .language(language_name)
+        .language(PiranhaLanguage::from(language_name.as_str()))
         .build(),
     )
   }
@@ -218,9 +218,7 @@ fn test_satisfies_constraints_positive() {
   let mut rule_store = RuleStore::default();
   let java = get_java_tree_sitter_language();
   let mut parser = java.parser();
-  let piranha_args = PiranhaArgumentsBuilder::default()
-    .language(java.name().to_string())
-    .build();
+  let piranha_args = PiranhaArgumentsBuilder::default().language(java).build();
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
     source_code.to_string(),
@@ -285,9 +283,7 @@ fn test_satisfies_constraints_negative() {
   let mut rule_store = RuleStore::default();
   let java = get_java_tree_sitter_language();
   let mut parser = java.parser();
-  let piranha_arguments = &PiranhaArgumentsBuilder::default()
-    .language(java.name().to_string())
-    .build();
+  let piranha_arguments = &PiranhaArgumentsBuilder::default().language(java).build();
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
     source_code.to_string(),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -157,7 +157,7 @@ macro_rules! create_match_tests {
       let piranha_arguments =  $crate::models::piranha_arguments::piranha_arguments!{
         path_to_codebase = path_to_codebase,
         path_to_configurations = path_to_configurations,
-        language= $language.to_string(),
+        language= $crate::models::language::PiranhaLanguage::from($language),
         $(
           $kw = $value,
         )*
@@ -203,7 +203,7 @@ macro_rules! create_rewrite_tests {
       let piranha_arguments =  $crate::models::piranha_arguments::piranha_arguments!{
         path_to_codebase = temp_dir.path().to_str().unwrap().to_string(),
         path_to_configurations = _path.join("configurations").to_str().unwrap().to_string(),
-        language= $language.to_string(),
+        language= $crate::models::language::PiranhaLanguage::from($language),
         $(
           $kw = $value,
         )*
@@ -240,7 +240,7 @@ macro_rules! substitutions(
   () =>  { vec![] };
   { $($key:literal => $value:literal),+ } => {
       {
-          vec![$(vec![$key.to_string(), $value.to_string()],)+]
+          vec![$(($key.to_string(), $value.to_string()),)+]
 
       }
    };

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -240,10 +240,7 @@ macro_rules! substitutions(
   () =>  { vec![] };
   { $($key:literal => $value:literal),+ } => {
       {
-          vec![$(crate::models::piranha_arguments::Substitution{
-            key: $key.to_string(),
-            value: $value.to_string()
-          },)+]
+          vec![$(($key.to_string(), $value.to_string()),)+]
 
       }
    };

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -240,7 +240,10 @@ macro_rules! substitutions(
   () =>  { vec![] };
   { $($key:literal => $value:literal),+ } => {
       {
-          vec![$(($key.to_string(), $value.to_string()),)+]
+          vec![$(crate::models::piranha_arguments::Substitution{
+            key: $key.to_string(),
+            value: $value.to_string()
+          },)+]
 
       }
    };

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -17,7 +17,9 @@ use super::{
 };
 use crate::{
   execute_piranha,
-  models::{default_configs::JAVA, piranha_arguments::piranha_arguments},
+  models::{
+    default_configs::JAVA, language::PiranhaLanguage, piranha_arguments::piranha_arguments,
+  },
 };
 use std::path::PathBuf;
 
@@ -79,7 +81,7 @@ fn test_scenarios_find_and_propagate_panic() {
   let piranha_arguments = piranha_arguments! {
     path_to_codebase = path_to_codebase,
     path_to_configurations = path_to_configurations,
-    language= JAVA.to_string(),
+    language= PiranhaLanguage::from(JAVA),
   };
 
   let _ = execute_piranha(&piranha_arguments);
@@ -111,7 +113,7 @@ fn _helper_user_option_delete_consecutive_lines(
   let piranha_arguments = piranha_arguments! {
     path_to_codebase = temp_dir.path().to_str().unwrap().to_string(),
     path_to_configurations = path_to_scenario.join("configurations").to_str().unwrap().to_string(),
-    language = JAVA.to_string(),
+    language = PiranhaLanguage::from(JAVA),
     delete_consecutive_new_lines = delete_consecutive_new_lines,
   };
 

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -81,7 +81,7 @@ fn test_scenarios_find_and_propagate_panic() {
   let piranha_arguments = piranha_arguments! {
     path_to_codebase = path_to_codebase,
     path_to_configurations = path_to_configurations,
-    language= PiranhaLanguage::from(JAVA),
+    language = PiranhaLanguage::from(JAVA),
   };
 
   let _ = execute_piranha(&piranha_arguments);

--- a/src/tests/test_piranha_python.rs
+++ b/src/tests/test_piranha_python.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 #[test]
-fn test_cli() {
+fn test_delete_modify_str_literal_from_list_via_cli() {
   let temp_dir = TempDir::new_in(".", "tmp_test").unwrap();
   let temp_file = temp_dir.path().join("output.txt");
   _ = File::create(temp_file.as_path());

--- a/src/tests/test_piranha_python.rs
+++ b/src/tests/test_piranha_python.rs
@@ -23,6 +23,9 @@ use crate::{
   utilities::{eq_without_whitespace, read_file},
 };
 
+/// This test is almost equivalent to create_rewrite_tests!(PYTHON, test_delete_modify_str_literal_from_list: ...)
+/// It is "almost equivalent" because we pass `--dry-run`and the compare the contents of
+/// of expected files against `PiranhaOutputSummary`
 #[test]
 fn test_delete_modify_str_literal_from_list_via_cli() {
   let temp_dir = TempDir::new_in(".", "tmp_test").unwrap();

--- a/src/tests/test_piranha_python.rs
+++ b/src/tests/test_piranha_python.rs
@@ -46,12 +46,12 @@ fn test_cli() {
       "-f",
       "test-resources/py/delete_cleanup_str_in_list/configurations",
     ])
-    .args(["-p", "py"])
+    .args(["-l", "py"])
     .args(["-j", temp_file.to_str().unwrap()])
     .arg("--dry-run")
-    .args(["-S", "str_literal=dependency2"])
-    .args(["-S", "str_to_replace=dependency1"])
-    .args(["-S", "str_replacement=dependency1_1"]);
+    .args(["-s", "str_literal=dependency2"])
+    .args(["-s", "str_to_replace=dependency1"])
+    .args(["-s", "str_replacement=dependency1_1"]);
 
   cmd.assert().success();
 

--- a/src/tests/test_piranha_python.rs
+++ b/src/tests/test_piranha_python.rs
@@ -39,7 +39,7 @@ fn test_cli() {
   let temp_file = temp_dir.path().join("output.txt");
   _ = File::create(temp_file.as_path());
 
-  let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+  let mut cmd = Command::cargo_bin("polyglot_piranha").unwrap();
   cmd
     .args(["-c", "test-resources/py/delete_cleanup_str_in_list/input"])
     .args([

--- a/src/tests/test_piranha_python.rs
+++ b/src/tests/test_piranha_python.rs
@@ -11,9 +11,17 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+use assert_cmd::prelude::{CommandCargoExt, OutputAssertExt};
+
+use std::{fs::File, process::Command};
+use tempdir::TempDir;
+
 use super::{create_match_tests, create_rewrite_tests, substitutions};
 
-use crate::models::default_configs::PYTHON;
+use crate::{
+  models::{default_configs::PYTHON, piranha_output::PiranhaOutputSummary},
+  utilities::read_file,
+};
 
 create_rewrite_tests!(
   PYTHON,
@@ -24,5 +32,37 @@ create_rewrite_tests!(
     "str_replacement" => "dependency1_1"
   };
 );
+
+#[test]
+fn test_cli() {
+  let temp_dir = TempDir::new_in(".", "tmp_test").unwrap();
+  let temp_file = temp_dir.path().join("output.txt");
+  _ = File::create(temp_file.as_path());
+
+  let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+  cmd
+    .args(["-c", "test-resources/py/delete_cleanup_str_in_list/input"])
+    .args([
+      "-f",
+      "test-resources/py/delete_cleanup_str_in_list/configurations",
+    ])
+    .args(["-p", "py"])
+    .args(["-j", temp_file.to_str().unwrap()])
+    .arg("--dry-run")
+    .args(["-S", "str_literal=dependency2"])
+    .args(["-S", "str_to_replace=dependency1"])
+    .args(["-S", "str_replacement=dependency1_1"]);
+
+  cmd.assert().success();
+
+  let content = read_file(&temp_file).unwrap();
+  assert!(!content.is_empty());
+  let output: Vec<PiranhaOutputSummary> = serde_json::from_str(&content).unwrap();
+  assert!(!output.is_empty());
+  assert!(output[0].path().to_str().unwrap().contains("only_lists.py"));
+  assert!(!output[0].rewrites().is_empty());
+
+  _ = temp_dir.close();
+}
 
 create_match_tests!(PYTHON, test_match_only: "structural_find", 3;);

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -13,6 +13,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 
 pub(crate) mod tree_sitter_utilities;
 use std::collections::HashMap;
+use std::error::Error;
 use std::fs::File;
 #[cfg(test)]
 use std::fs::{self, DirEntry};
@@ -85,6 +86,18 @@ pub(crate) fn has_name(dir_entry: &DirEntry, file_name: &str) -> bool {
     .file_name()
     .map(|e| e.eq(file_name))
     .unwrap_or(false)
+}
+
+/// Parse a single key-value pair
+/// I have literally copy pasted this method from here
+/// https://github.com/clap-rs/clap/blob/master/examples/typed-derive.rs#L48
+pub(crate) fn parse_key_val(
+  s: &str,
+) -> Result<(String, String), Box<dyn Error + Send + Sync + 'static>> {
+  let pos = s
+    .find('=')
+    .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
+  Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }
 
 /// Returns the file with the given name within the given directory.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,7 +16,6 @@ from os.path import join, basename
 from os import listdir
 import re
 
-
 def test_piranha_rewrite():
     args = PiranhaArguments(
         "test-resources/java/feature_flag_system_1/treated/input",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,6 +16,7 @@ from os.path import join, basename
 from os import listdir
 import re
 
+
 def test_piranha_rewrite():
     args = PiranhaArguments(
         "test-resources/java/feature_flag_system_1/treated/input",


### PR DESCRIPTION
(This looks like a large one, but real change is to just one file `piranha_arguments.rs`, most files have changes like adding a derive, updating api name, updating imports).

**Problem** #358 
**Background**  Few days ago we had introduced the new `piranha_arguments!` macro which we used to construct PiranhaArguments via the Rust API and the Python API. Using this macro (or builder) is the standard way of constructing PiranhaArguments. Note using this macro "enriches" piranha arguments i.e. it initializes the `input_substitutions` and `piranha_language` field. 
 However, our command line entry point did not use it.  Currently our command line simply parses the piranha arguments. 

**Solution** Introduce a `from_cli` method (equivalent to [py_new](https://github.com/uber/piranha/blob/master/src/models/piranha_arguments.rs#LL159C7-L159C7)) which basically invokes the `piranha_arguments!` macro.  
When doing this cleanup I observed that I had two redundant fields in `PiranhaArguments` - `substitutions:HashMap` and `language:str`. I could directly parse the command line arguments into `PiranhaLanguage` and a `Vec<(String, String)>` directly. So I did that. Basically I merged the attributes `language` and `piranha_language`, and `substitutions` and `input_substitutions`.  (Actually the more I am using rust, I am realizing its capabilities. This is the way things should have been from day 1, but i didnt know :| and things were too intimidating back then to do it very correctly ) 

**Test Plan** Earlier we were not testing the CLI interface at all :) (Hence this bug :|) . Added a test which runs the cli interface too. 




