### PR TITLE
[Java] Simplify == and != operators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ tempdir = "0.3"
 serde_json = "1.0.82"
 # TODO: Update after https://github.com/fwcd/tree-sitter-kotlin/pull/71 lands
 tree-sitter-kotlin = { git = "https://github.com/ketkarameya/tree-sitter-kotlin.git", rev = "a87ddd003368e068563f1cc478a1b2a3f9d73b60" }
-# TODO: Update after https://github.com/uber/piranha/pull/442 lands
-tree-sitter-java = { git = "https://github.com/ketkarameya/tree-sitter-java.git", branch = "introduce-condition-expression" }
+# TODO: Update after next version is released (https://github.com/tree-sitter/tree-sitter-java/issues/146)
+tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java.git", rev = "c194ee5e6ede5f26cf4799feead4a8f165dcf14d" }
 # TODO: Update after: https://github.com/alex-pinkus/tree-sitter-swift/issues/278 resolves
 tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git", rev = "c92496b5273e4d3b094148fee51de371c94729bf" }
 tree-sitter-python = "0.20.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,8 @@ tempdir = "0.3"
 serde_json = "1.0.82"
 # TODO: Update after https://github.com/fwcd/tree-sitter-kotlin/pull/71 lands
 tree-sitter-kotlin = { git = "https://github.com/ketkarameya/tree-sitter-kotlin.git", rev = "a87ddd003368e068563f1cc478a1b2a3f9d73b60" }
-tree-sitter-java = "0.20.0"
+# TODO: Update after https://github.com/uber/piranha/pull/442 lands
+tree-sitter-java = { git = "https://github.com/ketkarameya/tree-sitter-java.git", branch = "introduce-condition-expression" }
 # TODO: Update after: https://github.com/alex-pinkus/tree-sitter-swift/issues/278 resolves
 tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git", rev = "c92496b5273e4d3b094148fee51de371c94729bf" }
 tree-sitter-python = "0.20.2"

--- a/src/cleanup_rules/java/rules.toml
+++ b/src/cleanup_rules/java/rules.toml
@@ -11,6 +11,19 @@
 
 # The language specific rules in this file are applied after the API specific change has been performed.
 
+# Before: 
+# (true)
+# After 
+# true
+
+[[rules]]
+name = "simplify_parenthesized_expression"
+query = "(parenthesized_expression ([(true) (false) (identifier)] @expression)) @p_expr"
+replace = "@expression"
+replace_node = "p_expr"
+is_seed_rule = false
+groups = ["boolean_expression_simplify"]
+
 # Before : 
 #  if (true) { doSomething(); }
 # After :
@@ -27,7 +40,7 @@ name = "simplify_if_statement_true"
 query = """
 (
     (if_statement
-        condition : ((parenthesized_expression [(true) (parenthesized_expression (true))]))
+        condition : (condition (true))
         consequence : ((statement) @consequence))
 @if_statement)
 """
@@ -50,7 +63,7 @@ name = "simplify_if_statement_false"
 query = """
 (
     (if_statement
-        condition : (parenthesized_expression [(false) @i (parenthesized_expression (false))])
+        condition : (condition (false))
         consequence : ((statement) @consequence)
         alternative : ((_) @alternative) ?)
 @if_statement)"""
@@ -70,7 +83,7 @@ query = """
 (
     (unary_expression
         operator: "!"
-        operand: [(false) (parenthesized_expression (false))])
+        operand: (false))
 @unary_expression)
 """
 replace = "true"
@@ -89,7 +102,7 @@ query = """
 (
     (unary_expression
         operator: \"!\"
-        operand: [(true) (parenthesized_expression (true))])
+        operand: (true))
 @unary_expression)
 """
 replace = "false"
@@ -146,7 +159,7 @@ name = "simplify_true_and_something"
 query = """
 (
     (binary_expression
-        left: [(true) (parenthesized_expression (true))]
+        left: (true)
         operator:"&&"
         right : (_) @rhs) 
 ) @binary_expression
@@ -168,7 +181,7 @@ query = """
     (binary_expression
         left : (_) @lhs
         operator:"&&"
-        right: [(true) (parenthesized_expression (true))]
+        right: (true)
     )
 @binary_expression)"""
 replace = "@lhs"
@@ -186,7 +199,7 @@ name = "simplify_false_and_something"
 query = """
 (
     (binary_expression
-        left: [(false) (parenthesized_expression (false))]
+        left: (false)
         operator : "&&"
         right : (_) @rhs
     )
@@ -208,14 +221,11 @@ query = """
     (binary_expression
         left : [
             (identifier)
-            (parenthesized_expression (identifier))
             (true)
-            (parenthesized_expression (true))
             (false)
-            (parenthesized_expression (false))
         ] @lhs
         operator : "&&"
-        right: [(false) (parenthesized_expression (false))]
+        right: (false)
     )
 @binary_expression)
 """
@@ -236,14 +246,11 @@ query = """
     (binary_expression
         left : [
             (identifier)
-            (parenthesized_expression (identifier))
             (true)
-            (parenthesized_expression (true))
             (false)
-            (parenthesized_expression (false))
         ] @lhs
         operator:"||"
-        right: [(true) (parenthesized_expression (true))]
+        right: (true)
     )
 @binary_expression)"""
 replace = "true"
@@ -261,7 +268,7 @@ name = "simplify_true_or_something"
 query = """
 (
     (binary_expression
-        left : [(true) (parenthesized_expression (true))]
+        left : (true)
         operator:"||"
         right: (_) @rhs
     )
@@ -284,7 +291,7 @@ query = """(
     binary_expression
         left : (_) @lhs
         operator:"||"
-        right: [(false) (parenthesized_expression (false))]
+        right: (false)
     )
 @binary_expression)"""
 replace = "@lhs"
@@ -302,7 +309,7 @@ name = "simplify_false_or_something"
 query = """
 (
     (binary_expression
-        left : [(false) (parenthesized_expression (false))]
+        left : (false)
         operator:"||"
         right: (_) @rhs
     )
@@ -352,9 +359,9 @@ name = "simplify_equals_equals_false"
 query = """
 (
     (binary_expression
-        left : [(false) @lhs (true) @lhs (parenthesized_expression (false) @lhs ) (parenthesized_expression (true) @lhs) (string_literal) (decimal_integer_literal) @lhs (decimal_floating_point_literal) @lhs]
+        left : [(false) @lhs (true) @lhs (string_literal) (decimal_integer_literal) @lhs (decimal_floating_point_literal) @lhs]
         operator:"=="
-        right: [(false) @rhs (true) @rhs (parenthesized_expression (false) @rhs) (parenthesized_expression (true) @rhs) (string_literal) @rhs (decimal_integer_literal) @rhs (decimal_floating_point_literal) @rhs]
+        right: [(false) @rhs (true) @rhs (string_literal) @rhs (decimal_integer_literal) @rhs (decimal_floating_point_literal) @rhs]
     )
 @binary_expression
 (#not-eq? @lhs @rhs)
@@ -377,9 +384,9 @@ name = "simplify_not_equals_false"
 query = """
 (
     (binary_expression
-        left : [(false) @lhs (true) @lhs (parenthesized_expression (false) @lhs ) (parenthesized_expression (true) @lhs) (string_literal) (decimal_integer_literal) @lhs (decimal_floating_point_literal) @lhs]
+        left : [(false) @lhs (true) @lhs (string_literal) (decimal_integer_literal) @lhs (decimal_floating_point_literal) @lhs]
         operator:"!="
-        right: [(false) @rhs (true) @rhs (parenthesized_expression (false) @rhs) (parenthesized_expression (true) @rhs) (string_literal) @rhs (decimal_integer_literal) @rhs (decimal_floating_point_literal) @rhs]
+        right: [(false) @rhs (true) @rhs (string_literal) @rhs (decimal_integer_literal) @rhs (decimal_floating_point_literal) @rhs]
     )
 @binary_expression
 (#eq? @lhs @rhs)
@@ -402,9 +409,9 @@ name = "simplify_not_equals_true"
 query = """
 (
     (binary_expression
-        left : [(false) @lhs (true) @lhs (parenthesized_expression (false) @lhs) (parenthesized_expression (true) @lhs) (string_literal) (decimal_integer_literal) @lhs (decimal_floating_point_literal) @lhs]
+        left : [(false) @lhs (true) @lhs (string_literal) (decimal_integer_literal) @lhs (decimal_floating_point_literal) @lhs]
         operator:"!="
-        right: [(false) @rhs (true) @rhs (parenthesized_expression (false) @rhs) (parenthesized_expression (true) @rhs) (string_literal) @rhs (decimal_integer_literal) @rhs (decimal_floating_point_literal) @rhs]
+        right: [(false) @rhs (true) @rhs (string_literal) @rhs (decimal_integer_literal) @rhs (decimal_floating_point_literal) @rhs]
     )
 @binary_expression
 (#not-eq? @lhs @rhs)
@@ -446,7 +453,7 @@ groups = ["if_cleanup"]
 name = "simplify_ternary_operator_true"
 query = """
 (
-    (ternary_expression condition: [(true) (parenthesized_expression (true))]
+    (ternary_expression condition: (true)
         consequence: (_)* @consequence
         alternative: (_)* @alternative)
 @ternary_expression)"""
@@ -464,7 +471,7 @@ groups = ["if_cleanup"]
 name = "simplify_ternary_operator_false"
 query = """
 (
-    (ternary_expression condition: [(false) (parenthesized_expression (false))]
+    (ternary_expression condition: (false)
         consequence: (_)* @consequence
         alternative: (_)* @alternative)
 @ternary_expression)"""
@@ -570,7 +577,7 @@ query = """
 ((field_declaration 
                 declarator: (variable_declarator 
                                     name: (_) @variable_name
-                                    value: [(true) (false) (parenthesized_expression (true)) (parenthesized_expression (false))] @init)) @field_declaration)
+                                    value: [(true) (false)] @init)) @field_declaration)
 )
 """
 replace = ""

--- a/src/cleanup_rules/java/rules.toml
+++ b/src/cleanup_rules/java/rules.toml
@@ -311,11 +311,113 @@ replace = "@rhs"
 replace_node = "binary_expression"
 is_seed_rule = false
 
+
+# Before: 
+#  (x) == x
+#  x == (x)
+#  x == x
+# After :
+#  true
+#  true
+#  true
+#
+[[rules]]
+groups = ["boolean_expression_simplify"]
+name = "simplify_equals_equals_true"
+query = """
+(
+    (binary_expression
+        left : [(parenthesized_expression (_) @lhs) (_) @lhs]
+        operator:"=="
+        right: [(parenthesized_expression (_) @rhs) (_) @rhs]
+    )
+@binary_expression
+(#eq? @lhs @rhs)
+)"""
+replace = "true"
+replace_node = "binary_expression"
+is_seed_rule = false
+
+
+# Before: 
+#  false == true 
+#  true == false
+# After :
+#  false
+#  false
+#
+[[rules]]
+groups = ["boolean_expression_simplify"]
+name = "simplify_equals_equals_false"
+query = """
+(
+    (binary_expression
+        left : [(false) @lhs (true) @lhs (parenthesized_expression (false) @lhs ) (parenthesized_expression (true) @lhs) (string_literal) (decimal_integer_literal) @lhs (decimal_floating_point_literal) @lhs]
+        operator:"=="
+        right: [(false) @rhs (true) @rhs (parenthesized_expression (false) @rhs) (parenthesized_expression (true) @rhs) (string_literal) @rhs (decimal_integer_literal) @rhs (decimal_floating_point_literal) @rhs]
+    )
+@binary_expression
+(#not-eq? @lhs @rhs)
+)"""
+replace = "false"
+replace_node = "binary_expression"
+is_seed_rule = false
+
+
+# Before: 
+#  false != false 
+#  true != true
+# After :
+#  false
+#  false
+#
+[[rules]]
+groups = ["boolean_expression_simplify"]
+name = "simplify_not_equals_false"
+query = """
+(
+    (binary_expression
+        left : [(false) @lhs (true) @lhs (parenthesized_expression (false) @lhs ) (parenthesized_expression (true) @lhs) (string_literal) (decimal_integer_literal) @lhs (decimal_floating_point_literal) @lhs]
+        operator:"!="
+        right: [(false) @rhs (true) @rhs (parenthesized_expression (false) @rhs) (parenthesized_expression (true) @rhs) (string_literal) @rhs (decimal_integer_literal) @rhs (decimal_floating_point_literal) @rhs]
+    )
+@binary_expression
+(#eq? @lhs @rhs)
+)"""
+replace = "false"
+replace_node = "binary_expression"
+is_seed_rule = false
+
+
+# Before: 
+#  false != true 
+#  true != false
+# After :
+#  true
+#  true
+#
+[[rules]]
+groups = ["boolean_expression_simplify"]
+name = "simplify_not_equals_true"
+query = """
+(
+    (binary_expression
+        left : [(false) @lhs (true) @lhs (parenthesized_expression (false) @lhs) (parenthesized_expression (true) @lhs) (string_literal) (decimal_integer_literal) @lhs (decimal_floating_point_literal) @lhs]
+        operator:"!="
+        right: [(false) @rhs (true) @rhs (parenthesized_expression (false) @rhs) (parenthesized_expression (true) @rhs) (string_literal) @rhs (decimal_integer_literal) @rhs (decimal_floating_point_literal) @rhs]
+    )
+@binary_expression
+(#not-eq? @lhs @rhs)
+)"""
+replace = "true"
+replace_node = "binary_expression"
+is_seed_rule = false
+
 # Before :
 #  {
 #    something();
 #    return 10;
-#    somethingMore();  
+#    somethingMore();
 #    return 100;
 #  } 
 # After :

--- a/test-resources/java/feature_flag_system_1/treated/expected/XPFlagCleanerPositiveCases.java
+++ b/test-resources/java/feature_flag_system_1/treated/expected/XPFlagCleanerPositiveCases.java
@@ -66,7 +66,10 @@ class XPFlagCleanerPositiveCases {
 
   public void conditional_with_else_contains_stale_flag() {
 
-    System.out.println("Hello World");
+    System.out.println("Hello World 1");
+    System.out.println("Hello World 2");
+    System.out.println("Hello World 3");
+    System.out.println("Hi world 4");
   }
 
   public void complex_conditional_contains_stale_flag(boolean tBool) {

--- a/test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java
+++ b/test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java
@@ -81,7 +81,7 @@ class XPFlagCleanerPositiveCases {
     if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG) == true) {
       System.out.println("Hello World 1");
     } else {
-      System.out.println("Hi world 2");
+      System.out.println("Hi world 1");
     }
 
     if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG) != false) {

--- a/test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java
+++ b/test-resources/java/feature_flag_system_1/treated/input/XPFlagCleanerPositiveCases.java
@@ -71,17 +71,35 @@ class XPFlagCleanerPositiveCases {
     if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
       System.out.println("Hello World");
     }
-    if (!experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
+    if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG) == false) {
       System.out.println("Hi World");
     }
   }
 
   public void conditional_with_else_contains_stale_flag() {
 
-    if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) {
-      System.out.println("Hello World");
+    if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG) == true) {
+      System.out.println("Hello World 1");
     } else {
-      System.out.println("Hi world");
+      System.out.println("Hi world 2");
+    }
+
+    if (experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG) != false) {
+      System.out.println("Hello World 2");
+    } else {
+      System.out.println("Hi world 2");
+    }
+
+    if ((experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) == true) {
+      System.out.println("Hello World 3");
+    } else {
+      System.out.println("Hi world 3");
+    }
+
+    if ((experimentation.isToggleEnabled(TestExperimentName.STALE_FLAG)) != true) {
+      System.out.println("Hello World 4");
+    } else {
+      System.out.println("Hi world 4");
     }
   }
 


### PR DESCRIPTION
Simplify the `==` operator to `true`/`false` whenever possible.

Added the following rules : 
`<lhs> == <rhs>`  => `true` iff `lhs` == `rhs`
`<l_literal>` == `<r_literal>` => `false` iff `l_literal` != `r_literal` 
`<l_literal>` != `<r_literal>` => `true` iff `l_literal` != `r_literal` 
`<l_literal>` != `<r_literal>` => `false` iff `l_literal` == `r_literal` 

Test Plan: CI | Adapted the tests.


(As separate diffs I will introduce this for Kotlin, Swift and Go)