### PR TITLE
Update commit hash to include constructor match fix in swift

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tree-sitter-kotlin = { git = "https://github.com/ketkarameya/tree-sitter-kotlin.
 # TODO: Update after next version is released (https://github.com/tree-sitter/tree-sitter-java/issues/146)
 tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java.git", rev = "c194ee5e6ede5f26cf4799feead4a8f165dcf14d" }
 # TODO: Update after: https://github.com/alex-pinkus/tree-sitter-swift/issues/278 resolves
-tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git", rev = "c92496b5273e4d3b094148fee51de371c94729bf" }
+tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git", rev = "895cd7814488cb32cf73f68a75458b4bc6d50a85" }
 tree-sitter-python = "0.20.2"
 tree-sitter-typescript = "0.20.1"
 # TODO: Update after https://github.com/tree-sitter/tree-sitter-go/pull/103 lands

--- a/test-resources/swift/cascade_file_delete/configurations/rules.toml
+++ b/test-resources/swift/cascade_file_delete/configurations/rules.toml
@@ -60,7 +60,7 @@ query = """
 (source_file
 ((class_declaration name: (type_identifier)
     (inheritance_specifier inherits_from: (user_type (type_identifier)@container ))
-        body: (class_body (function_declaration 
+        body: (class_body (init_declaration 
             body: (function_body (statements (call_expression
                 (call_suffix (value_arguments (value_argument 
                     value: (prefix_expression target: (simple_identifier) @name)))))))))))) @source_file

--- a/test-resources/swift/cascade_file_delete_custom_global_tag/configurations/rules.toml
+++ b/test-resources/swift/cascade_file_delete_custom_global_tag/configurations/rules.toml
@@ -61,7 +61,7 @@ query = """
 (source_file
 ((class_declaration name: (type_identifier)
     (inheritance_specifier inherits_from: (user_type (type_identifier)@container ))
-        body: (class_body (function_declaration 
+        body: (class_body (init_declaration 
             body: (function_body (statements (call_expression
                 (call_suffix (value_arguments (value_argument 
                     value: (prefix_expression target: (simple_identifier) @name)))))))))))) @source_file


### PR DESCRIPTION
This PR updates the commit hash pointing to @Satyam1749's tree-sitter-swift fork. The new commit in his fork includes the provision of catching constructor `init` nodes in swift. 