### PR TITLE
Move PiranhaArguments from RuleStore into Piranha

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,8 @@ struct Piranha {
   path_to_codebase: String,
   // Files updated by Piranha.
   relevant_files: HashMap<PathBuf, SourceCodeUnit>,
+  // Piranha Arguments
+  piranha_arguments: PiranhaArguments,
 }
 
 impl Piranha {
@@ -137,7 +139,7 @@ impl Piranha {
   fn perform_cleanup(&mut self) {
     // Setup the parser for the specific language
     let mut parser = Parser::new();
-    let piranha_args = self.rule_store.piranha_args().clone();
+    let piranha_args = &self.piranha_arguments;
     parser
       .set_language(*piranha_args.language().language())
       .expect("Could not set the language for the parser.");
@@ -162,7 +164,7 @@ impl Piranha {
               content,
               &current_global_substitutions,
               path.as_path(),
-              &piranha_args,
+              piranha_args,
             )
           });
 
@@ -191,6 +193,7 @@ impl Piranha {
       rule_store: graph_rule_store,
       path_to_codebase: String::from(piranha_arguments.path_to_codebase()),
       relevant_files: HashMap::new(),
+      piranha_arguments: piranha_arguments.clone(),
     }
   }
 }

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -124,9 +124,9 @@ pub struct PiranhaArguments {
 }
 
 impl Default for PiranhaArguments {
-    fn default() -> Self {
-        PiranhaArgumentsBuilder::default().build()
-    }
+  fn default() -> Self {
+    PiranhaArgumentsBuilder::default().build()
+  }
 }
 
 #[pymethods]

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -34,7 +34,7 @@ use serde_derive::Deserialize;
 use std::{collections::HashMap, path::PathBuf};
 
 /// A refactoring tool that eliminates dead code related to stale feature flags
-#[derive(Deserialize, Clone, Getters, CopyGetters, Debug, Parser, Default, Builder)]
+#[derive(Deserialize, Clone, Getters, CopyGetters, Debug, Parser, Builder)]
 #[clap(name = "Piranha")]
 #[pyclass]
 #[builder(build_fn(name = "create"))]
@@ -121,6 +121,12 @@ pub struct PiranhaArguments {
   #[clap(long, default_value_t = false)]
   #[serde(default = "default_dry_run")]
   dry_run: bool,
+}
+
+impl Default for PiranhaArguments {
+    fn default() -> Self {
+        PiranhaArgumentsBuilder::default().build()
+    }
 }
 
 #[pymethods]

--- a/src/models/source_code_unit.rs
+++ b/src/models/source_code_unit.rs
@@ -511,9 +511,8 @@ impl SourceCodeUnit {
     &self, previous_edit_start: usize, previous_edit_end: usize, rules_store: &mut RuleStore,
     rules: &Vec<InstantiatedRule>,
   ) -> Option<Edit> {
-    let number_of_ancestors_in_parent_scope = *rules_store
-      .piranha_args()
-      .number_of_ancestors_in_parent_scope();
+    let number_of_ancestors_in_parent_scope =
+      *self.piranha_arguments.number_of_ancestors_in_parent_scope();
     let changed_node = get_node_for_range(self.root_node(), previous_edit_start, previous_edit_end);
     debug!(
       "\n{}",
@@ -628,7 +627,7 @@ impl SourceCodeUnit {
     &self, node: Node, rule: &InstantiatedRule, substitutions: &HashMap<String, String>,
     rule_store: &mut RuleStore,
   ) -> bool {
-    let mut updated_substitutions = rule_store.piranha_args().input_substitutions();
+    let mut updated_substitutions = self.piranha_arguments.input_substitutions();
     updated_substitutions.extend(substitutions.clone());
     rule.constraints().iter().all(|constraint| {
       self._is_satisfied(constraint.clone(), node, rule_store, &updated_substitutions)

--- a/src/models/unit_tests/rule_test.rs
+++ b/src/models/unit_tests/rule_test.rs
@@ -11,9 +11,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 use crate::{
-  constraint,
-  models::{default_configs::JAVA, language::PiranhaLanguage},
-  utilities::eq_without_whitespace,
+  constraint, models::piranha_arguments::PiranhaArgumentsBuilder, utilities::eq_without_whitespace,
 };
 use std::collections::HashSet;
 
@@ -107,14 +105,15 @@ fn test_get_edit_positive_recursive() {
 
   let mut rule_store = RuleStore::default();
 
-  let mut parser = PiranhaLanguage::from(JAVA).parser();
+  let args = PiranhaArgumentsBuilder::default().build();
+  let mut parser = args.language().parser();
 
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args(),
+    &args,
   );
   let node = source_code_unit.root_node();
   let matches = source_code_unit.get_matches(&rule, &mut rule_store, node, true);
@@ -163,14 +162,16 @@ fn test_get_edit_negative_recursive() {
 
   let rule = InstantiatedRule::new(&_rule, &HashMap::new());
   let mut rule_store = RuleStore::default();
-  let mut parser = PiranhaLanguage::from(JAVA).parser();
+
+  let args = PiranhaArgumentsBuilder::default().build();
+  let mut parser = args.language().parser();
 
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args(),
+    &args,
   );
   let node = source_code_unit.root_node();
   let matches = source_code_unit.get_matches(&rule, &mut rule_store, node, true);
@@ -201,15 +202,15 @@ fn test_get_edit_for_context_positive() {
         }";
 
   let mut rule_store = RuleStore::default();
-
-  let mut parser = PiranhaLanguage::from(JAVA).parser();
+  let args = PiranhaArgumentsBuilder::default().build();
+  let mut parser = args.language().parser();
 
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args(),
+    &args,
   );
   let edit =
     source_code_unit.get_edit_for_context(41_usize, 44_usize, &mut rule_store, &vec![rule]);
@@ -240,14 +241,15 @@ fn test_get_edit_for_context_negative() {
 
   let mut rule_store = RuleStore::default();
 
-  let mut parser = PiranhaLanguage::from(JAVA).parser();
+  let args = PiranhaArgumentsBuilder::default().build();
+  let mut parser = args.language().parser();
 
   let source_code_unit = SourceCodeUnit::new(
     &mut parser,
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args(),
+    &args,
   );
   let edit =
     source_code_unit.get_edit_for_context(29_usize, 33_usize, &mut rule_store, &vec![rule]);

--- a/src/models/unit_tests/scopes_test.rs
+++ b/src/models/unit_tests/scopes_test.rs
@@ -1,5 +1,20 @@
+/*
+ Copyright (c) 2022 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 use crate::models::{
-  default_configs::JAVA, language::PiranhaLanguage, piranha_arguments::PiranhaArgumentsBuilder,
+  default_configs::JAVA,
+  language::PiranhaLanguage,
+  piranha_arguments::{PiranhaArguments, PiranhaArgumentsBuilder},
 };
 
 /*
@@ -82,14 +97,13 @@ fn _get_method_scope() -> ScopeGenerator {
     .unwrap();
 }
 
-fn _get_rule_store() -> RuleStore {
+fn _get_piranha_args() -> PiranhaArguments {
   let mut piranha_language = PiranhaLanguage::from(JAVA);
   piranha_language.set_scopes(vec![_get_method_scope(), _get_class_scope()]);
-  let piranha_args = PiranhaArgumentsBuilder::default()
+  PiranhaArgumentsBuilder::default()
     .language(piranha_language)
     .create()
-    .unwrap();
-  RuleStore::from(piranha_args)
+    .unwrap()
 }
 
 /// Positive test for the generated scope query, given scope generators, source code and position of pervious edit.
@@ -105,7 +119,7 @@ fn test_get_scope_query_positive() {
       }
     }";
 
-  let mut rule_store = _get_rule_store();
+  let piranha_args = _get_piranha_args();
   let mut parser = PiranhaLanguage::from(JAVA).parser();
 
   let source_code_unit = SourceCodeUnit::new(
@@ -113,9 +127,9 @@ fn test_get_scope_query_positive() {
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args(),
+    &piranha_args,
   );
-
+  let mut rule_store = RuleStore::new(&piranha_args);
   let scope_query_method = source_code_unit.get_scope_query("Method", 133, 134, &mut rule_store);
 
   println!("{}", scope_query_method.as_str());
@@ -161,7 +175,7 @@ fn test_get_scope_query_negative() {
         }
       }
     }";
-  let mut rule_store = _get_rule_store();
+  let piranha_args = _get_piranha_args();
   let mut parser = PiranhaLanguage::from(JAVA).parser();
 
   let source_code_unit = SourceCodeUnit::new(
@@ -169,8 +183,8 @@ fn test_get_scope_query_negative() {
     source_code.to_string(),
     &HashMap::new(),
     PathBuf::new().as_path(),
-    rule_store.piranha_args(),
+    &piranha_args,
   );
-
+  let mut rule_store = RuleStore::new(&piranha_args);
   let _ = source_code_unit.get_scope_query("Method", 9, 10, &mut rule_store);
 }


### PR DESCRIPTION
Moves `piranha_arguments: PiranhaArguments` from `RuleStore` to `Piranha` (the sort of main runner class).

--------
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #369
* #364
* #363
* __->__ #362

