### PR TITLE
[DO NOT LAND]: Name outermost node local var inline

### DIFF
--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -12,10 +12,21 @@
 
 # The edges in this file specify the flow between the rules.
 
+
+[[edges]]
+scope = "Function"
+from = "delete_variable_declaration"
+to = ["replace_identifier_with_value", "delete_parent_assignment"]
+
 [[edges]]
 scope = "Parent"
 from = "replace_expression_with_boolean_literal"
-to = ["boolean_literal_cleanup"]
+to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
+
+[[edges]]
+scope = "File"
+from = "variable_inline_cleanup"
+to = ["delete_variable_declaration"]
 
 [[edges]]
 scope = "Parent"

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -448,7 +448,7 @@ query = """(
                 ) @property_declaration
             )
         )
-    )
+    ) @fdecl
 )"""
 replace_node = "property_declaration"
 replace = ""
@@ -470,7 +470,7 @@ queries = ["""(
             ]
             )
         result: (boolean_literal) @val
-    )
+    ) @asign1
     (#eq? @var "@hvariable")
     (#not-eq? @val "@hvalue")
 )"""]
@@ -515,7 +515,7 @@ queries = ["""(
                 ]
             )
             result: (boolean_literal) @val
-        )
+        ) @assign2
         (#eq? @var "@avariable")
         (#not-eq? @val "@avalue")
 )"""]
@@ -564,7 +564,7 @@ queries = ["""(
             ]
         )
         result: (boolean_literal) @val
-    )
+    ) @assign3
     (#eq? @var "@avariable")
     (#not-eq? @val "@avalue")
 )"""]
@@ -587,7 +587,7 @@ matcher = "(function_declaration) @fd"
 queries = ["""(
     (parameter
         name: (simple_identifier) @var
-    )
+    ) @param
     (#eq? @var "@identifier")
 )"""]
 
@@ -600,7 +600,7 @@ queries = ["""(
             bound_identifier: (simple_identifier) @variable
         )
         value: (boolean_literal) @value
-    )
+    ) @pdecl
     (#eq? @variable "@identifier")
 )"""]
 
@@ -613,7 +613,7 @@ queries = ["""(
         suffix: (navigation_suffix
             suffix: (simple_identifier) @variable
         )
-    )
+    ) @nav
     (#eq? @variable "@identifier")
 )"""]
 

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -433,6 +433,190 @@ replace_node = "guard_block"
 replace = "@else_block"
 is_seed_rule = false
 
+# delete variables declared in a function scope
+[[rules]]
+name = "delete_variable_declaration"
+query = """(
+    (function_declaration
+        body: (function_body
+            (statements
+                (property_declaration
+                    name: (pattern
+                        bound_identifier: (simple_identifier) @hvariable
+                    )
+                    value: (boolean_literal) @hvalue
+                ) @property_declaration
+            )
+        )
+    )
+)"""
+replace_node = "property_declaration"
+replace = ""
+is_seed_rule = false
+
+# skip the rule if the variable is assigned with some other value in the class scope
+[[rules.constraints]]
+matcher = "(class_declaration) @cd"
+queries = ["""(
+    (assignment
+        target: (directly_assignable_expression
+            [ (navigation_expression
+                target: (self_expression)
+                suffix: (navigation_suffix
+                    suffix: (simple_identifier) @var
+                )
+                )
+                (simple_identifier) @var
+            ]
+            )
+        result: (boolean_literal) @val
+    )
+    (#eq? @var "@hvariable")
+    (#not-eq? @val "@hvalue")
+)"""]
+
+# rule to delete assignments like a = true subject to the mentioned constraints
+[[rules]]
+name = "delete_parent_assignment"
+query = """(
+    (assignment
+        target: (directly_assignable_expression
+            [ (navigation_expression
+                target: (self_expression)
+                suffix: (navigation_suffix
+                    suffix: (simple_identifier) @avariable
+                )
+                )
+                (simple_identifier) @avariable
+            ]
+            )
+        result: (boolean_literal) @avalue
+    ) @assignment
+    (#eq? @avariable "@hvariable")
+)"""
+replace_node = "assignment"
+replace = ""
+holes = ["hvariable", "hvalue"]
+is_seed_rule = false
+
+# skip running the rule if the enclosing scope is function and the variable is assigned a different value
+[[rules.constraints]]
+matcher = "(function_declaration) @fd"
+queries = ["""( 
+        (assignment
+            target: (directly_assignable_expression
+                [   (navigation_expression
+                        target: (self_expression)
+                        suffix: (navigation_suffix
+                            suffix: (simple_identifier) @var
+                        )
+                    )
+                    (simple_identifier) @var
+                ]
+            )
+            result: (boolean_literal) @val
+        )
+        (#eq? @var "@avariable")
+        (#not-eq? @val "@avalue")
+)"""]
+
+# skip running the rule if the variable is declared in the function scope with a different value
+[[rules.constraints]]
+matcher = "(function_declaration) @fd"
+queries = ["""(
+    (property_declaration
+        name: (pattern
+            bound_identifier: (simple_identifier) @var
+        )
+        value: (boolean_literal) @val
+    )@property_declaration
+    (#eq? @var "@avariable")
+    (#not-eq? @val "@avalue")
+)"""]
+
+# skip the rule if the variable is declared with a different value in the class
+[[rules.constraints]]
+matcher = "(class_declaration) @cd"
+queries = ["""(
+    (property_declaration
+        name: (pattern
+            bound_identifier: (simple_identifier) @var
+        )
+        value: (boolean_literal) @val
+    )@property_declaration
+    (#eq? @var "@avariable")
+    (#not-eq? @val "@avalue")
+)"""]
+
+# skip the rule if the variable is being assigned a different value in the class scope
+[[rules.constraints]]
+matcher = "(class_declaration) @cd"
+queries = ["""(
+    (assignment
+        target: (directly_assignable_expression
+            [   (navigation_expression
+                    target: (self_expression)
+                    suffix: (navigation_suffix
+                        suffix: (simple_identifier) @var
+                    )
+                )
+                (simple_identifier) @var
+            ]
+        )
+        result: (boolean_literal) @val
+    )
+    (#eq? @var "@avariable")
+    (#not-eq? @val "@avalue")
+)"""]
+
+# rule to replace the identifier with the value with the mentioned constraints
+[[rules]]
+name = "replace_identifier_with_value"
+query = """(
+    (simple_identifier) @identifier
+    (#eq? @identifier "@hvariable")
+)"""
+replace_node = "identifier"
+replace = "@hvalue"
+holes = ["hvariable", "hvalue"]
+is_seed_rule = false
+
+# skip the rule if the variable is one of the parameters of the function
+[[rules.constraints]]
+matcher = "(function_declaration) @fd"
+queries = ["""(
+    (parameter
+        name: (simple_identifier) @var
+    )
+    (#eq? @var "@identifier")
+)"""]
+
+# skip the rule if there is a declaration of the same variable
+[[rules.constraints]]
+matcher = "(class_declaration) @cd"
+queries = ["""(
+    (property_declaration
+        name: (pattern
+            bound_identifier: (simple_identifier) @variable
+        )
+        value: (boolean_literal) @value
+    )
+    (#eq? @variable "@identifier")
+)"""]
+
+# skip the rule if there is an assignment of the same variable
+[[rules.constraints]]
+matcher = "(class_declaration) @cd"
+queries = ["""(
+    (navigation_expression
+        target: (self_expression)
+        suffix: (navigation_suffix
+            suffix: (simple_identifier) @variable
+        )
+    )
+    (#eq? @variable "@identifier")
+)"""]
+
 # Dummy rule that acts as a junction for all boolean based cleanups
 # Let's say you want to define rules from A -> B, A -> C, D -> B, D -> C, ... 
 # A pattern here is - if there is an outgoing edge to B there is another to C.
@@ -444,4 +628,8 @@ is_seed_rule = false
 
 [[rules]]
 name = "statement_cleanup"
+is_seed_rule = false
+
+[[rules]]
+name = "variable_inline_cleanup"
 is_seed_rule = false

--- a/src/cleanup_rules/swift/scope_config.toml
+++ b/src/cleanup_rules/swift/scope_config.toml
@@ -25,21 +25,52 @@ generator = """(
 name = "Function"
 [[scopes.rules]]
 matcher = """(
-    (function_declaration
-        name: (simple_identifier)? @name
-        (parameter)? @params
-        body: (function_body)
-    ) @function
+    [
+        (function_declaration
+            name: (simple_identifier) @m_function_with_param_name
+            (parameter) @m_function_with_param_params
+            body: (function_body)
+        )
+        (function_declaration
+            name: (simple_identifier) @m_function_without_param_name
+            .
+            body: (function_body)
+        )
+        (function_declaration
+            .
+            (parameter) @m_constructor_with_param_params
+            body: (function_body)
+        )
+        (function_declaration
+            .
+            body: (function_body) @m_constructor_without_param_body
+        )
+    ]@xdn
 )"""
 generator = """(
-    (function_declaration
-        name: (simple_identifier)? @func_name
-        (parameter)? @parameters
-        body: (function_body)
-    ) @func
-    (#eq? @func_name "@name")
-    (#eq? @parameters "@params")
-)"""
+    [
+        (((function_declaration
+            name: (simple_identifier) @g_function_with_param_name
+            (parameter) @g_function_with_param_params
+            body: (function_body)))
+        (#eq? @g_function_with_param_name "@m_function_with_param_name")
+        (#eq? @g_function_with_param_params "@m_function_with_param_params"))
+        (((function_declaration
+            name: (simple_identifier) @g_function_without_param_name
+            .
+            body: (function_body)))
+        (#eq? @g_function_without_param_name "@m_function_without_param_name"))
+        (((function_declaration
+            .
+            (parameter) @g_constructor_with_param_params
+            body: (function_body)))
+        (#eq? @g_constructor_with_param_params "@m_constructor_with_param_params"))
+        (((function_declaration
+            .
+            body: (function_body)@g_constructor_without_param_body))
+        (#eq? @g_constructor_without_param_body "@m_constructor_without_param_body"))
+    ]
+)@qdn"""
 
 
 [[scopes]]

--- a/src/cleanup_rules/swift/scope_config.toml
+++ b/src/cleanup_rules/swift/scope_config.toml
@@ -68,7 +68,7 @@ generator = """(
         (((function_declaration
             .
             body: (function_body)@g_constructor_without_param_body))
-        (#eq? @g_constructor_without_param_body "@m_constructor_without_param_body"))
+            (#eq? @g_constructor_without_param_body "@m_constructor_without_param_body"))
     ]
 )@qdn"""
 

--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -39,4 +39,6 @@ create_rewrite_tests! {
       "treated_complement" => "false"
     },
     cleanup_comments = true, delete_file_if_empty= false;
+    test_local_variable_inline_file: "variable_inline", 1,
+    cleanup_comments = true, delete_file_if_empty= false;
 }

--- a/test-resources/swift/variable_inline/configurations/edges.toml
+++ b/test-resources/swift/variable_inline/configurations/edges.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+scope = "File"
+from = "test_rule_var_inline"
+to = ["variable_inline_cleanup"]

--- a/test-resources/swift/variable_inline/configurations/rules.toml
+++ b/test-resources/swift/variable_inline/configurations/rules.toml
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains rules to the specific feature flag API.
+[[rules]]
+name = "test_rule_var_inline"
+query = """(
+    (property_declaration
+        name: (pattern
+            bound_identifier: (simple_identifier) @var
+        )
+        value: (line_string_literal
+            text: (line_str_text) @val
+        )
+    ) @decl
+    (#eq? @val "foobar")
+)"""
+replace_node = "decl"
+replace = ""

--- a/test-resources/swift/variable_inline/expected/VariableInlining.swift
+++ b/test-resources/swift/variable_inline/expected/VariableInlining.swift
@@ -1,0 +1,84 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+// 
+// <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+// <p>http://www.apache.org/licenses/LICENSE-2.0
+// 
+// <p>Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+class TestFooBar{
+    func foobar(){
+        
+    }
+}
+
+class C1{
+    func f1(){
+        
+    }
+}
+
+class C2{
+    func f2(){
+        var a = true
+        a = false
+    }
+}
+
+class C3{
+    func f3(){
+        
+        if true{
+         f234()
+        }
+    }
+}
+
+class C4{
+    func f4(a: Bool){
+        if a{
+            f244()
+        }
+    }
+}
+
+class C5{
+    func f5(){
+        var a = true
+        if a {
+            a = false
+        }
+    }
+}
+
+class C6 {
+    func f6(){
+        
+        
+        if true {
+            someFunc()
+        }
+        if false {
+            doSomethingElse()
+        }
+    }
+}
+
+class C7 {
+    func f7a(){
+        
+        if true {
+            doSomething()
+        }
+    }
+
+    func f7b(){
+        
+        
+        if true {
+            doSomething()
+        }
+    }
+}

--- a/test-resources/swift/variable_inline/input/VariableInlining.swift
+++ b/test-resources/swift/variable_inline/input/VariableInlining.swift
@@ -1,0 +1,85 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+// 
+// <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+// <p>http://www.apache.org/licenses/LICENSE-2.0
+// 
+// <p>Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+class TestFooBar{
+    func foobar(){
+        var a = "foobar"
+    }
+}
+
+class C1{
+    func f1(){
+        var a = true
+    }
+}
+
+class C2{
+    func f2(){
+        var a = true
+        a = false
+    }
+}
+
+class C3{
+    func f3(){
+        var a = true
+        if a{
+         f234()
+        }
+    }
+}
+
+class C4{
+    func f4(a: Bool){
+        if a{
+            f244()
+        }
+    }
+}
+
+class C5{
+    func f5(){
+        var a = true
+        if a {
+            a = false
+        }
+    }
+}
+
+class C6 {
+    func f6(){
+        var a = true
+        var b = false
+        if a {
+            someFunc()
+        }
+        if b {
+            doSomethingElse()
+        }
+    }
+}
+
+class C7 {
+    func f7a(){
+        var a = true
+        if a {
+            doSomething()
+        }
+    }
+
+    func f7b(){
+        var a = true
+        var b = true
+        if b {
+            doSomething()
+        }
+    }
+}


### PR DESCRIPTION
@ketkarameya  This is the behaviour I was talking about. When I named the outermost node, few rules stopped working. Also checked after removing the equality in scope config, nothing changed. 