### PR TITLE
Expose allow-dirty-tree option for Python users

### DIFF
--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -42,10 +42,11 @@ class PiranhaArguments:
         cleanup_comments: Optional[bool] = None,
         cleanup_comments_buffer: Optional[int] = None,
         number_of_ancestors_in_parent_scope: Optional[int] = None,
-        delete_file_if_empty : Optional[bool] = None,
         delete_consecutive_new_lines : Optional[bool] = None,
-        path_to_output: Optional[str] = None
- 
+        global_tag_prefix: Optional[str] = 'GLOBAL_TAG',
+        delete_file_if_empty : Optional[bool] = None,
+        path_to_output: Optional[str] = None,
+        allow_dirty_ast : Optional[bool] = None
     ):
         """
         Constructs `PiranhaArguments`
@@ -65,9 +66,11 @@ class PiranhaArguments:
                  cleanup_comments (bool) : Enables deletion of associated comments
                  cleanup_comments_buffer (int): The number of lines to consider for cleaning up the comments
                  number_of_ancestors_in_parent_scope (int): The number of ancestors considered when PARENT rules
-                 delete_file_if_empty (bool): User option that determines whether an empty file will be deleted
                  delete_consecutive_new_lines (bool) : Replaces consecutive \ns  with a \n
+                 global_tag_prefix (str): the prefix for global tags
+                 delete_file_if_empty (bool): User option that determines whether an empty file will be deleted
                  path_to_output (str): Path to the output json file
+                 allow_dirty_ast (bool) : Allows syntax errors in the input source code 
         """
         ...
 

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -160,6 +160,7 @@ impl PiranhaArguments {
   /// * global_tag_prefix (string): the prefix for global tags
   /// * delete_file_if_empty (bool): User option that determines whether an empty file will be deleted
   /// * path_to_output_summary : Path to the file where the Piranha output summary should be persisted
+  /// * allow_dirty_ast : Allows syntax errors in the input source code
   /// Returns PiranhaArgument.
   #[new]
   fn py_new(
@@ -168,7 +169,7 @@ impl PiranhaArguments {
     dry_run: Option<bool>, cleanup_comments: Option<bool>, cleanup_comments_buffer: Option<i32>,
     number_of_ancestors_in_parent_scope: Option<u8>, delete_consecutive_new_lines: Option<bool>,
     global_tag_prefix: Option<String>, delete_file_if_empty: Option<bool>,
-    path_to_output_summary: Option<String>,
+    path_to_output_summary: Option<String>, allow_dirty_ast: Option<bool>,
   ) -> Self {
     let subs = substitutions
       .iter()
@@ -191,6 +192,7 @@ impl PiranhaArguments {
       global_tag_prefix = global_tag_prefix.unwrap_or_else(default_global_tag_prefix),
       delete_file_if_empty = delete_file_if_empty.unwrap_or_else(default_delete_file_if_empty),
       path_to_output_summary = path_to_output_summary,
+      allow_dirty_ast = allow_dirty_ast.unwrap_or_else(default_allow_dirty_ast),
     }
   }
 }


### PR DESCRIPTION
Add missing `--allow-dirty-tree` option for python users. 
Reorder the pyi definition to match the implementation 