### PR TITLE
`piranha_rule!` macro for creating a rule

### DIFF
--- a/src/models/constraint.rs
+++ b/src/models/constraint.rs
@@ -11,23 +11,32 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+use derive_builder::Builder;
 use getset::Getters;
 use serde_derive::Deserialize;
 
-#[derive(Deserialize, Debug, Clone, Hash, PartialEq, Eq, Getters)]
+use super::default_configs::{default_matcher, default_queries};
+
+#[derive(Deserialize, Debug, Clone, Hash, PartialEq, Eq, Getters, Builder)]
 pub(crate) struct Constraint {
   /// Scope in which the constraint query has to be applied
+  #[builder(default = "default_matcher()")]
   #[get = "pub"]
   matcher: String,
   /// The Tree-sitter queries that need to be applied in the `matcher` scope
+  #[builder(default = "default_queries()")]
   #[get = "pub"]
   #[serde(default)]
   queries: Vec<String>,
 }
 
-impl Constraint {
-  #[cfg(test)]
-  pub(crate) fn new(matcher: String, queries: Vec<String>) -> Self {
-    Self { matcher, queries }
-  }
+#[macro_export]
+macro_rules! constraint {
+  (matcher = $matcher:expr, queries= [$($q:expr,)*]) => {
+    $crate::models::constraint::ConstraintBuilder::default()
+      .matcher($matcher.to_string())
+      .queries(vec![$($q.to_string(),)*])
+      .build().unwrap()
+  };
 }
+pub use constraint;

--- a/src/models/constraint.rs
+++ b/src/models/constraint.rs
@@ -31,6 +31,27 @@ pub(crate) struct Constraint {
 }
 
 #[macro_export]
+/// This macro can be used to construct a Constraint (via the builder).'
+/// Allows to use builder pattern more "dynamically"
+///
+/// Usage:
+///
+/// ```ignore
+/// constraint! {
+///   matcher = "(method_declaration) @md".to_string(),
+///   queries=  ["(method_invocation name: (_) @name) @mi".to_string()]
+/// }
+/// ```
+///
+/// expands to
+///
+/// ```ignore
+/// ConstraintBuilder::default()
+///      .matcher("(method_declaration) @md".to_string())
+///      .queries(vec!["(method_invocation name: (_) @name) @mi".to_string()])
+///      .build()
+/// ```
+///
 macro_rules! constraint {
   (matcher = $matcher:expr, queries= [$($q:expr,)*]) => {
     $crate::models::constraint::ConstraintBuilder::default()

--- a/src/models/constraint.rs
+++ b/src/models/constraint.rs
@@ -31,7 +31,7 @@ pub(crate) struct Constraint {
 }
 
 #[macro_export]
-/// This macro can be used to construct a Constraint (via the builder).'
+/// This macro can be used to construct a Constraint (via the builder)'
 /// Allows to use builder pattern more "dynamically"
 ///
 /// Usage:

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -11,9 +11,9 @@
  limitations under the License.
 */
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use super::language::PiranhaLanguage;
+use super::{constraint::Constraint, language::PiranhaLanguage};
 
 pub const JAVA: &str = "java";
 pub const KOTLIN: &str = "kt";
@@ -93,4 +93,28 @@ pub fn default_replace() -> String {
 
 pub fn default_rule_graph() -> HashMap<String, Vec<(String, String)>> {
   HashMap::new()
+}
+
+pub(crate) fn default_holes() -> HashSet<String> {
+  HashSet::new()
+}
+
+pub(crate) fn default_groups() -> HashSet<String> {
+  HashSet::new()
+}
+
+pub(crate) fn default_constraints() -> HashSet<Constraint> {
+  HashSet::new()
+}
+
+pub(crate) fn default_queries() -> Vec<String> {
+  Vec::new()
+}
+
+pub(crate) fn default_matcher() -> String {
+  String::new()
+}
+
+pub(crate) fn default_rule_name() -> String {
+  String::new()
 }

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -14,6 +14,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 use std::collections::{HashMap, HashSet};
 
 use colored::Colorize;
+use derive_builder::Builder;
 use getset::Getters;
 use serde_derive::Deserialize;
 
@@ -21,7 +22,10 @@ use crate::utilities::tree_sitter_utilities::substitute_tags;
 
 use super::{
   constraint::Constraint,
-  default_configs::{default_query, default_replace, default_replace_node},
+  default_configs::{
+    default_constraints, default_groups, default_holes, default_query, default_replace,
+    default_replace_node, default_rule_name,
+  },
 };
 
 static SEED: &str = "Seed Rule";
@@ -33,33 +37,41 @@ pub(crate) struct Rules {
   pub(crate) rules: Vec<Rule>,
 }
 
-#[derive(Deserialize, Debug, Clone, Default, PartialEq, Getters)]
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Getters, Builder)]
 pub(crate) struct Rule {
   /// Name of the rule. (It is unique)
+  #[builder(default = "default_rule_name()")]
   #[get = "pub"]
   name: String,
   /// Tree-sitter query as string
+  #[builder(default = "default_query()")]
   #[serde(default = "default_query")]
   #[get = "pub"]
   query: String,
   /// The tag corresponding to the node to be replaced
+  #[builder(default = "default_replace_node()")]
   #[serde(default = "default_replace_node")]
   #[get = "pub"]
   replace_node: String,
   /// Replacement pattern
+  #[builder(default = "default_replace()")]
   #[serde(default = "default_replace")]
   #[get = "pub"]
   replace: String,
   /// Group(s) to which the rule belongs
-  #[serde(default)]
+
+  #[builder(default = "default_groups()")]
+  #[serde(default = "default_groups")]
   #[get = "pub"]
   groups: HashSet<String>,
   /// Holes that need to be filled, in order to instantiate a rule
-  #[serde(default)]
+  #[builder(default = "default_holes()")]
+  #[serde(default = "default_holes")]
   #[get = "pub"]
   holes: HashSet<String>,
   /// Additional constraints for matching the rule
-  #[serde(default)]
+  #[builder(default = "default_constraints()")]
+  #[serde(default = "default_constraints")]
   #[get = "pub"]
   constraints: HashSet<Constraint>,
 }
@@ -103,23 +115,28 @@ impl Rule {
   }
 }
 
-#[cfg(test)]
-impl Rule {
-  pub(crate) fn new(
-    name: &str, query: &str, replace_node: &str, replace: &str, holes: HashSet<String>,
-    constraints: HashSet<Constraint>,
-  ) -> Self {
-    Self {
-      name: name.to_string(),
-      query: query.to_string(),
-      replace_node: replace_node.to_string(),
-      replace: replace.to_string(),
-      groups: HashSet::default(),
-      holes,
-      constraints,
-    }
-  }
+#[macro_export]
+macro_rules! piranha_rule {
+  (name = $name:expr
+                $(, query =$query: expr)?
+                $(, replace_node = $replace_node:expr)?
+                $(, replace = $replace:expr)?
+                $(, holes = [$($hole: expr)*])?
+                $(, groups = [$($group_name: expr)*])?
+                $(, constraints = [$($constraint:tt)*])?
+              ) => {
+    $crate::models::rule::RuleBuilder::default()
+    .name($name.to_string())
+    $(.query($query.to_string()))?
+    $(.replace_node($replace_node.to_string()))?
+    $(.replace($replace.to_string()))?
+    $(.holes(HashSet::from([$($hole.to_string(),)*])))?
+    $(.groups(HashSet::from([$($group_name.to_string(),)*])))?
+    $(.constraints(HashSet::from([$($constraint)*])))?
+    .build().unwrap()
+  };
 }
+pub use piranha_rule;
 
 #[derive(Debug, Getters, Clone)]
 pub(crate) struct InstantiatedRule {

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -116,6 +116,27 @@ impl Rule {
 }
 
 #[macro_export]
+/// This macro can be used to construct a Rule (via the builder).'
+/// Allows to use builder pattern more "dynamically"
+///
+/// Usage:
+///
+/// ```ignore
+/// piranha_rule! {
+///   name = "Some Rule".to_string(),
+///   query= "(method_invocation name: (_) @name) @mi".to_string()
+/// }
+/// ```
+///
+/// expands to
+///
+/// ```ignore
+/// RuleBuilder::default()
+///      .name("Some Rule".to_string())
+///      .query("(method_invocation name: (_) @name) @mi".to_string)
+///      .build()
+/// ```
+///
 macro_rules! piranha_rule {
   (name = $name:expr
                 $(, query =$query: expr)?

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -16,7 +16,7 @@ use crate::models::piranha_arguments::PiranhaArguments;
 use crate::utilities::{eq_without_whitespace, read_file};
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tempdir::TempDir;
 
 mod test_piranha_java;
@@ -53,11 +53,11 @@ static PLACEHOLDER: &str = ".placeholder";
 /// * dest: Path to destination
 ///
 /// This method causes side effects - writes new files to a directory
-fn copy_folder_to_temp_dir(src: &PathBuf) -> TempDir {
+fn copy_folder_to_temp_dir(src: &Path) -> TempDir {
   // Copy the test scenario to temporary directory
   let temp_dir = TempDir::new_in(".", "tmp_test").unwrap();
   let temp_dir_path = &temp_dir.path();
-  for entry in fs::read_dir(src.as_path()).unwrap() {
+  for entry in fs::read_dir(src).unwrap() {
     let entry = entry.unwrap();
     let path = entry.path();
     if path.is_file() {


### PR DESCRIPTION
**Background:**  Currently we use `new(..)` to instantiate `Rule` and `Constraint` which is messy. We want to add the Builder pattern to build it, and then wrap it with a macro. 
**Why?** We ultimately want to move `RuleGraph` into `PiranhaArguments`. Which implies that we will have to expose rules, constraints to the user.  So rather than doing that move and then retroactively fixing stuff, I am doing it the other way.
**Implementation:** Basically the `Rule::new()` and `Constraint::new()` are replaced by the macros `piranha_rule` and `constraint` respectively
**Test Plan:** Updated the tests to use the macro. No semantic change. 

(Trying to break down the change into smaller diffs)

