### PR TITLE
Added rule to cleanup guard statements which are always true

### DIFF
--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -31,3 +31,8 @@ to = ["boolean_literal_cleanup"]
 scope = "File"
 from = "statement_cleanup"
 to = ["if_cleanup"]
+
+[[edges]]
+scope = "Parent"
+from = "statement_cleanup"
+to = ["guard_cleanup"]

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -259,6 +259,7 @@ replace_node = "if_else_block"
 replace = "@if_block"
 is_seed_rule = false
 
+#
 # Before 
 #   else if true {
 #     abcd()
@@ -380,6 +381,30 @@ query = """(
 groups = ["if_cleanup"]
 replace_node = "if_else_block"
 replace = "@alternatives"
+is_seed_rule = false
+
+#
+# Before
+#   guard true else {
+#       return f1()
+#   }
+#   f2()
+# After 
+#   f2()
+#
+[[rules]]
+name = "guard_always_true"
+query = """(
+(guard_statement
+    condition: [(boolean_literal) @true  
+            (tuple_expression 
+                value: (boolean_literal) @true)]
+    ) @guard_block
+(#eq? @true "true")
+)"""
+groups = ["guard_cleanup"]
+replace_node = "guard_block"
+replace = ""
 is_seed_rule = false
 
 

--- a/test-resources/swift/cleanup_rules/configurations/rules.toml
+++ b/test-resources/swift/cleanup_rules/configurations/rules.toml
@@ -18,7 +18,6 @@
 # After 
 #   true
 #
-
 [[rules]]
 name = "test_rule_replace_true_placeholder"
 query = """(
@@ -71,7 +70,6 @@ groups = ["replace_expression_with_boolean_literal"]
 # After 
 #   false
 #
-
 [[rules]]
 name = "test_rule_replace_false_placeholder"
 query = """(

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -143,4 +143,12 @@ class SampleClass {
         
         }
     }
+    
+    func checkGaurdTrue() {
+        f1()
+    }
+
+    func checkGaurdTrueWithAnd() {
+        f1()
+    }
 }

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -183,4 +183,18 @@ class SampleClass {
             f2()
         }
     }
+    
+    func checkGaurdTrue() {
+        guard TestEnum.stale_flag_one.isEnabled || f1() else {
+            return
+        }
+        f1()
+    }
+    
+    func checkGaurdTrueWithAnd() {
+        guard TestEnum.stale_flag_one.isEnabled && true else {
+            return
+        }
+        f1()
+    }
 }


### PR DESCRIPTION
Rules created

```
Before 
guard true else {
   return
}
f1()
After
f1()
```