### PR TITLE
Bumped up tree-sitter-swift dependency and resolved test failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,8 @@ serde_json = "1.0.82"
 # TODO: Update after https://github.com/fwcd/tree-sitter-kotlin/pull/71 lands
 tree-sitter-kotlin = { git = "https://github.com/ketkarameya/tree-sitter-kotlin.git", rev = "a87ddd003368e068563f1cc478a1b2a3f9d73b60" }
 tree-sitter-java = "0.20.0"
-tree-sitter-swift = "0.3.4"
+# TODO: Update after: https://github.com/alex-pinkus/tree-sitter-swift/issues/278 resolves
+tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git", rev = "c92496b5273e4d3b094148fee51de371c94729bf" }
 tree-sitter-python = "0.20.2"
 tree-sitter-typescript = "0.20.1"
 # TODO: Update after https://github.com/tree-sitter/tree-sitter-go/pull/103 lands

--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -32,4 +32,12 @@ create_rewrite_tests! {
     cleanup_comments = true,
     global_tag_prefix ="universal_tag.".to_string(),
     cleanup_comments_buffer = 3, delete_file_if_empty= false;
+
+  test_cleanup_rules_file: "cleanup_rules", 1,
+    substitutions = substitutions! {
+      "stale_flag" => "stale_flag_one",
+      "treated" => "true",
+      "treated_complement" => "false"
+    },
+    cleanup_comments = true, delete_file_if_empty= false;
 }

--- a/test-resources/swift/cleanup_rules/configurations/rules.toml
+++ b/test-resources/swift/cleanup_rules/configurations/rules.toml
@@ -20,7 +20,7 @@
 #
 
 [[rules]]
-name = "replace_isToggleEnabled_with_boolean_literal"
+name = "test_rule_replace_true_placeholder"
 query = """(
 (navigation_expression
         target: (navigation_expression
@@ -40,26 +40,17 @@ groups = ["replace_expression_with_boolean_literal"]
 #
 # For @stale_flag_name = stale_flag and @treated = true
 # Before 
-#   !TestEnum.stale_flag.isEnabled
+#   placeholder_false
 # After 
 #   false
 #
 
 [[rules]]
-name = "replace_isToggleDisabled_with_boolean_literal"
+name = "test_rule_replace_false_placeholder"
 query = """(
-(navigation_expression
-        target: (navigation_expression
-            target: (prefix_expression
-                operation: (bang))
-            suffix: (navigation_suffix
-                suffix: (simple_identifier) @param))
-        suffix: (navigation_suffix
-            suffix: (simple_identifier) @access_identifier)) @parameter_access
-(#eq? @param "@stale_flag")
-(#eq? @access_identifier "isEnabled")
+(simple_identifier) @variable
+(#eq? @variable "placeholder_false")
 )"""
-replace_node = "parameter_access"
-replace = "@treated_complement"
-holes = ["stale_flag", "treated_complement"]
+replace_node = "variable"
+replace = "false"
 groups = ["replace_expression_with_boolean_literal"]

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -10,15 +10,12 @@
 // limitations under the License.
 
 class SampleClass {
-    var isEnabled = true
-
     func sampleFunction() {
         isEnabled = v1
         isEnabled = f2()
         isEnabled = v2
         isEnabled = v2
         isEnabled = v2
-        isEnabled = false
     }
 
     func checkOrTrue() {

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -10,15 +10,12 @@
 // limitations under the License.
 
 class SampleClass {
-    var isEnabled = TestEnum.stale_flag_one.isEnabled
-
     func sampleFunction() {
         isEnabled = TestEnum.stale_flag_one.isEnabled && v1
         isEnabled = f2() && TestEnum.stale_flag_one.isEnabled 
         isEnabled = v2 && TestEnum.stale_flag_one.isEnabled 
         isEnabled = v2 && (TestEnum.stale_flag_one.isEnabled && true)
         isEnabled = (TestEnum.stale_flag_one.isEnabled && true) && v2
-        isEnabled = !TestEnum.stale_flag_one.isEnabled
     }
 
     func checkOrTrue() {
@@ -37,9 +34,9 @@ class SampleClass {
     }
     
     func checkOrFalse() {
-        isEnabled = !TestEnum.stale_flag_one.isEnabled || f1()
-        isEnabled = !TestEnum.stale_flag_one.isEnabled || v1
-        isEnabled = f2() || !TestEnum.stale_flag_one.isEnabled 
-        isEnabled = v2 || !TestEnum.stale_flag_one.isEnabled 
+        isEnabled = placeholder_false || f1()
+        isEnabled = placeholder_false || v1
+        isEnabled = f2() || placeholder_false 
+        isEnabled = v2 || placeholder_false 
     }
 }


### PR DESCRIPTION
A new version of `tree-sitter-swift` was released to resolve issues reported by us ([issue-272](https://github.com/alex-pinkus/tree-sitter-swift/issues/272), [issue-271](https://github.com/alex-pinkus/tree-sitter-swift/issues/271)) .

The new version has an [issue](https://github.com/tree-sitter/tree-sitter-go/pull/103), which is critical for our usecase, So created a fork with fix and updated tree-sitter-swift dependency with the same.

Since the grammar for `!abc` has changed in new release, A seprate rule for `!TestEnum.stale_flag.isEnabled` is not required and this rule would be handled with `!true` and `!false` rules.