### PR TITLE
Remove the piranha_arguments! macro

### DIFF
--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -182,23 +182,30 @@ impl PiranhaArguments {
     };
 
     let rg = rule_graph.unwrap_or_else(|| RuleGraphBuilder::default().build());
-    piranha_arguments! {
-      path_to_codebase = path_to_codebase.unwrap_or_else(default_path_to_codebase),
-      path_to_configurations = path_to_configurations.unwrap_or_else(default_path_to_configurations),
-      rule_graph = rg,
-      code_snippet = code_snippet.unwrap_or_else(default_code_snippet),
-      language = PiranhaLanguage::from(language.as_str()),
-      substitutions = subs,
-      dry_run = dry_run.unwrap_or_else(default_dry_run),
-      cleanup_comments = cleanup_comments.unwrap_or_else(default_cleanup_comments),
-      cleanup_comments_buffer = cleanup_comments_buffer.unwrap_or_else(default_cleanup_comments_buffer),
-      number_of_ancestors_in_parent_scope = number_of_ancestors_in_parent_scope.unwrap_or_else(default_number_of_ancestors_in_parent_scope),
-      delete_consecutive_new_lines = delete_consecutive_new_lines.unwrap_or_else(default_delete_consecutive_new_lines),
-      global_tag_prefix = global_tag_prefix.unwrap_or_else(default_global_tag_prefix),
-      delete_file_if_empty = delete_file_if_empty.unwrap_or_else(default_delete_file_if_empty),
-      path_to_output_summary = path_to_output_summary,
-      allow_dirty_ast = allow_dirty_ast.unwrap_or_else(default_allow_dirty_ast),
-    }
+    PiranhaArgumentsBuilder::default()
+      .path_to_codebase(path_to_codebase.unwrap_or_else(default_path_to_codebase))
+      .path_to_configurations(path_to_configurations.unwrap_or_else(default_path_to_configurations))
+      .rule_graph(rg)
+      .code_snippet(code_snippet.unwrap_or_else(default_code_snippet))
+      .language(PiranhaLanguage::from(language.as_str()))
+      .substitutions(subs)
+      .dry_run(dry_run.unwrap_or_else(default_dry_run))
+      .cleanup_comments(cleanup_comments.unwrap_or_else(default_cleanup_comments))
+      .cleanup_comments_buffer(
+        cleanup_comments_buffer.unwrap_or_else(default_cleanup_comments_buffer),
+      )
+      .number_of_ancestors_in_parent_scope(
+        number_of_ancestors_in_parent_scope
+          .unwrap_or_else(default_number_of_ancestors_in_parent_scope),
+      )
+      .delete_consecutive_new_lines(
+        delete_consecutive_new_lines.unwrap_or_else(default_delete_consecutive_new_lines),
+      )
+      .global_tag_prefix(global_tag_prefix.unwrap_or_else(default_global_tag_prefix))
+      .delete_file_if_empty(delete_file_if_empty.unwrap_or_else(default_delete_file_if_empty))
+      .path_to_output_summary(path_to_output_summary)
+      .allow_dirty_ast(allow_dirty_ast.unwrap_or_else(default_allow_dirty_ast))
+      .build()
   }
 }
 
@@ -209,20 +216,20 @@ impl PiranhaArguments {
 
   pub fn from_cli() -> Self {
     let p = PiranhaArguments::parse();
-    piranha_arguments! {
-      path_to_codebase = p.path_to_codebase().to_string(),
-      substitutions = p.substitutions.clone(),
-      language = p.language().clone(),
-      path_to_configurations = p.path_to_configurations().to_string(),
-      path_to_output_summary = p.path_to_output_summary().clone(),
-      delete_file_if_empty = *p.delete_file_if_empty(),
-      delete_consecutive_new_lines = *p.delete_consecutive_new_lines(),
-      global_tag_prefix = p.global_tag_prefix().to_string(),
-      number_of_ancestors_in_parent_scope = *p.number_of_ancestors_in_parent_scope(),
-      cleanup_comments_buffer = *p.cleanup_comments_buffer(),
-      cleanup_comments = *p.cleanup_comments(),
-      dry_run = *p.dry_run(),
-    }
+    PiranhaArgumentsBuilder::default()
+      .path_to_codebase(p.path_to_codebase().to_string())
+      .substitutions(p.substitutions.clone())
+      .language(p.language().clone())
+      .path_to_configurations(p.path_to_configurations().to_string())
+      .path_to_output_summary(p.path_to_output_summary().clone())
+      .delete_file_if_empty(*p.delete_file_if_empty())
+      .delete_consecutive_new_lines(*p.delete_consecutive_new_lines())
+      .global_tag_prefix(p.global_tag_prefix().to_string())
+      .number_of_ancestors_in_parent_scope(*p.number_of_ancestors_in_parent_scope())
+      .cleanup_comments_buffer(*p.cleanup_comments_buffer())
+      .cleanup_comments(*p.cleanup_comments())
+      .dry_run(*p.dry_run())
+      .build()
   }
 
   pub(crate) fn input_substitutions(&self) -> HashMap<String, String> {
@@ -297,41 +304,6 @@ fn get_rule_graph(_arg: &PiranhaArguments) -> RuleGraph {
 
   built_in_rules.merge(&user_defined_rules)
 }
-
-#[macro_export]
-/// This macro can be used to construct a PiranhaArgument (via the builder).'
-/// Allows to use builder pattern more "dynamically"
-///
-/// Usage:
-///
-/// ```ignore
-/// piranha_arguments! {
-///   path_to_codebase = "path/to/code/base".to_string(),
-///   language = "Java".to_string(),
-///   path_to_configurations = "path/to/configurations".to_string(),
-/// }
-/// ```
-///
-/// expands to
-///
-/// ```ignore
-/// PiranhaArgumentsBuilder::default()
-///      .path_to_codebase("path/to/code/base".to_string())
-///      .language("Java".to_string())
-///      .path_to_configurations("path/to/configurations".to_string())
-///      .build()
-/// ```
-///
-macro_rules! piranha_arguments {
-    ($($kw: ident = $value: expr,)*) => {
-      $crate::models::piranha_arguments::PiranhaArgumentsBuilder::default()
-      $(
-        .$kw($value)
-       )*
-      .build()
-    };
-}
-pub use piranha_arguments;
 
 #[cfg(test)]
 #[path = "unit_tests/piranha_arguments_test.rs"]

--- a/src/models/unit_tests/piranha_arguments_test.rs
+++ b/src/models/unit_tests/piranha_arguments_test.rs
@@ -16,14 +16,16 @@ use crate::{
   tests::substitutions,
 };
 
+use super::PiranhaArgumentsBuilder;
+
 #[test]
 #[should_panic(expected = "Invalid Piranha Argument. Missing `path_to_codebase` or `code_snippet`")]
 fn piranha_argument_invalid_no_codebase_and_snippet() {
-  let _ = piranha_arguments! {
-    path_to_configurations = "some/path".to_string(),
-    language = PiranhaLanguage::from(JAVA),
-    substitutions = substitutions! {"super_interface_name" => "SomeInterface"},
-  };
+  let _ = PiranhaArgumentsBuilder::default()
+    .path_to_configurations("some/path".to_string())
+    .language(PiranhaLanguage::from(JAVA))
+    .substitutions(substitutions! {"super_interface_name" => "SomeInterface"})
+    .build();
 }
 
 #[test]
@@ -31,11 +33,11 @@ fn piranha_argument_invalid_no_codebase_and_snippet() {
   expected = "Invalid Piranha arguments. Please either specify the `path_to_codebase` or the `code_snippet`. Not Both."
 )]
 fn piranha_argument_invalid_both_codebase_and_snippet() {
-  let _ = piranha_arguments! {
-    path_to_configurations = "some/path".to_string(),
-    path_to_codebase = "dev/null".to_string(),
-    code_snippet = "class A { }".to_string(),
-    language = PiranhaLanguage::from(JAVA),
-    substitutions = substitutions! {"super_interface_name" => "SomeInterface"},
-  };
+  let _ = PiranhaArgumentsBuilder::default()
+    .path_to_configurations("some/path".to_string())
+    .path_to_codebase("dev/null".to_string())
+    .code_snippet("class A { }".to_string())
+    .language(PiranhaLanguage::from(JAVA))
+    .substitutions(substitutions! {"super_interface_name" => "SomeInterface"})
+    .build();
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -174,14 +174,14 @@ macro_rules! create_match_tests {
       let _path= std::path::PathBuf::from("test-resources").join($language).join($path_to_test);
       let path_to_codebase = _path.join("input").to_str().unwrap().to_string();
       let path_to_configurations = _path.join("configurations").to_str().unwrap().to_string();
-      let piranha_arguments =  $crate::models::piranha_arguments::piranha_arguments!{
-        path_to_codebase = path_to_codebase,
-        path_to_configurations = path_to_configurations,
-        language= $crate::models::language::PiranhaLanguage::from($language),
+      let piranha_arguments =  $crate::models::piranha_arguments::PiranhaArgumentsBuilder::default()
+        .path_to_codebase(path_to_codebase)
+        .path_to_configurations(path_to_configurations)
+        .language($crate::models::language::PiranhaLanguage::from($language))
         $(
-          $kw = $value,
+          .$kw($value)
         )*
-      };
+      .build();
       let output_summaries = $crate::execute_piranha(&piranha_arguments);
       super::assert_frequency_for_matches(&output_summaries, &$matches_frequency);
     }
@@ -217,14 +217,14 @@ macro_rules! create_rewrite_tests {
       let _path= std::path::PathBuf::from("test-resources").join($language).join($path_to_test);
       let temp_dir= super::copy_folder_to_temp_dir(&_path.join("input"));
 
-      let piranha_arguments =  $crate::models::piranha_arguments::piranha_arguments!{
-        path_to_codebase = temp_dir.path().to_str().unwrap().to_string(),
-        path_to_configurations = _path.join("configurations").to_str().unwrap().to_string(),
-        language= $crate::models::language::PiranhaLanguage::from($language),
+      let piranha_arguments =  $crate::models::piranha_arguments::PiranhaArgumentsBuilder::default()
+        .path_to_codebase(temp_dir.path().to_str().unwrap().to_string())
+        .path_to_configurations(_path.join("configurations").to_str().unwrap().to_string())
+        .language($crate::models::language::PiranhaLanguage::from($language))
         $(
-          $kw = $value,
+          .$kw($value)
         )*
-      };
+      .build();
 
       super::execute_piranha_and_check_result(&piranha_arguments, &_path.join("expected"), $files_changed, true);
       // Delete temp_dir


### PR DESCRIPTION
Remove `piranha_arguments!` because its a hassle to keep updating its usages (I know you told me this did so:| - [Reference](https://github.com/uber/piranha/pull/325#pullrequestreview-1250784153) Lol! I thought I was clever.)
Anyhoo, I plan to improve the PiranhaArguments struct itself, so that using the API becomes simpler.So for now I am removing this macro.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #468
* #467
* __->__ #440

