### PR TITLE
Reproduce go comment cleanup issues

### DIFF
--- a/src/tests/test_piranha_go.rs
+++ b/src/tests/test_piranha_go.rs
@@ -28,15 +28,15 @@ create_rewrite_tests! {
       "true_flag_name" => "true",
       "false_flag_name" => "false",
       "nil_flag_name" => "nil"
-    };
+    },cleanup_comments = true;
   test_builtin_statement_cleanup: "feature_flag/builtin_rules/statement_cleanup", 1,
     substitutions= substitutions! {
       "treated" => "true",
       "treated_complement" => "false"
-    };
+    },cleanup_comments = true;
   test_const_same_file: "feature_flag/system_1/const_same_file", 1,
     substitutions= substitutions! {
       "stale_flag_name" => "staleFlag",
       "treated" => "false"
-    };
+    },cleanup_comments = true;
 }

--- a/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/expected/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/expected/sample.go
@@ -109,6 +109,25 @@ func simplify_if_statement_false() {
     // no alternative, should remove the whole `if_statement`
 }
 
+func simplify_if_statement_false_comment_demo_single_comment() {
+    fmt.Println("remain")
+    // this comment doesnt get removed but it should
+}
+
+func simplify_if_statement_false_comment_demo_double_comment() {
+    fmt.Println("remain")
+    // this comment doesnt get removed
+}
+
+func simplify_if_statement_false_comment_demo_multiline_comment() {
+    fmt.Println("remain")
+}
+
+func simplify_if_statement_false_comment_demo_multiline_comment_one_line() {
+    fmt.Println("remain")
+    /* this comment doesnt get removed */
+}
+
 func simplify_identity_eq() {
     fmt.Println("keep 1")
     fmt.Println("keep 2")

--- a/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/input/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/input/sample.go
@@ -178,6 +178,59 @@ func simplify_if_statement_false() {
     }
 }
 
+func simplify_if_statement_false_comment_demo_single_comment() {
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed")
+    } else {
+        fmt.Println("remain")
+    }
+    // this comment doesnt get removed but it should
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed 2")
+    }
+}
+
+func simplify_if_statement_false_comment_demo_double_comment() {
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed")
+    } else {
+        fmt.Println("remain")
+    }
+    // this comment doesnt get removed
+    // this comment does get removed - but only if theres another comment above it
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed 2")
+    }
+}
+
+func simplify_if_statement_false_comment_demo_multiline_comment() {
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed")
+    } else {
+        fmt.Println("remain")
+    }
+    /* this comment does get removed
+    with all the lines
+    in it 
+    */
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed 2")
+    }
+}
+
+func simplify_if_statement_false_comment_demo_multiline_comment_one_line() {
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed")
+    } else {
+        fmt.Println("remain")
+    }
+    /* this comment doesnt get removed */
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed 2")
+    }
+}
+
+
 func simplify_identity_eq() {
     if exp.BoolValue("true") == exp.BoolValue("true") {
         fmt.Println("keep 1")


### PR DESCRIPTION
**Purpose**
I'm seeing some inconsistencies in how go comment cleanup is handled within the tool. I've added some test cases here to demonstrate this. 

Observations:

- Multiline comments are cleaned up (simplify_if_statement_false_comment_demo_multiline_comment)
- Single line comments are not cleaned up (simplify_if_statement_false_comment_demo_single_comment)
- Single line comments are cleaned up provided the next node above is also a comment (simplify_if_statement_false_comment_demo_double_comment)

These test cases are for cleaning up if blocks however I've noticed the same behaviour when cleaning up constants in my own codebase e.g.

**Before**
```
const (
    // comment
    myFlag = "flag"

   // stale comment
   myStaleFlag = "stale flag"
)
```

**After**
```
const (
    // comment
    myFlag = "flag"

   // stale comment
)
```

**Expected**
```
const (
    // comment
    myFlag = "flag"
)
```

The constants example above exhibits the same behaviour around only cleaning up comments if they're (a) multiline or (b) have another comment node directly above them