### PR TITLE
Fix (identifier && false) and (identifier || true) for Java

### DIFF
--- a/src/cleanup_rules/java/rules.toml
+++ b/src/cleanup_rules/java/rules.toml
@@ -196,7 +196,7 @@ replace_node = "binary_expression"
 is_seed_rule = false
 
 # Before :
-#  abc() && false
+#  abc && false
 # After :
 #  false
 #
@@ -206,7 +206,14 @@ groups = ["boolean_expression_simplify"]
 query = """
 (
     (binary_expression
-        left : (_) @lhs
+        left : [
+            (identifier)
+            (parenthesized_expression (identifier))
+            (true)
+            (parenthesized_expression (true))
+            (false)
+            (parenthesized_expression (false))
+        ] @lhs
         operator : "&&"
         right: [(false) (parenthesized_expression (false))]
     )
@@ -217,7 +224,7 @@ replace_node = "binary_expression"
 is_seed_rule = false
 
 # Before :
-#  abc() || true
+#  abc || true
 # After :
 #  true
 #
@@ -227,12 +234,19 @@ name = "simplify_something_or_true"
 query = """
 (
     (binary_expression
-        left : (_) @lhs
+        left : [
+            (identifier)
+            (parenthesized_expression (identifier))
+            (true)
+            (parenthesized_expression (true))
+            (false)
+            (parenthesized_expression (false))
+        ] @lhs
         operator:"||"
         right: [(true) (parenthesized_expression (true))]
     )
 @binary_expression)"""
-replace = "@lhs"
+replace = "true"
 replace_node = "binary_expression"
 is_seed_rule = false
 

--- a/test-resources/java/feature_flag_system_1/control/expected/XPFlagCleanerPositiveCases.java
+++ b/test-resources/java/feature_flag_system_1/control/expected/XPFlagCleanerPositiveCases.java
@@ -67,11 +67,7 @@ class XPFlagCleanerPositiveCases {
 
   public void complex_conditional_contains_stale_flag(boolean tBool) {
 
-    if (tBool) {
-      System.out.println("Hello World");
-    } else {
-      System.out.println("Hi world");
-    }
+    System.out.println("Hello World");
   }
 
   public void check_comment_cleanup(){
@@ -89,7 +85,7 @@ class XPFlagCleanerPositiveCases {
 
     tBool = false;
 
-    tBool = false;
+    tBool = true;
 
     tBool = tBool;
 

--- a/test-resources/java/feature_flag_system_1/treated/expected/XPFlagCleanerPositiveCases.java
+++ b/test-resources/java/feature_flag_system_1/treated/expected/XPFlagCleanerPositiveCases.java
@@ -71,11 +71,7 @@ class XPFlagCleanerPositiveCases {
 
   public void complex_conditional_contains_stale_flag(boolean tBool) {
 
-    if (tBool) {
-      System.out.println("Hello World");
-    } else {
-      System.out.println("Hi world");
-    }
+    System.out.println("Hello World");
   }
 
   public void other_api_stale_flag() {
@@ -194,11 +190,7 @@ class XPFlagCleanerPositiveCases {
 
   public int or_compounded_with_not(int x, boolean extra_toggle) {
 
-    if (extra_toggle) {
-      return 0;
-    } else {
-      return 1;
-    }
+    return 0;
   }
 
   public int remove_else_if(boolean extra_toggle) {

--- a/test-resources/java/feature_flag_system_2/control/expected/XPMethodChainCases.java
+++ b/test-resources/java/feature_flag_system_2/control/expected/XPMethodChainCases.java
@@ -33,9 +33,17 @@ class XPMethodChainCases {
       System.out.println("!!!");
     }
 
+    if (sp.otherFlag().getCachedValue() && false) {	
+      System.out.println("!!!");	
+    }
+
     if (sp.otherFlag().getCachedValue()) {
       System.out.println("!!!");
     }
+
+    // test for identifier || true
+    System.out.println("!!!! Testing identifier disjunction true");
+
     SomeParamRev spr = SomeParamRev.create(cp);
     // Does not match API- is reverse order
     if (spr.getCachedValue().isStaleFeature()) {

--- a/test-resources/java/feature_flag_system_2/control/input/XPMethodChainCases.java
+++ b/test-resources/java/feature_flag_system_2/control/input/XPMethodChainCases.java
@@ -43,6 +43,14 @@ class XPMethodChainCases {
     if (sp.otherFlag().getCachedValue() || sp.isStaleFeature().getCachedValue()) {
       System.out.println("!!!");
     }
+    // test for identifier && false
+    if (a && sp.isStaleFeature().getCachedValue()){
+      System.out.println("!!! Testing identifier conjunction false");
+    }
+    // test for identifier || true
+    if (a || !sp.isStaleFeature().getCachedValue()){
+      System.out.println("!!!! Testing identifier disjunction true");
+    }
     SomeParamRev spr = SomeParamRev.create(cp);
     // Does not match API- is reverse order
     if (spr.getCachedValue().isStaleFeature()) {

--- a/test-resources/java/feature_flag_system_2/treated/expected/XPMethodChainCases.java
+++ b/test-resources/java/feature_flag_system_2/treated/expected/XPMethodChainCases.java
@@ -35,9 +35,12 @@ class XPMethodChainCases {
     if (sp.otherFlag().getCachedValue()) {
       System.out.println("!!!");
     }
-    if (sp.otherFlag().getCachedValue()) {
+    if (sp.otherFlag().getCachedValue() || true) {
       System.out.println("!!!");
     }
+    // test for identifier || true
+    System.out.println("!!!");
+    
     SomeParamRev spr = SomeParamRev.create(cp);
     // Does not match API- is reverse order
     if (spr.getCachedValue().isStaleFeature()) {

--- a/test-resources/java/feature_flag_system_2/treated/input/XPMethodChainCases.java
+++ b/test-resources/java/feature_flag_system_2/treated/input/XPMethodChainCases.java
@@ -43,6 +43,14 @@ class XPMethodChainCases {
     if (sp.otherFlag().getCachedValue() || sp.isStaleFeature().getCachedValue()) {
       System.out.println("!!!");
     }
+    // test for identifier || true
+    if (a || sp.isStaleFeature().getCachedValue()){
+      System.out.println("!!!");
+    }
+    // test for identifier && false
+    if (b && !sp.isStaleFeature().getCachedValue()){
+      System.out.println("!!! b");
+    }
     SomeParamRev spr = SomeParamRev.create(cp);
     // Does not match API- is reverse order
     if (spr.getCachedValue().isStaleFeature()) {


### PR DESCRIPTION
This PR fixes cleanup cases for (identifier && false) and (identifier || true) for Java cleanup rules. Issue: #286 