### PR TITLE
Add enum scope for Java

### DIFF
--- a/src/cleanup_rules/java/scope_config.toml
+++ b/src/cleanup_rules/java/scope_config.toml
@@ -77,10 +77,17 @@ generator = """
 [[scopes]]
 name = "Class"
 [[scopes.rules]]
-matcher = "(class_declaration name:(_) @n) @c"
-generator = """
-(
-((class_declaration name:(_) @z) @qc)
+matcher = """(
+  [
+    (class_declaration name:(_) @n) @c
+    (enum_declaration name:(_) @n) @c
+  ]
+)"""
+generator = """(
+  [
+    ((class_declaration name:(_) @z) @qc)
+    ((enum_declaration name:(_) @z) @qc)
+  ]
 (#eq? @z "@n")
 )
 """

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -150,23 +150,21 @@ fn execute_piranha_and_check_result(
 /// # Arguments:
 /// * test_name: Name of the test (identifier)
 /// * relative_path: relative path such that `test-resources/<language>/<relative_path>` leads to a directory containing the folders `input` and `configurations`
-/// * expected_number_of_matches: expression returning the expected number of matches
-/// * matches_frequency: The expected frequency of the matches
+/// * matches_frequency: The expected frequency for each match
 ///
 /// Usage:
 /// ```
 /// create_match_tests! {
 ///  "java",
-///  test_a1:  "relative/path_1", 2;
-///  test_a2:  "relative/path_2", 3
-///  HashMap::from([("match_class", 2)])
+///  test_a1:  "relative/path_1", HashMap::from([("match_class", 2));
+///  test_a2:  "relative/path_2", HashMap::from([("match_class", 2), ("match_class_1", 1)])
+///  
 /// ;
 /// }
 /// ```
 macro_rules! create_match_tests {
   ($language: expr,
     $($test_name:ident: $path_to_test: expr,
-                        $expected_number_of_matches: expr,
                         $matches_frequency: expr
                         $(,$kw: ident = $value: expr)* ; )*) => {
     $(
@@ -185,10 +183,6 @@ macro_rules! create_match_tests {
         )*
       };
       let output_summaries = $crate::execute_piranha(&piranha_arguments);
-      assert_eq!(
-        output_summaries.iter().flat_map(|os| os.matches().iter()).count(),
-        $expected_number_of_matches
-      );
       super::assert_frequency_for_matches(&output_summaries, &$matches_frequency);
     }
   )*

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,8 +13,11 @@ Copyright (c) 2022 Uber Technologies, Inc.
 
 use crate::execute_piranha;
 use crate::models::piranha_arguments::PiranhaArguments;
+use crate::models::piranha_output::PiranhaOutputSummary;
 use crate::utilities::{eq_without_whitespace, read_file};
 
+use itertools::Itertools;
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use tempdir::TempDir;
@@ -72,6 +75,21 @@ fn copy_folder_to_temp_dir(src: &Path) -> TempDir {
     }
   }
   temp_dir
+}
+
+fn assert_frequency_for_matches(
+  summaries: &Vec<PiranhaOutputSummary>, match_freq: &HashMap<&str, u32>,
+) {
+  let frequencies: HashMap<String, u32> = summaries
+    .iter()
+    .flat_map(|x| x.matches())
+    .into_group_map_by(|x| x.0.clone())
+    .into_iter()
+    .map(|(k, v)| (k, v.len() as u32))
+    .collect();
+  for (matched_rule, count) in match_freq.iter() {
+    assert_eq!(frequencies[*matched_rule], *count)
+  }
 }
 
 /// Checks if the file updates returned by piranha are as expected.
@@ -133,19 +151,23 @@ fn execute_piranha_and_check_result(
 /// * test_name: Name of the test (identifier)
 /// * relative_path: relative path such that `test-resources/<language>/<relative_path>` leads to a directory containing the folders `input` and `configurations`
 /// * expected_number_of_matches: expression returning the expected number of matches
+/// * matches_frequency: The expected frequency of the matches
 ///
 /// Usage:
 /// ```
 /// create_match_tests! {
 ///  "java",
 ///  test_a1:  "relative/path_1", 2;
-///  test_a2:  "relative/path_2", 3;
+///  test_a2:  "relative/path_2", 3
+///  HashMap::from([("match_class", 2)])
+/// ;
 /// }
 /// ```
 macro_rules! create_match_tests {
   ($language: expr,
     $($test_name:ident: $path_to_test: expr,
-                        $expected_number_of_matches: expr
+                        $expected_number_of_matches: expr,
+                        $matches_frequency: expr
                         $(,$kw: ident = $value: expr)* ; )*) => {
     $(
     #[test]
@@ -167,6 +189,7 @@ macro_rules! create_match_tests {
         output_summaries.iter().flat_map(|os| os.matches().iter()).count(),
         $expected_number_of_matches
       );
+      super::assert_frequency_for_matches(&output_summaries, &$matches_frequency);
     }
   )*
   };

--- a/src/tests/test_piranha_go.rs
+++ b/src/tests/test_piranha_go.rs
@@ -11,14 +11,16 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+use std::collections::HashMap;
+
 use super::{create_match_tests, create_rewrite_tests, substitutions};
 
 use crate::models::default_configs::GO;
 
 create_match_tests! {
   GO,
-  test_match_only_for_loop: "structural_find/go_stmt_for_loop", 1;
-  test_match_only_go_stmt_for_loop:"structural_find/for_loop", 4;
+  test_match_only_for_loop: "structural_find/go_stmt_for_loop", 1, HashMap::from([("find_go_stmt_for_loop", 1)]);
+  test_match_only_go_stmt_for_loop:"structural_find/for_loop", 4, HashMap::from([("find_for", 4)]);
 }
 
 create_rewrite_tests! {

--- a/src/tests/test_piranha_go.rs
+++ b/src/tests/test_piranha_go.rs
@@ -19,8 +19,8 @@ use crate::models::default_configs::GO;
 
 create_match_tests! {
   GO,
-  test_match_only_for_loop: "structural_find/go_stmt_for_loop", 1, HashMap::from([("find_go_stmt_for_loop", 1)]);
-  test_match_only_go_stmt_for_loop:"structural_find/for_loop", 4, HashMap::from([("find_for", 4)]);
+  test_match_only_for_loop: "structural_find/go_stmt_for_loop", HashMap::from([("find_go_stmt_for_loop", 1)]);
+  test_match_only_go_stmt_for_loop:"structural_find/for_loop", HashMap::from([("find_for", 4)]);
 }
 
 create_rewrite_tests! {

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -24,7 +24,7 @@ use crate::{
   piranha_rule,
   utilities::eq_without_whitespace,
 };
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 create_rewrite_tests! {
   JAVA,
@@ -66,7 +66,7 @@ create_rewrite_tests! {
 
 create_match_tests! {
   JAVA,
-  test_java_match_only: "structural_find", 22;
+  test_java_match_only: "structural_find", 22, HashMap::from([("find_enum_constant", 1), ("find_method", 1), ("replace_isToggleEnabled_with_boolean_literal", 20)]);
 }
 
 #[test]

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -66,7 +66,7 @@ create_rewrite_tests! {
 
 create_match_tests! {
   JAVA,
-  test_java_match_only: "structural_find", 20;
+  test_java_match_only: "structural_find", 22;
 }
 
 #[test]

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -66,7 +66,7 @@ create_rewrite_tests! {
 
 create_match_tests! {
   JAVA,
-  test_java_match_only: "structural_find", 22, HashMap::from([("find_enum_constant", 1), ("find_method", 1), ("replace_isToggleEnabled_with_boolean_literal", 20)]);
+  test_java_match_only: "structural_find", HashMap::from([("find_enum_constant", 1), ("find_method", 1), ("replace_isToggleEnabled_with_boolean_literal", 20)]);
 }
 
 #[test]

--- a/src/tests/test_piranha_python.rs
+++ b/src/tests/test_piranha_python.rs
@@ -57,4 +57,4 @@ fn test_delete_modify_str_literal_from_list_via_cli() {
   _ = temp_dir.close();
 }
 
-create_match_tests!(PYTHON, test_match_only: "structural_find", 3, HashMap::from([("find_lists_with_str_literals", 3)]););
+create_match_tests!(PYTHON, test_match_only: "structural_find", HashMap::from([("find_lists_with_str_literals", 3)]););

--- a/src/tests/test_piranha_python.rs
+++ b/src/tests/test_piranha_python.rs
@@ -13,7 +13,7 @@ Copyright (c) 2022 Uber Technologies, Inc.
 
 use assert_cmd::prelude::{CommandCargoExt, OutputAssertExt};
 
-use std::{fs::File, path::Path, process::Command};
+use std::{collections::HashMap, fs::File, path::Path, process::Command};
 use tempdir::TempDir;
 
 use super::create_match_tests;
@@ -57,4 +57,4 @@ fn test_delete_modify_str_literal_from_list_via_cli() {
   _ = temp_dir.close();
 }
 
-create_match_tests!(PYTHON, test_match_only: "structural_find", 3;);
+create_match_tests!(PYTHON, test_match_only: "structural_find", 3, HashMap::from([("find_lists_with_str_literals", 3)]););

--- a/src/tests/test_piranha_ts.rs
+++ b/src/tests/test_piranha_ts.rs
@@ -18,7 +18,7 @@ use crate::models::default_configs::TYPESCRIPT;
 
 create_match_tests! {
   TYPESCRIPT,
-  test_find_fors_within_functions_not_within_whiles:  "structural_find/find_fors_within_functions_not_within_whiles", 1, HashMap::from([("find_fors_within_functions_not_within_whiles", 1)]);
-  test_find_fors_within_functions:"structural_find/find_fors_within_functions", 2, HashMap::from([("find_fors_within_functions", 2)]);
-  test_find_fors: "structural_find/find_fors", 3, HashMap::from([("find_fors", 3)]);
+  test_find_fors_within_functions_not_within_whiles:  "structural_find/find_fors_within_functions_not_within_whiles", HashMap::from([("find_fors_within_functions_not_within_whiles", 1)]);
+  test_find_fors_within_functions:"structural_find/find_fors_within_functions", HashMap::from([("find_fors_within_functions", 2)]);
+  test_find_fors: "structural_find/find_fors", HashMap::from([("find_fors", 3)]);
 }

--- a/src/tests/test_piranha_ts.rs
+++ b/src/tests/test_piranha_ts.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 /*
 Copyright (c) 2022 Uber Technologies, Inc.
 
@@ -16,7 +18,7 @@ use crate::models::default_configs::TYPESCRIPT;
 
 create_match_tests! {
   TYPESCRIPT,
-  test_find_fors_within_functions_not_within_whiles:  "structural_find/find_fors_within_functions_not_within_whiles", 1;
-  test_find_fors_within_functions:"structural_find/find_fors_within_functions", 2;
-  test_find_fors: "structural_find/find_fors", 3;
+  test_find_fors_within_functions_not_within_whiles:  "structural_find/find_fors_within_functions_not_within_whiles", 1, HashMap::from([("find_fors_within_functions_not_within_whiles", 1)]);
+  test_find_fors_within_functions:"structural_find/find_fors_within_functions", 2, HashMap::from([("find_fors_within_functions", 2)]);
+  test_find_fors: "structural_find/find_fors", 3, HashMap::from([("find_fors", 3)]);
 }

--- a/src/tests/test_piranha_tsx.rs
+++ b/src/tests/test_piranha_tsx.rs
@@ -19,7 +19,7 @@ use crate::models::default_configs::TSX;
 
 create_match_tests! {
   TSX,
-  test_ts_match_only_find_fors: "structural_find/find_jsx_elements", 4, HashMap::from([("find_jsx_elements", 4)]);
-  test_match_find_props_identifiers_within_b_jsx_elements: "structural_find/find_props_identifiers_within_b_jsx_elements", 2, HashMap::from([("find_props_identifiers_within_b_jsx_elements", 2)]);
-  test_find_props_identifiers_within_variable_declarators_not_within_divs: "structural_find/find_props_identifiers_within_variable_declarators_not_within_divs", 2, HashMap::from([("find_props_identifiers_within_variable_declarators_not_within_divs", 2)]);
+  test_ts_match_only_find_fors: "structural_find/find_jsx_elements", HashMap::from([("find_jsx_elements", 4)]);
+  test_match_find_props_identifiers_within_b_jsx_elements: "structural_find/find_props_identifiers_within_b_jsx_elements", HashMap::from([("find_props_identifiers_within_b_jsx_elements", 2)]);
+  test_find_props_identifiers_within_variable_declarators_not_within_divs: "structural_find/find_props_identifiers_within_variable_declarators_not_within_divs", HashMap::from([("find_props_identifiers_within_variable_declarators_not_within_divs", 2)]);
 }

--- a/src/tests/test_piranha_tsx.rs
+++ b/src/tests/test_piranha_tsx.rs
@@ -11,13 +11,15 @@ Copyright (c) 2022 Uber Technologies, Inc.
  limitations under the License.
 */
 
+use std::collections::HashMap;
+
 use super::create_match_tests;
 
 use crate::models::default_configs::TSX;
 
 create_match_tests! {
   TSX,
-  test_ts_match_only_find_fors: "structural_find/find_jsx_elements", 4;
-  test_match_find_props_identifiers_within_b_jsx_elements: "structural_find/find_props_identifiers_within_b_jsx_elements", 2;
-  test_find_props_identifiers_within_variable_declarators_not_within_divs: "structural_find/find_props_identifiers_within_variable_declarators_not_within_divs", 2;
+  test_ts_match_only_find_fors: "structural_find/find_jsx_elements", 4, HashMap::from([("find_jsx_elements", 4)]);
+  test_match_find_props_identifiers_within_b_jsx_elements: "structural_find/find_props_identifiers_within_b_jsx_elements", 2, HashMap::from([("find_props_identifiers_within_b_jsx_elements", 2)]);
+  test_find_props_identifiers_within_variable_declarators_not_within_divs: "structural_find/find_props_identifiers_within_variable_declarators_not_within_divs", 2, HashMap::from([("find_props_identifiers_within_variable_declarators_not_within_divs", 2)]);
 }

--- a/test-resources/java/structural_find/configurations/edges.toml
+++ b/test-resources/java/structural_find/configurations/edges.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The edges in this file specify the flow between the rules
+[[edges]]
+scope = "Class"
+from = "find_enum_constant"
+to = ["find_method"]

--- a/test-resources/java/structural_find/configurations/rules.toml
+++ b/test-resources/java/structural_find/configurations/rules.toml
@@ -34,3 +34,18 @@ query = """((
 (#eq? @name "isToggleEnabled")
 (#eq? @argument "STALE_FLAG")
 )"""
+
+
+[[rules]]
+name = "find_enum_constant"
+query = """
+    (
+    ((enum_constant name : (_) @n) @ec)       
+    (#eq? @n  "FOO")
+    )
+"""
+
+[[rules]]
+name = "find_method"
+query = "(method_declaration name: (_)@name ) @md"
+is_seed_rule = false

--- a/test-resources/java/structural_find/input/SampleEnum.java
+++ b/test-resources/java/structural_find/input/SampleEnum.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.uber.piranha;
+
+public enum SampleEnum {
+    FOO,
+    BAR;
+    public String getName() {
+        switch(this) {
+          case FOO:
+            return "foo";
+          case BAR:
+            return "bar";
+          }
+    }
+}
+
+public class SomeClass {
+    public void someMethod(){
+        System.out.println("Hello World!");
+    }
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -60,7 +60,7 @@ def test_piranha_match_only():
         dry_run=True,
     )
     output_summaries = execute_piranha(args)
-    assert len(output_summaries[0].matches) == 20
+    assert sum([len(summary.matches) for summary in output_summaries]) == 22
     for summary in output_summaries:
         assert _is_readable(str(summary))
         for rule, match in summary.matches:


### PR DESCRIPTION
This PR adds enum as "Class" scope for Java. 
Test Plan: Added a test case 

Kotlin AST treats enums and classes as `(class_declaration)` so we do not need to update the "Class" scope query for Kotlin