### PR TITLE
Fix Kotlin bug at handling if statement blocks containing comments and statements

### DIFF
--- a/src/cleanup_rules/kt/rules.toml
+++ b/src/cleanup_rules/kt/rules.toml
@@ -66,7 +66,7 @@ query = """
 (
 (if_expression (_) (_) 
                (control_structure_body ((if_expression [((boolean_literal) @condition) (parenthesized_expression (boolean_literal) @condition)] 
-               (control_structure_body (_) ) @consquent
+               (control_structure_body) @consquent
                (_) @alternative) @if_expression) )) @outer_if
 (#eq? @condition "false")
 )
@@ -86,7 +86,7 @@ query = """
 (
 (if_expression (_) (_) 
                (control_structure_body ((if_expression [((boolean_literal) @condition) (parenthesized_expression (boolean_literal) @condition)] 
-               (control_structure_body (_) ) @consquent)) ) @alternative) @if_expression
+               (control_structure_body) @consquent)) ) @alternative) @if_expression
 (#eq? @condition "false")
 )
 """
@@ -105,7 +105,7 @@ name = "simplify_if_true"
 query = """
 (
 (if_expression [((boolean_literal) @condition) (parenthesized_expression (boolean_literal) @condition)] 
-               (control_structure_body (_) @consequence ) ) @if_expression
+               (control_structure_body (_)* @consequence ) ) @if_expression
 (#eq? @condition "true")
 )
 """
@@ -125,8 +125,8 @@ name = "simplify_if_true_with_alternative"
 query = """
 (
 (if_expression [((boolean_literal) @condition) (parenthesized_expression (boolean_literal) @condition)] 
-               (control_structure_body (_) @consequence ) 
-               (control_structure_body (_) ) @alternative) @if_expression
+               (control_structure_body (_)* @consequence ) 
+               (control_structure_body) @alternative) @if_expression
 (#eq? @condition "true")
 )
 """
@@ -137,7 +137,7 @@ is_seed_rule = false
 # Before : 
 #  if (false) { doSomething(); } else { doSomethingElse();}
 # After :
-#  { doSomethingElse(); } 
+#  doSomethingElse(); 
 #
 # Before : 
 #  if (false) { doSomething(); }
@@ -149,8 +149,8 @@ name = "simplify_if_false_with_alternative"
 query = """
 (
 (if_expression [((boolean_literal) @condition) (parenthesized_expression (boolean_literal) @condition)] 
-               (control_structure_body (_)? ) @consquent
-               (control_structure_body (_)? @alternative) ) @if_expression
+               (control_structure_body) @consquent
+               (control_structure_body (_)* @alternative) ) @if_expression
 (#eq? @condition "false")
 )"""
 replace = "@alternative"
@@ -167,7 +167,7 @@ name = "simplify_if_false"
 query = """
 (
 (if_expression [((boolean_literal) @condition) (parenthesized_expression (boolean_literal) @condition)] 
-               (control_structure_body (_)? ) @consquent) @if_expression
+               (control_structure_body) @consquent) @if_expression
 (#eq? @condition "false")
 )"""
 replace = ""

--- a/test-resources/kt/feature_flag_system_2/control/expected/XPFlagCleanerInterfaceMethod.kt
+++ b/test-resources/kt/feature_flag_system_2/control/expected/XPFlagCleanerInterfaceMethod.kt
@@ -25,6 +25,7 @@ internal class XPFlagCleanerPositiveCases {
     }
 
     fun conditional_with_else_contains_stale_flag() {
+        // Some comment
         println("Hi world")
     }
 

--- a/test-resources/kt/feature_flag_system_2/control/input/XPFlagCleanerInterfaceMethod.kt
+++ b/test-resources/kt/feature_flag_system_2/control/input/XPFlagCleanerInterfaceMethod.kt
@@ -31,6 +31,7 @@ internal class XPFlagCleanerPositiveCases {
         if (experimentation.isStaleFeature().cachedValue) {
             println("Hello World")
         } else {
+            // Some comment
             println("Hi world")
         }
     }

--- a/test-resources/kt/feature_flag_system_2/treated/expected/XPFlagCleanerInterfaceMethod.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/expected/XPFlagCleanerInterfaceMethod.kt
@@ -25,6 +25,7 @@ internal class XPFlagCleanerPositiveCases {
     }
 
     fun conditional_with_else_contains_stale_flag() {
+        // Some comment
         println("Hello World")
     }
 

--- a/test-resources/kt/feature_flag_system_2/treated/input/XPFlagCleanerInterfaceMethod.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/input/XPFlagCleanerInterfaceMethod.kt
@@ -29,6 +29,7 @@ internal class XPFlagCleanerPositiveCases {
 
     fun conditional_with_else_contains_stale_flag() {
         if (experimentation.isStaleFeature().cachedValue) {
+            // Some comment
             println("Hello World")
         } else {
             println("Hi world")


### PR DESCRIPTION
We were not handling scenarios when blocks contained statements and comments.
The problem is that in tree-sitter-kotlin `comment` is not subtype of `statement`. Its a sibling type. (if it makes sense).
Therefore I had to make it `(_)*` because `(_)` would only match first statement(s) or comment(s).

----
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #419

