### PR TITLE
[Swift Refactoring]: Add Function Scope in Swift Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ polyglot/piranha/demo/piranha
 target
 Cargo.lock
 tmp_test*
+env/

--- a/src/cleanup_rules/swift/scope_config.toml
+++ b/src/cleanup_rules/swift/scope_config.toml
@@ -21,6 +21,26 @@ generator = """(
 (#eq? @name "@cls_name")              
 )"""
 
+[[scopes]]
+name = "Function"
+[[scopes.rules]]
+matcher = """(
+    (function_declaration
+        name: (simple_identifier)? @name
+        (parameter)? @params
+        body: (function_body)
+    ) @function
+)"""
+generator = """(
+    (function_declaration
+        name: (simple_identifier)? @func_name
+        (parameter)? @parameters
+        body: (function_body)
+    ) @func
+    (#eq? @func_name "@name")
+    (#eq? @parameters "@params")
+)"""
+
 
 [[scopes]]
 name = "File"


### PR DESCRIPTION
This PR adds the function scope to the swift cleanup. This is important predecessor for other cleanup rules to follow.
Closes #404 
 