### PR TITLE
Fix (something || true) and (something && false) for go

### DIFF
--- a/src/cleanup_rules/go/rules.toml
+++ b/src/cleanup_rules/go/rules.toml
@@ -120,7 +120,7 @@ groups = ["boolean_expression_simplify"]
 is_seed_rule = false
 
 # Before :
-#  abc() && false
+#  abc && false
 # After :
 #  false
 #
@@ -131,9 +131,13 @@ query = """
     (binary_expression
         left : ([
                 (identifier)
+                (parenthesized_expression (identifier))
                 (true)
+                (parenthesized_expression (true))
                 (false)
+                (parenthesized_expression (false))
                 (selector_expression)
+                (parenthesized_expression (selector_expression))
             ]) @lhs
         operator : "&&"
         right: [(false) (parenthesized_expression (false))]
@@ -158,9 +162,13 @@ query = """
     (binary_expression
         left : ([
                 (identifier)
+                (parenthesized_expression (identifier))
                 (true)
+                (parenthesized_expression (true))
                 (false)
+                (parenthesized_expression (false))
                 (selector_expression)
+                (parenthesized_expression (selector_expression))
             ]) @lhs
         operator:"||"
         right: [(true) (parenthesized_expression (true))]

--- a/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/expected/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/expected/sample.go
@@ -25,8 +25,8 @@ func simplify_not() {
 }
 
 // simplify `!true` and `!false` and also:
-// true && something -> true
-// something && true -> true
+// true && something -> something
+// something && true -> something
 func simplify_true_and_something(something bool) {
     if something {
         fmt.Println("only something")
@@ -45,7 +45,7 @@ func simplify_true_and_something(something bool) {
 
 // simplify `!true` and `!false` and also:
 // false && something -> false
-// something && false -> true
+// something && false -> false
 func simplify_false_and_something(something bool) {
     fmt.Println("else 1")
     fmt.Println("else 2")
@@ -58,6 +58,16 @@ func simplify_false_and_something(something bool) {
         fmt.Println("keep 1")
     } else {
         fmt.Println("keep 2")
+    }
+
+    // function call && false
+    if f1() && false {
+        fmt.Println("keep as it is")
+    }
+
+    // function call || true
+    if f1() || true {
+        fmt.Println("keep as it is")
     }
 }
 

--- a/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/input/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/input/sample.go
@@ -42,8 +42,8 @@ func simplify_not() {
 }
 
 // simplify `!true` and `!false` and also:
-// true && something -> true
-// something && true -> true
+// true && something -> something
+// something && true -> something
 func simplify_true_and_something(something bool) {
     if exp.BoolValue("true") && something {
         fmt.Println("only something")
@@ -62,7 +62,7 @@ func simplify_true_and_something(something bool) {
 
 // simplify `!true` and `!false` and also:
 // false && something -> false
-// something && false -> true
+// something && false -> false
 func simplify_false_and_something(something bool) {
     if exp.BoolValue("false") && something {
         fmt.Println("only false")
@@ -96,6 +96,15 @@ func simplify_false_and_something(something bool) {
         fmt.Println("keep 1")
     } else {
         fmt.Println("keep 2")
+    }
+    // function call && false
+    if f1() && exp.BoolValue("false") {
+        fmt.Println("keep as it is")
+    }
+
+    // function call || true
+    if f1() || exp.BoolValue("true") {
+        fmt.Println("keep as it is")
     }
 }
 


### PR DESCRIPTION
This PR fixes Fix (something || true) and (something && false) for go. In case of function calls, there will be no cleanups for the two cases. Fixes #286 for Go.