### PR TITLE
Added rules to clean if-false from swift

### DIFF
--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -283,6 +283,105 @@ replace_node = "if_else_block"
 replace = "{ @if_block }"
 is_seed_rule = false
 
+# Order of next 3 rules should not be changed as, we depend on order to clean if always false cases.
+# Before 
+#   if false {
+#     abcd()
+#   } 
+#   hij()
+# After 
+#   hij()
+# 
+[[rules]]
+name = "if_always_false"
+query = """(  
+(if_statement
+    bound_identifier: (_)?
+    condition: (boolean_literal) @condition_literal
+    .(statements) @if_block
+    [(statements) (if_statement)]? @alternatives 
+    ) @if_else_block
+(#eq? @condition_literal "false")
+)"""
+groups = ["if_cleanup"]
+replace_node = "if_else_block"
+replace = "@alternatives"
+is_seed_rule = false
+
+
+# Before 
+#   if v1 {
+#       f1()
+#   } else if false {
+#       f2()
+#   } else {
+#       f3()
+#   }
+#   f4()
+# After 
+#   if v1 {
+#       f1()
+#   } else {
+#       f3()
+#   }
+#   f4()
+[[rules]]
+name = "else_if_always_false_followed_by_else"
+query = """(  
+(else)
+(if_statement
+    bound_identifier: (_)?
+    condition: (boolean_literal) @condition_literal
+    .(statements) @if_block
+    (statements)? @alternatives 
+    ) @if_else_block
+(#eq? @condition_literal "false")
+)"""
+groups = ["if_cleanup"]
+replace_node = "if_else_block"
+replace = """{ 
+    @alternatives
+    }"""
+is_seed_rule = false
+
+
+# Before 
+#   if v1 {
+#       f1()
+#   } else if false {
+#       f2()
+#   } else if v2{
+#       f3()
+#   } else {
+#       f4()
+#   }
+#   f5()
+# After 
+#   if v1 {
+#       f1()
+#   } else if v2 {
+#       f3()
+#   } else {
+#       f4()
+#   }
+#   f5()
+[[rules]]
+name = "else_if_always_false_followed_by_else_if"
+query = """(  
+(else)
+(if_statement
+    bound_identifier: (_)?
+    condition: (boolean_literal) @condition_literal
+    .(statements) @if_block
+    (if_statement) @alternatives 
+    ) @if_else_block
+(#eq? @condition_literal "false")
+)"""
+groups = ["if_cleanup"]
+replace_node = "if_else_block"
+replace = "@alternatives"
+is_seed_rule = false
+
 
 # Dummy rule that acts as a junction for all boolean based cleanups
 # Let's say you want to define rules from A -> B, A -> C, D -> B, D -> C, ... 

--- a/test-resources/swift/cleanup_rules/configurations/rules.toml
+++ b/test-resources/swift/cleanup_rules/configurations/rules.toml
@@ -40,6 +40,33 @@ groups = ["replace_expression_with_boolean_literal"]
 #
 # For @stale_flag_name = stale_flag and @treated = true
 # Before 
+#   !TestEnum.stale_flag.isEnabled
+# After 
+#   false
+#
+
+[[rules]]
+name = "replace_isToggleDisabled_with_boolean_literal"
+query = """(
+(navigation_expression
+        target: (navigation_expression
+            target: (prefix_expression
+                operation: (bang))
+            suffix: (navigation_suffix
+                suffix: (simple_identifier) @param))
+        suffix: (navigation_suffix
+            suffix: (simple_identifier) @access_identifier)) @parameter_access
+(#eq? @param "@stale_flag")
+(#eq? @access_identifier "isEnabled")
+)"""
+replace_node = "parameter_access"
+replace = "@treated_complement"
+holes = ["stale_flag", "treated_complement"]
+groups = ["replace_expression_with_boolean_literal"]
+
+#
+# For @stale_flag_name = stale_flag and @treated = true
+# Before 
 #   placeholder_false
 # After 
 #   false

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -83,4 +83,64 @@ class SampleClass {
             f4()
         } 
     }
+    
+    func checkIfFalse() {
+        f2()
+
+        if v1 {
+            f2()
+        } else {
+            f3()
+        }
+
+        if v1 {
+            f1()
+        } else { 
+            f3()
+        }
+
+        if v1 {
+            f1()
+        } else if v2 {
+            f3()
+        } else {
+            f4()
+        }
+
+        if v1 {
+            f1()
+        } else { 
+        
+        }
+    }
+
+    func checkIfLetFalse() {
+        f2()
+
+        if v1 {
+            f2()
+        } else {
+            f3()
+        }
+
+        if v1 {
+            f1()
+        } else { 
+            f3()
+        }
+
+        if v1 {
+            f1()
+        } else if v2 {
+            f3()
+        } else {
+            f4()
+        }
+
+        if v1 {
+            f1()
+        } else { 
+        
+        }
+    }
 }

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -93,4 +93,94 @@ class SampleClass {
             f5()
         }
     }
+    
+    func checkIfFalse() {
+        //test comments to be cleaned
+        if !TestEnum.stale_flag_one.isEnabled && abc {
+            f1()
+        }
+
+        if !TestEnum.stale_flag_one.isEnabled && abc {
+            f1()
+        } else {
+            f2()
+        }
+
+        if !TestEnum.stale_flag_one.isEnabled && abc {
+            f1()
+            //test comments to be cleaned
+        } else if v1 {
+            f2()
+        } else {
+            f3()
+        }
+
+        if v1 {
+            f1()
+        } else if !TestEnum.stale_flag_one.isEnabled && abc {
+            f2()
+        } else {
+            f3()
+        }
+
+        if v1 {
+            f1()
+        } else if !TestEnum.stale_flag_one.isEnabled && abc {
+            f2()
+        } else if v2 {
+            f3()
+        } else {
+            f4()
+        }
+
+        if v1 {
+            f1()
+        } else if !TestEnum.stale_flag_one.isEnabled && abc {
+            f2()
+        }
+    }
+
+    func checkIfLetFalse() {
+        if let v1 = v1, !TestEnum.stale_flag_one.isEnabled && abc {
+            f1()
+        }
+
+        if let v1 = v1, !TestEnum.stale_flag_one.isEnabled && abc {
+            f1()
+        } else {
+            f2()
+        }
+
+        if let v1 = v1, !TestEnum.stale_flag_one.isEnabled && abc {
+            f1()
+        } else if v1 {
+            f2()
+        } else {
+            f3()
+        }
+
+        if v1 {
+            f1()
+        } else if let v1 = v1, !TestEnum.stale_flag_one.isEnabled && abc {
+            f2()
+        } else {
+            f3()
+        }
+
+        if v1 {
+            f1()
+        } else if let v1 = v1, !TestEnum.stale_flag_one.isEnabled && abc {
+            f2()
+        } else if v2 {
+            f3()
+        } else {
+            f4()
+        }
+
+        if v1 {
+            f1()
+        } else if let v1 = v1, !TestEnum.stale_flag_one.isEnabled && abc {
+            f2()
+        }
+    }
 }


### PR DESCRIPTION
Rules to be created 

```
Before
if false {
   f1()
}
f2()
After
f2()
```

3 rules are created and we are depending on the order of rules to clean all corner cases of if always false.
 1. else if is always false and followed by else if
 2. else if is always false and followed by else or nothing
 3. if is always false.

These rules also handles cases with if let
i.e. below mentioned case will also be handled
```
Before
if let value = value, false {
   f1()
}
f2()

After
f2()
```