### PR TITLE
Fix go comments bug

### DIFF
--- a/src/models/edit.rs
+++ b/src/models/edit.rs
@@ -68,6 +68,10 @@ impl Edit {
       matched_rule: "Delete Range".to_string(),
     }
   }
+
+  pub(crate) fn is_delete(&self) -> bool {
+    self.replacement_string.trim().is_empty()
+  }
 }
 
 impl fmt::Display for Edit {

--- a/src/models/language.rs
+++ b/src/models/language.rs
@@ -57,8 +57,9 @@ pub struct PiranhaLanguage {
   ignore_nodes_for_comments: Vec<String>,
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Default)]
 pub enum SupportedLanguage {
+  #[default]
   Java,
   Kotlin,
   Go,
@@ -66,12 +67,6 @@ pub enum SupportedLanguage {
   Ts,
   Tsx,
   Python,
-}
-
-impl Default for SupportedLanguage {
-  fn default() -> Self {
-    SupportedLanguage::Java
-  }
 }
 
 impl PiranhaLanguage {

--- a/src/models/language.rs
+++ b/src/models/language.rs
@@ -28,20 +28,28 @@ use super::{
 
 #[derive(Debug, Clone, Getters, PartialEq)]
 pub struct PiranhaLanguage {
+  /// The extension of the language FIXME: - https://github.com/uber/piranha/issues/365
   #[get = "pub"]
   name: String,
+  /// the language (enum)
   #[get = "pub"]
   supported_language: SupportedLanguage,
+  /// the language (As tree sitter model)
   #[get = "pub"]
   language: tree_sitter::Language,
+  /// Built-in rules for the language
   #[get = "pub(crate)"]
   rules: Option<Rules>,
+  /// Built-in edges for the language
   #[get = "pub(crate)"]
   edges: Option<Edges>,
+  /// Scope configurations for the language
   #[get = "pub(crate)"]
   scopes: Vec<ScopeGenerator>,
+  /// The node kinds to be considered when reasoning about comments
   #[get = "pub"]
   comment_nodes: Vec<String>,
+  /// The node kinds to be ignored when reasoning about comments
   #[get = "pub"]
   ignore_nodes_for_comments: Vec<String>,
 }

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -386,6 +386,13 @@ impl SourceCodeUnit {
       .unwrap_or_else(|| self.root_node());
 
     for node in traverse(node.walk(), Order::Post) {
+      if self
+        .piranha_arguments()
+        .language()
+        .should_ignore_node_for_comment(&node)
+      {
+        continue;
+      }
       if node.start_position().row == row || node.end_position().row == row {
         relevant_nodes_found = true;
         let is_comment: bool = self

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -335,7 +335,7 @@ impl SourceCodeUnit {
   /// This ensures that can delete a series of comments.
   ///
   /// Let's say `apply_edit` deletes `int foo` in the below example.
-  /// ```
+  /// ```ignore
   /// // some
   /// // comment
   /// int foo;
@@ -343,19 +343,19 @@ impl SourceCodeUnit {
   ///
   /// becomes
   ///
-  /// ```
+  /// ```ignore
   /// // some
   /// // comment
   /// ```
   ///
   /// now `_delete_associated_comment` is triggered, and now we produce
-  /// ```
+  /// ```ignore
   /// // some
   /// ```
   ///
   /// Since `_delete_associated_comment` is effectively called recursively
   ///
-  /// ```
+  /// ```ignore
   /// <all comments are deleted>
   /// ```
   pub(crate) fn _delete_associated_comment(

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -385,20 +385,17 @@ impl SourceCodeUnit {
       .descendant_for_byte_range(start_byte, start_byte)
       .unwrap_or_else(|| self.root_node());
 
+    // Search for all nodes starting/ending in the current row.
+    // if it is not amongst the `language.ignore_node_for_comment`, then check if it is a comment
+    // If the node is a comment, then return its range
     for node in traverse(node.walk(), Order::Post) {
-      if self
-        .piranha_arguments()
-        .language()
-        .should_ignore_node_for_comment(&node)
-      {
+      if self.should_ignore_node_for_comment_search(node) {
         continue;
       }
+
       if node.start_position().row == row || node.end_position().row == row {
         relevant_nodes_found = true;
-        let is_comment: bool = self
-          .piranha_arguments()
-          .language()
-          .is_comment(node.kind().to_string());
+        let is_comment: bool = self.is_comment(node.kind().to_string());
         relevant_nodes_are_comments = relevant_nodes_are_comments && is_comment;
         if is_comment {
           comment_range = Some(node.range());

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -330,6 +330,34 @@ mod piranha_arguments_test;
 // Implements instance methods related to applying the user options provided in  piranha arguments
 impl SourceCodeUnit {
   /// Delete the comment associated to the deleted code element
+  ///
+  /// From `apply_edit` we call `_delete_associated_comment` and from `_delete_associated_comment` we recursively call `apply_edit`.
+  /// This ensures that can delete a series of comments.
+  ///
+  /// Let's say `apply_edit` deletes `int foo` in the below example.
+  /// ```
+  /// // some
+  /// // comment
+  /// int foo;
+  /// ```
+  ///
+  /// becomes
+  ///
+  /// ```
+  /// // some
+  /// // comment
+  /// ```
+  ///
+  /// now `_delete_associated_comment` is triggered, and now we produce
+  /// ```
+  /// // some
+  /// ```
+  ///
+  /// Since `_delete_associated_comment` is effectively called recursively
+  ///
+  /// ```
+  /// <all comments are deleted>
+  /// ```
   pub(crate) fn _delete_associated_comment(
     &mut self, edit: &Edit, parser: &mut tree_sitter::Parser,
   ) -> Option<InputEdit> {

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -38,8 +38,7 @@ use pyo3::{
   types::PyDict,
 };
 use regex::Regex;
-use tree_sitter::{InputEdit, Range};
-use tree_sitter_traversal::{traverse, Order};
+use tree_sitter::InputEdit;
 
 use std::collections::HashMap;
 
@@ -346,73 +345,6 @@ impl SourceCodeUnit {
         *applied_edit = self._apply_edit(&Edit::delete_range(self.code(), comment_range), parser);
       }
     }
-  }
-
-  /// This function reports the range of the comment associated to the deleted element.
-  ///
-  /// # Arguments:
-  /// * row : The row number where the deleted element started
-  /// * buffer: Number of lines that we want to look up to find associated comment
-  ///
-  /// # Algorithm :
-  /// Get all the nodes that either start and end at [row]
-  /// If **all** nodes are comments
-  /// * return the range of the comment
-  /// If the [row] has no node that either starts/ends there:
-  /// * recursively call this method for [row] -1 (until buffer is positive)
-  /// This function reports the range of the comment associated to the deleted element.
-  ///
-  /// # Arguments:
-  /// * row : The row number where the deleted element started
-  /// * buffer: Number of lines that we want to look up to find associated comment
-  ///
-  /// # Algorithm :
-  /// Get all the nodes that either start and end at [row]
-  /// If **all** nodes are comments
-  /// * return the range of the comment
-  /// If the [row] has no node that either starts/ends there:
-  /// * recursively call this method for [row] -1 (until buffer is positive)
-  fn _get_comment_at_line(
-    &mut self, row: usize, buffer: usize, start_byte: usize,
-  ) -> Option<Range> {
-    // Get all nodes that start or end on `updated_row`.
-    let mut relevant_nodes_found = false;
-    let mut relevant_nodes_are_comments = true;
-    let mut comment_range = None;
-    // Since the previous edit was a delete, the start and end of the replacement range is [start_byte].
-    let node = self
-      .root_node()
-      .descendant_for_byte_range(start_byte, start_byte)
-      .unwrap_or_else(|| self.root_node());
-
-    // Search for all nodes starting/ending in the current row.
-    // if it is not amongst the `language.ignore_node_for_comment`, then check if it is a comment
-    // If the node is a comment, then return its range
-    for node in traverse(node.walk(), Order::Post) {
-      if self.should_ignore_node_for_comment_search(node) {
-        continue;
-      }
-
-      if node.start_position().row == row || node.end_position().row == row {
-        relevant_nodes_found = true;
-        let is_comment: bool = self.is_comment(node.kind().to_string());
-        relevant_nodes_are_comments = relevant_nodes_are_comments && is_comment;
-        if is_comment {
-          comment_range = Some(node.range());
-        }
-      }
-    }
-
-    if relevant_nodes_found {
-      if relevant_nodes_are_comments {
-        return comment_range;
-      }
-    } else if buffer > 0 {
-      // We pass [start_byte] itself, because we know that parent of the current row is the parent of the above row too.
-      // If that's not the case, its okay, because we will not find any comments in these scenarios.
-      return self._get_comment_at_line(row - 1, buffer - 1, start_byte);
-    }
-    None
   }
 
   /// Replaces three consecutive newline characters with two

--- a/src/tests/test_piranha_go.rs
+++ b/src/tests/test_piranha_go.rs
@@ -33,7 +33,7 @@ create_rewrite_tests! {
     substitutions= substitutions! {
       "treated" => "true",
       "treated_complement" => "false"
-    };
+    }, cleanup_comments = true;
   test_const_same_file: "feature_flag/system_1/const_same_file", 1,
     substitutions= substitutions! {
       "stale_flag_name" => "staleFlag",

--- a/test-resources/go/feature_flag/builtin_rules/statement_cleanup/expected/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/statement_cleanup/expected/sample.go
@@ -72,7 +72,6 @@ func simplify_if_statement_false_comment_demo_single_comment() {
 
 func simplify_if_statement_false_comment_demo_double_comment() {
     fmt.Println("remain")
-    // this comment doesnt get removed
 }
 
 func simplify_if_statement_false_comment_demo_multiline_comment() {

--- a/test-resources/go/feature_flag/builtin_rules/statement_cleanup/expected/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/statement_cleanup/expected/sample.go
@@ -63,3 +63,22 @@ func after_return4() string {
 
     return "not enabled"
 }
+
+
+func simplify_if_statement_false_comment_demo_single_comment() {
+    fmt.Println("remain")
+}
+
+
+func simplify_if_statement_false_comment_demo_double_comment() {
+    fmt.Println("remain")
+    // this comment doesnt get removed
+}
+
+func simplify_if_statement_false_comment_demo_multiline_comment() {
+    fmt.Println("remain")
+}
+
+func simplify_if_statement_false_comment_demo_multiline_comment_one_line() {
+    fmt.Println("remain")
+}

--- a/test-resources/go/feature_flag/builtin_rules/statement_cleanup/input/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/statement_cleanup/input/sample.go
@@ -115,7 +115,7 @@ func simplify_if_statement_false_comment_demo_single_comment() {
         fmt.Println("remain")
     }
     // this comment doesnt get removed but it should
-    if exp1.BoolValue("false") {
+    if exp.BoolValue("false") {
         fmt.Println("to be removed 2")
     }
 }

--- a/test-resources/go/feature_flag/builtin_rules/statement_cleanup/input/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/statement_cleanup/input/sample.go
@@ -106,3 +106,57 @@ func after_return4() string {
     fmt.Println("5")
     return "enabled"
 }
+
+
+func simplify_if_statement_false_comment_demo_single_comment() {
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed")
+    } else {
+        fmt.Println("remain")
+    }
+    // this comment doesnt get removed but it should
+    if exp1.BoolValue("false") {
+        fmt.Println("to be removed 2")
+    }
+}
+
+
+func simplify_if_statement_false_comment_demo_double_comment() {
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed")
+    } else {
+        fmt.Println("remain")
+    }
+    // this comment doesnt get removed
+    // this comment does get removed - but only if theres another comment above it
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed 2")
+    }
+}
+
+func simplify_if_statement_false_comment_demo_multiline_comment() {
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed")
+    } else {
+        fmt.Println("remain")
+    }
+    /* this comment does get removed
+    with all the lines
+    in it 
+    */
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed 2")
+    }
+}
+
+func simplify_if_statement_false_comment_demo_multiline_comment_one_line() {
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed")
+    } else {
+        fmt.Println("remain")
+    }
+    /* this comment doesnt get removed */
+    if exp.BoolValue("false") {
+        fmt.Println("to be removed 2")
+    }
+}

--- a/test-resources/go/feature_flag/builtin_rules/statement_cleanup/input/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/statement_cleanup/input/sample.go
@@ -114,7 +114,7 @@ func simplify_if_statement_false_comment_demo_single_comment() {
     } else {
         fmt.Println("remain")
     }
-    // this comment doesnt get removed but it should
+    // this comment will be deleted
     if exp.BoolValue("false") {
         fmt.Println("to be removed 2")
     }
@@ -127,8 +127,8 @@ func simplify_if_statement_false_comment_demo_double_comment() {
     } else {
         fmt.Println("remain")
     }
-    // this comment doesnt get removed
-    // this comment does get removed - but only if theres another comment above it
+    // these comments
+    // will be deleted
     if exp.BoolValue("false") {
         fmt.Println("to be removed 2")
     }
@@ -155,7 +155,7 @@ func simplify_if_statement_false_comment_demo_multiline_comment_one_line() {
     } else {
         fmt.Println("remain")
     }
-    /* this comment doesnt get removed */
+    /* this comment will be deleted */
     if exp.BoolValue("false") {
         fmt.Println("to be removed 2")
     }

--- a/test-resources/java/feature_flag_system_1/control/expected/XPFlagCleanerPositiveCases.java
+++ b/test-resources/java/feature_flag_system_1/control/expected/XPFlagCleanerPositiveCases.java
@@ -74,6 +74,10 @@ class XPFlagCleanerPositiveCases {
     }
   }
 
+  public void check_comment_cleanup(){
+    System.out.println("Hellow World!");
+  }
+
   public void other_api_stale_flag() {
 
     System.out.println("Hi world");

--- a/test-resources/java/feature_flag_system_1/control/input/XPFlagCleanerPositiveCases.java
+++ b/test-resources/java/feature_flag_system_1/control/input/XPFlagCleanerPositiveCases.java
@@ -94,6 +94,14 @@ class XPFlagCleanerPositiveCases {
     }
   }
 
+  public void check_comment_cleanup(){
+    System.out.println("Hellow World!");
+    // Should be deleted
+    if (experimentation.isFlagTreated(TestExperimentName.STALE_FLAG)) {
+      System.out.println("Hello World");
+    }
+  }
+
   public void other_api_stale_flag() {
 
     if (experimentation.isFlagTreated(TestExperimentName.STALE_FLAG)) {

--- a/test-resources/kt/feature_flag_system_2/treated/expected/XPFlagCleanerInterfaceMethod.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/expected/XPFlagCleanerInterfaceMethod.kt
@@ -93,4 +93,8 @@ internal class XPFlagCleanerPositiveCases {
             println("Hi world")
         }
     }
+
+    fun check_comments(a: Int, z: Int) {
+        println("Hello World!")
+    }
 }

--- a/test-resources/kt/feature_flag_system_2/treated/input/XPFlagCleanerInterfaceMethod.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/input/XPFlagCleanerInterfaceMethod.kt
@@ -135,4 +135,12 @@ internal class XPFlagCleanerPositiveCases {
             println("Hi world")
         }
     }
+
+    fun check_comments(a: Int, z: Int) {
+        println("Hello World!")
+        // Should be deleted!
+        if (!experimentation.isStaleFeature().cachedValue) {
+            println("Hello World")
+        }
+    }
 }


### PR DESCRIPTION
**Bug Diagnosis** (#376):  This problem is only in`Go` (because of its grammar, in my observation). The problem is caused when the comment is associated to the last statement of a method body in `Go`. Diagnosis: 
Our comment fetching [algorithm](https://github.com/uber/piranha/blob/8edb8dbdc6da2c704efddc6894c7dcbf110414ad/src/models/piranha_arguments.rs#L357) looks for comments on lines on the same line as deleted element and some lines above it (determined by the `cleanup_comment_buffer` flag).  There is a caveat in this algorithm - (i) Get all the nodes that either start and end at [row] (ii) If **all** nodes are comments. 
Now lets take the `Go` case where the comment is associated to the last statement of a method body in `Go`. 
When we delete the last statement of the method body, now the last "statement" of the method body is a comment. 
For some reason, tree sitter reports that this last row is where the comment and the block end.  :| 

**Fix**: Add a field `ignore_node_for_comment` property to `PiranhaLanguage`, now our algorithm will ignore the node kinds when reasoning about **all** nodes that start/end at last row. 

**Test Plan** Added the test cases as reported in the issue. I added similar test cases for Java and Kotlin too, but I did not find this inconsistency for them (so did not have set the `ignore_node_for_comment` property for Java and Kotlin)