### PR TITLE
Fixed function scope for swift

### DIFF
--- a/src/cleanup_rules/swift/scope_config.toml
+++ b/src/cleanup_rules/swift/scope_config.toml
@@ -25,21 +25,52 @@ generator = """(
 name = "Function"
 [[scopes.rules]]
 matcher = """(
-    (function_declaration
-        name: (simple_identifier)? @name
-        (parameter)? @params
-        body: (function_body)
-    ) @function
+    [
+        (function_declaration
+            name: (simple_identifier) @m_function_with_param_name
+            (parameter) @m_function_with_param_params
+            body: (function_body)
+        )
+        (function_declaration
+            name: (simple_identifier) @m_function_without_param_name
+            .
+            body: (function_body)
+        )
+        (function_declaration
+            .
+            (parameter) @m_constructor_with_param_params
+            body: (function_body)
+        )
+        (function_declaration
+            .
+            body: (function_body) @m_constructor_without_param_body
+        )
+    ]@xdn
 )"""
 generator = """(
-    (function_declaration
-        name: (simple_identifier)? @func_name
-        (parameter)? @parameters
-        body: (function_body)
-    ) @func
-    (#eq? @func_name "@name")
-    (#eq? @parameters "@params")
-)"""
+    [
+        (((function_declaration
+            name: (simple_identifier) @g_function_with_param_name
+            (parameter) @g_function_with_param_params
+            body: (function_body)))
+        (#eq? @g_function_with_param_name "@m_function_with_param_name")
+        (#eq? @g_function_with_param_params "@m_function_with_param_params"))
+        (((function_declaration
+            name: (simple_identifier) @g_function_without_param_name
+            .
+            body: (function_body)))
+        (#eq? @g_function_without_param_name "@m_function_without_param_name"))
+        (((function_declaration
+            .
+            (parameter) @g_constructor_with_param_params
+            body: (function_body)))
+        (#eq? @g_constructor_with_param_params "@m_constructor_with_param_params"))
+        (((function_declaration
+            .
+            body: (function_body)@g_constructor_without_param_body))
+        (#eq? @g_constructor_without_param_body "@m_constructor_without_param_body"))
+    ]
+)@qdn"""
 
 
 [[scopes]]


### PR DESCRIPTION
Function scope for swift was flaky as eq doesn't work in tree-sitter query for optional matched patterns. For example in this case the defined eq wouldn't work
```
(
   (simple_identifier)? @variable
   (#eq? @variable "var")
)
```

To resolve this, created separate matcher and generators for the below defined 4 cases.

```
class DummyClass{
    init(){
    }

    func dummyFunction(){
    }

    func dummyFunction(a:String) {
    
    }

    init(a: String) {

    }
}

```


