### PR TITLE
Added rules for if cleanup in swift

### DIFF
--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -20,9 +20,14 @@ to = ["boolean_literal_cleanup"]
 [[edges]]
 scope = "Parent"
 from = "boolean_literal_cleanup"
-to = ["boolean_expression_simplify"]
+to = ["boolean_expression_simplify", "statement_cleanup"]
 
 [[edges]]
 scope = "Parent"
 from = "boolean_expression_simplify"
 to = ["boolean_literal_cleanup"]
+
+[[edges]]
+scope = "File"
+from = "statement_cleanup"
+to = ["if_cleanup"]

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -231,6 +231,59 @@ replace_node = "not_expression"
 replace = "true"
 is_seed_rule = false
 
+#
+# Next two rules take care of if-else cleanup, these 2 rules depend on their order in this file
+# 
+
+#
+# Before 
+#   if true {
+#     abcd()
+#   } else {
+#     hij()
+#   }
+# After 
+#   abcd()
+#
+[[rules]]
+name = "if_always_true"
+query = """ (
+(if_statement
+    condition: (boolean_literal) @condition_literal
+    .(statements) @if_block
+    ) @if_else_block
+(#eq? @condition_literal "true")
+)"""
+groups = ["if_cleanup"]
+replace_node = "if_else_block"
+replace = "@if_block"
+is_seed_rule = false
+
+# Before 
+#   else if true {
+#     abcd()
+#   } else {
+#     hij()
+#   }
+# After 
+#   abcd()
+#
+[[rules]]
+name = "else_if_always_true"
+query = """ (
+(else)
+(if_statement
+    condition: (boolean_literal) @condition_literal
+    .(statements) @if_block
+    ) @if_else_block
+(#eq? @condition_literal "true")
+)"""
+groups = ["if_cleanup"]
+replace_node = "if_else_block"
+replace = "{ @if_block }"
+is_seed_rule = false
+
+
 # Dummy rule that acts as a junction for all boolean based cleanups
 # Let's say you want to define rules from A -> B, A -> C, D -> B, D -> C, ... 
 # A pattern here is - if there is an outgoing edge to B there is another to C.
@@ -238,4 +291,8 @@ is_seed_rule = false
 # X -> B, X - C, A -> X, D -> X, ...
 [[rules]]
 name = "boolean_literal_cleanup"
+is_seed_rule = false
+
+[[rules]]
+name = "statement_cleanup"
 is_seed_rule = false

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -47,9 +47,40 @@ class SampleClass {
         isEnabled = false
     }
     
-     func checkNotCondition() {
+    func checkNotCondition() {
         isEnabled = v2
         isEnabled = v2
         isEnabled = v2
+    }
+
+    func checkIfTrueCleanup() {
+        f1()
+        f2()  
+        
+        if isEnabled {
+            f2()
+        } else {
+            f3()
+        }  
+
+        if isEnabled {
+            f2()
+        } else {
+            f3()
+        } 
+
+        if isEnabled {
+            f2()
+        } else if isDisabled {
+            f3()
+        } else {
+            f4()
+        } 
+
+        if isEnabled {
+            f2()
+        } else  {
+            f4()
+        } 
     }
 }

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -52,4 +52,45 @@ class SampleClass {
         isEnabled = (TestEnum.stale_flag_one.isEnabled && !false) && v2
         isEnabled = v2 || (placeholder_false || !true)
     } 
+
+    func checkIfTrueCleanup() {
+        f1()
+        if TestEnum.stale_flag_one.isEnabled {
+            f2()
+        }
+
+        if isEnabled {
+            f2()
+        } else if TestEnum.stale_flag_one.isEnabled {
+            f3()
+        } 
+
+        if isEnabled {
+            f2()
+        } else if TestEnum.stale_flag_one.isEnabled {
+            f3()
+        } else {
+            f4()
+        } 
+
+        if isEnabled {
+            f2()
+        } else if isDisabled {
+            f3()
+        } else if TestEnum.stale_flag_one.isEnabled {
+            f4()
+        } else {
+            f5()
+        }
+
+        if isEnabled {
+            f2()
+        }  else if TestEnum.stale_flag_one.isEnabled {
+            f4()
+        } else if isDisabled {
+            f3()
+        } else {
+            f5()
+        }
+    }
 }


### PR DESCRIPTION
Rules created to cleanup if statements which are always true.
Rule 1:
```
Before 
if true {
   f1()
}
After 
{
   f1()
}
```

Rule 2:
```
Before
{
   f1()
}
After
f1()
```

Rule 2 will always be child of Rule 1, Since output of Rule 1 is not compilable in swift. This is done to make sure else if case is handled. Example of else if case: 
```
Before:

if var {
   f1()
} else if true {
   f2()
} else {
   f3()
}

After:

if var {
  f1()
} else {
  f2()
}
```