### PR TITLE
Improve the Python interface

### DIFF
--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -33,8 +33,8 @@ class PiranhaArguments:
     def __init__(
         self,
         language: str,
-        substitutions: dict,
-        path_to_configurations: Optional[str],
+        substitutions: Optional[dict] = None,
+        path_to_configurations: Optional[str] = None,
         rule_graph: Optional[RuleGraph]= None,
         path_to_codebase: Optional[str] = None,
         code_snippet: Optional[str] = None,
@@ -55,9 +55,8 @@ class PiranhaArguments:
         ------------
             language: str
                 the target language
-            substitutions: dict
-                 Substitutions to instantiate the initial set of rules
             keyword arguments: _
+                 substitutions (dict) : Substitutions to instantiate the initial set of rules
                  path_to_configurations (str) : Directory containing the configuration files - `piranha_arguments.toml`, `rules.toml`, and  `edges.toml`
                  rule_graph (RuleGraph) : The rule graph constructed via RuleGraph DSL
                  path_to_codebase (str) : Path to source code folder or file

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -164,17 +164,22 @@ impl PiranhaArguments {
   /// Returns PiranhaArgument.
   #[new]
   fn py_new(
-    language: String, substitutions: &PyDict, path_to_configurations: Option<String>,
+    language: String, substitutions: Option<&PyDict>, path_to_configurations: Option<String>,
     rule_graph: Option<RuleGraph>, path_to_codebase: Option<String>, code_snippet: Option<String>,
     dry_run: Option<bool>, cleanup_comments: Option<bool>, cleanup_comments_buffer: Option<i32>,
     number_of_ancestors_in_parent_scope: Option<u8>, delete_consecutive_new_lines: Option<bool>,
     global_tag_prefix: Option<String>, delete_file_if_empty: Option<bool>,
     path_to_output_summary: Option<String>, allow_dirty_ast: Option<bool>,
   ) -> Self {
-    let subs = substitutions
-      .iter()
-      .map(|(k, v)| (k.to_string(), v.to_string()))
-      .collect_vec();
+    let subs = if substitutions.is_some() {
+      substitutions
+        .unwrap()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect_vec()
+    } else {
+      vec![]
+    };
 
     let rg = rule_graph.unwrap_or_else(|| RuleGraphBuilder::default().build());
     piranha_arguments! {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -55,7 +55,6 @@ def test_piranha_match_only():
     args = PiranhaArguments(
         path_to_configurations="test-resources/java/structural_find/configurations",
         language="java",
-        substitutions={},
         path_to_codebase="test-resources/java/structural_find/input",
         dry_run=True,
     )
@@ -127,9 +126,7 @@ import java.util.List;
 
     args = PiranhaArguments(
         path_to_codebase= "test-resources/java/insert_field_and_import/input",
-        path_to_configurations= "test-resources/java/insert_field_and_initializer/configurations",
         language="java",
-        substitutions={},
         rule_graph = rule_graph,
         dry_run=True,
     )


### PR DESCRIPTION
This PR updates the python interface for creating piranha arguments. Specifically it makes it optional for a user to provide substitutions. I also observed that, `path_to_configuration` appeared to be non-optional when using it via the pyi stub (though it is optional internally). I fixed the pyi file to reflect that.