### PR TITLE
Fix (identifier && false) and (identifier || true) for Kotlin

### DIFF
--- a/src/cleanup_rules/kt/rules.toml
+++ b/src/cleanup_rules/kt/rules.toml
@@ -269,7 +269,7 @@ replace_node = "conjunction_expression"
 is_seed_rule = false
 
 # Before :
-#  abc() && false
+#  abc && false
 # After :
 #  false
 #
@@ -278,7 +278,11 @@ groups = ["boolean_expression_simplify"]
 name = "simplify_something_and_false"
 query = """
 (
-(conjunction_expression (_) @lhs 
+(conjunction_expression [(simple_identifier)
+                          (parenthesized_expression (simple_identifier))
+                          (boolean_literal)
+                          (parenthesized_expression (boolean_literal))
+                        ] @lhs 
                         [((boolean_literal) @rhs) (parenthesized_expression (boolean_literal) @rhs)] ) @conjunction_expression
 (#eq? @rhs "false")  
 )
@@ -288,7 +292,7 @@ replace_node = "conjunction_expression"
 is_seed_rule = false
 
 # Before :
-#  abc() || true
+#  abc || true
 # After :
 #  true
 #
@@ -297,7 +301,11 @@ groups = ["boolean_expression_simplify"]
 name = "simplify_something_or_true"
 query = """
 (
-(disjunction_expression (_) @lhs 
+(disjunction_expression [(simple_identifier)
+                          (parenthesized_expression (simple_identifier))
+                          (boolean_literal)
+                          (parenthesized_expression (boolean_literal))
+                        ] @lhs 
                         [((boolean_literal) @rhs) (parenthesized_expression (boolean_literal) @rhs)] ) @disjunction_expression
 (#eq? @rhs "true")  
 )"""

--- a/src/cleanup_rules/kt/rules.toml
+++ b/src/cleanup_rules/kt/rules.toml
@@ -309,7 +309,7 @@ query = """
                         [((boolean_literal) @rhs) (parenthesized_expression (boolean_literal) @rhs)] ) @disjunction_expression
 (#eq? @rhs "true")  
 )"""
-replace = "@lhs"
+replace = "true"
 replace_node = "disjunction_expression"
 is_seed_rule = false
 

--- a/test-resources/kt/feature_flag_system_1/control/expected/XPFlagCleanerCases.kt
+++ b/test-resources/kt/feature_flag_system_1/control/expected/XPFlagCleanerCases.kt
@@ -57,7 +57,7 @@ internal class XPFlagCleanerPositiveCases {
         tBool = false
         tBool = false
 
-        tBool = false
+        tBool = true
 
         tBool = tBool
         tBool = false

--- a/test-resources/kt/feature_flag_system_1/treated/expected/XPFlagCleanerCases.kt
+++ b/test-resources/kt/feature_flag_system_1/treated/expected/XPFlagCleanerCases.kt
@@ -128,11 +128,7 @@ internal class XPFlagCleanerPositiveCases {
     }
 
     fun or_compounded_with_not(x: Int, extra_toggle: Boolean): Int {
-        if (extra_toggle) {
-            return 0
-        } else {
-            return 1
-        }
+        return 0
     }
 
     fun remove_else_if(extra_toggle: Boolean): Int {

--- a/test-resources/kt/feature_flag_system_2/control/expected/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/control/expected/XPMethodChainCases.kt
@@ -44,7 +44,7 @@ internal class XPMethodChainCases {
                 println("!!!")
             }
             // simple_identifier || true
-            println("!!!")
+            println("Test for simple_identifier or true!!!")
             val spr = SomeParamRev.create(cp)
             // Does not match API- is reverse order
             if (spr.cachedValue.isStaleFeature()) {

--- a/test-resources/kt/feature_flag_system_2/control/expected/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/control/expected/XPMethodChainCases.kt
@@ -44,9 +44,7 @@ internal class XPMethodChainCases {
                 println("!!!")
             }
             // simple_identifier || true
-            if (a){
-                println("!!!")
-            }
+            println("!!!")
             val spr = SomeParamRev.create(cp)
             // Does not match API- is reverse order
             if (spr.cachedValue.isStaleFeature()) {

--- a/test-resources/kt/feature_flag_system_2/control/expected/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/control/expected/XPMethodChainCases.kt
@@ -38,13 +38,13 @@ internal class XPMethodChainCases {
             }
 
             if (sp.isOtherFlag().cachedValue && false) {
-                println("!!!")
+                println("LHS is not a simple identifier!!!")
             }
             if (sp.isOtherFlag().cachedValue) {
                 println("!!!")
             }
             // simple_identifier || true
-            println("Test for simple_identifier or true!!!")
+            println("Test for simple_identifier || true!!!")
             val spr = SomeParamRev.create(cp)
             // Does not match API- is reverse order
             if (spr.cachedValue.isStaleFeature()) {

--- a/test-resources/kt/feature_flag_system_2/control/expected/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/control/expected/XPMethodChainCases.kt
@@ -37,7 +37,14 @@ internal class XPMethodChainCases {
                 println("!!!")
             }
 
+            if (sp.isOtherFlag().cachedValue && false) {
+                println("!!!")
+            }
             if (sp.isOtherFlag().cachedValue) {
+                println("!!!")
+            }
+            // simple_identifier || true
+            if (a){
                 println("!!!")
             }
             val spr = SomeParamRev.create(cp)

--- a/test-resources/kt/feature_flag_system_2/control/input/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/control/input/XPMethodChainCases.kt
@@ -49,11 +49,11 @@ internal class XPMethodChainCases {
             }
             // simple_identifier && false, should be deleted
             if (a && sp.isStaleFeature().cachedValue){
-                println("!!!")
+                println("Test for simple identifier && false!!!")
             }
             // simple_identifier || true
             if (a || !sp.isStaleFeature().cachedValue){
-                println("!!!")
+                println("Test for simple_identifier || true!!!")
             }
             val spr = SomeParamRev.create(cp)
             // Does not match API- is reverse order

--- a/test-resources/kt/feature_flag_system_2/control/input/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/control/input/XPMethodChainCases.kt
@@ -47,6 +47,14 @@ internal class XPMethodChainCases {
             if (sp.isOtherFlag().cachedValue || sp.isStaleFeature().cachedValue) {
                 println("!!!")
             }
+            // simple_identifier && false, should be deleted
+            if (a && sp.isStaleFeature().cachedValue){
+                println("!!!")
+            }
+            // simple_identifier || true
+            if (a || !sp.isStaleFeature().cachedValue){
+                println("!!!")
+            }
             val spr = SomeParamRev.create(cp)
             // Does not match API- is reverse order
             if (spr.cachedValue.isStaleFeature()) {

--- a/test-resources/kt/feature_flag_system_2/control/input/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/control/input/XPMethodChainCases.kt
@@ -42,7 +42,7 @@ internal class XPMethodChainCases {
                 println("!!!")
             }
             if (sp.isOtherFlag().cachedValue && sp.isStaleFeature().cachedValue) {
-                println("!!!")
+                println("LHS is not a simple identifier!!!")
             }
             if (sp.isOtherFlag().cachedValue || sp.isStaleFeature().cachedValue) {
                 println("!!!")

--- a/test-resources/kt/feature_flag_system_2/treated/expected/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/expected/XPMethodChainCases.kt
@@ -40,10 +40,10 @@ internal class XPMethodChainCases {
                 println("!!!")
             }
             if (sp.isOtherFlag().cachedValue || true) {
-                println("!!!")
+                println("LHS is not a simple identifier!!!")
             }
             // simple_identifier || true
-            println("!!!")
+            println("Test for identifier || true!!!")
             
             val spr = SomeParamRev.create(cp)
             // Does not match API- is reverse order

--- a/test-resources/kt/feature_flag_system_2/treated/expected/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/expected/XPMethodChainCases.kt
@@ -43,9 +43,8 @@ internal class XPMethodChainCases {
                 println("!!!")
             }
             // simple_identifier || true
-            if (a){
-                println("!!!")
-            }
+            println("!!!")
+            
             val spr = SomeParamRev.create(cp)
             // Does not match API- is reverse order
             if (spr.cachedValue.isStaleFeature()) {

--- a/test-resources/kt/feature_flag_system_2/treated/expected/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/expected/XPMethodChainCases.kt
@@ -39,7 +39,11 @@ internal class XPMethodChainCases {
             if (sp.isOtherFlag().cachedValue) {
                 println("!!!")
             }
-            if (sp.isOtherFlag().cachedValue) {
+            if (sp.isOtherFlag().cachedValue || true) {
+                println("!!!")
+            }
+            // simple_identifier || true
+            if (a){
                 println("!!!")
             }
             val spr = SomeParamRev.create(cp)

--- a/test-resources/kt/feature_flag_system_2/treated/input/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/input/XPMethodChainCases.kt
@@ -45,15 +45,15 @@ internal class XPMethodChainCases {
                 println("!!!")
             }
             if (sp.isOtherFlag().cachedValue || sp.isStaleFeature().cachedValue) {
-                println("!!!")
+                println("LHS is not a simple identifier!!!")
             }
             // simple_identifier && false, should be deleted
             if (a && !sp.isStaleFeature().cachedValue){
-                println("!!!")
+                println("Test for identifier && false!!!")
             }
             // simple_identifier || true
             if (a || sp.isStaleFeature().cachedValue){
-                println("!!!")
+                println("Test for identifier || true!!!")
             }
             val spr = SomeParamRev.create(cp)
             // Does not match API- is reverse order

--- a/test-resources/kt/feature_flag_system_2/treated/input/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/input/XPMethodChainCases.kt
@@ -47,6 +47,14 @@ internal class XPMethodChainCases {
             if (sp.isOtherFlag().cachedValue || sp.isStaleFeature().cachedValue) {
                 println("!!!")
             }
+            // simple_identifier && false, should be deleted
+            if (a && !sp.isStaleFeature().cachedValue){
+                println("!!!")
+            }
+            // simple_identifier || true
+            if (a || sp.isStaleFeature().cachedValue){
+                println("!!!")
+            }
             val spr = SomeParamRev.create(cp)
             // Does not match API- is reverse order
             if (spr.cachedValue.isStaleFeature()) {


### PR DESCRIPTION
This PR solves issues around (identifier && false) and (identifier || true) for Kotlin. No cleanups if there is function call in case of identifier for the two cases. Solves Kotlin part of #286 