### PR TITLE
Added rules for ternary operator cleanup

### DIFF
--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -409,6 +409,29 @@ is_seed_rule = false
 
 #
 # Before
+# var v = true ? x : y
+#
+# After
+# var v = x
+#
+[[rules]]
+name = "ternary_true"
+query = """(
+(ternary_expression
+    condition:[(boolean_literal) @true  
+            (tuple_expression 
+                value: (boolean_literal) @true)]
+    if_true:(_) @block_true
+    ) @ternary_block
+(#eq? @true "true")
+)"""
+groups = ["if_cleanup"]
+replace_node = "ternary_block"
+replace = "@block_true"
+is_seed_rule = false
+
+#
+# Before
 #   guard false else {
 #       return f1()
 #   }
@@ -431,6 +454,28 @@ query = """(
 groups = ["guard_cleanup"]
 replace_node = "guard_block"
 replace = "@else_block"
+is_seed_rule = false
+
+#
+# var v = false ? x : y
+#
+# After
+# var v = y
+#
+[[rules]]
+name = "ternary_false"
+query = """(
+(ternary_expression
+    condition:[(boolean_literal) @false  
+            (tuple_expression 
+                value: (boolean_literal) @false)]
+    if_false:(_) @block_false
+    ) @ternary_block
+(#eq? @false "false")
+)"""
+groups = ["if_cleanup"]
+replace_node = "ternary_block"
+replace = "@block_false"
 is_seed_rule = false
 
 # Dummy rule that acts as a junction for all boolean based cleanups

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -158,4 +158,9 @@ class SampleClass {
     func checkGuardFalseWithAnd() {
         return
     }
+    
+    func checkTernary() {
+        var value = 2
+        var value2 = 3
+    }
 }

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -208,4 +208,9 @@ class SampleClass {
             return
         }
     }
+    
+    func checkTernary() {
+        var value = TestEnum.stale_flag_one.isEnabled || v2 ? 2 : 3
+        var value2 =  placeholder_false ? 2 : 3
+    }
 }


### PR DESCRIPTION
Rules added

```
Before
true ? x : y
After
x
```

```
Before
false ? x : y
After
y
```