### PR TITLE
Add if boolean, (_) cleanup rules

### DIFF
--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -386,10 +386,10 @@ is_seed_rule = false
 
 # Before:
 # if true, anything { }
-# if true, someOptional { }
+# if anything, true { }
 # After: 
-# if someOptionalCall() { }
-# if someOptional { }
+# if anything { }
+# anything: [variable, function_call, variable_assignment, call_expression, equality check]
 [[rules]]
 name = "if_let_true_cleanup_literal_checks"
 query = """(

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -389,7 +389,8 @@ is_seed_rule = false
 # if anything, true { }
 # After: 
 # if anything { }
-# anything: [variable, function_call, variable_assignment, call_expression, equality check]
+# anything: [ variable, function_call, variable_assignment (to a function's return value, optional variable),
+# equality check (with a function's return value, variable ]
 [[rules]]
 name = "if_let_true_cleanup_literal_checks"
 query = """(

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -383,6 +383,40 @@ replace_node = "if_else_block"
 replace = "@alternatives"
 is_seed_rule = false
 
+
+# Before:
+# if true, anything { }
+# if true, someOptional { }
+# After: 
+# if someOptionalCall() { }
+# if someOptional { }
+[[rules]]
+name = "if_let_true_cleanup_literal_checks"
+query = """(
+    [
+        (if_statement
+            condition: (boolean_literal) @boollc
+            (_)
+            .(statements)
+        )
+        (if_statement
+            (_)
+            condition: (boolean_literal) @boollc
+            .(statements)
+        )
+        (if_statement
+            condition: (boolean_literal) @boollc
+            bound_identifier: (simple_identifier)
+            (statements)
+        )
+    ] @ifstl
+    (#eq? @boollc "true")
+)"""
+replace_node = "boollc"
+replace = ""
+groups = ["boolean_expression_simplify"]
+is_seed_rule = false
+
 #
 # Before
 #   guard true else {

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -163,4 +163,56 @@ class SampleClass {
         var value = 2
         var value2 = 3
     }
+
+    func checkIfShortCircuitStatementsWithBooleanPrefix() {
+        if  let a1 = something1a{
+            doSomething1a()
+        }
+
+        if  let b1 = something2a(){
+            doSomething2a()
+        }
+
+        if  c1 == something3a(){
+            doSomething3a()
+        }
+
+        if  d1 == something4a(){
+            doSomething4a()
+        }
+
+        if  something5a(){
+            doSomething5a()
+        }
+
+        if  something6a{
+            doSomething6a()
+        }
+    }
+
+    func checkIfShortCircuitStatementsWithBooleanSuffix() {
+        if let a2 = something1{
+            doSomething1b()
+        }
+
+        if let b2 = something2(){
+            doSomething2b()
+        }
+
+        if c2 == something3(){
+            doSomething3b()
+        }
+
+        if d2 == something4(){
+            doSomething4b()
+        }
+
+        if something5a(){
+            doSomething5b()
+        }
+
+        if something6b{
+            doSomething6b()
+        }
+    }
 }

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -213,4 +213,56 @@ class SampleClass {
         var value = TestEnum.stale_flag_one.isEnabled || v2 ? 2 : 3
         var value2 =  placeholder_false ? 2 : 3
     }
+
+    func checkIfShortCircuitStatementsWithBooleanPrefix() {
+        if TestEnum.stale_flag_one.isEnabled, let a1 = something1a{
+            doSomething1a()
+        }
+
+        if TestEnum.stale_flag_one.isEnabled, let b1 = something2a(){
+            doSomething2a()
+        }
+
+        if TestEnum.stale_flag_one.isEnabled, c1 == something3a(){
+            doSomething3a()
+        }
+
+        if TestEnum.stale_flag_one.isEnabled, d1 == something4a(){
+            doSomething4a()
+        }
+
+        if TestEnum.stale_flag_one.isEnabled, something5a(){
+            doSomething5a()
+        }
+
+        if TestEnum.stale_flag_one.isEnabled, something6a{
+            doSomething6a()
+        }
+    }
+
+    func checkIfShortCircuitStatementsWithBooleanSuffix() {
+        if let a2 = something1, TestEnum.stale_flag_one.isEnabled{
+            doSomething1b()
+        }
+
+        if let b2 = something2(), TestEnum.stale_flag_one.isEnabled{
+            doSomething2b()
+        }
+
+        if c2 == something3(), TestEnum.stale_flag_one.isEnabled{
+            doSomething3b()
+        }
+
+        if d2 == something4(), TestEnum.stale_flag_one.isEnabled{
+            doSomething4b()
+        }
+
+        if something5a(), TestEnum.stale_flag_one.isEnabled{
+            doSomething5b()
+        }
+
+        if something6b, TestEnum.stale_flag_one.isEnabled{
+            doSomething6b()
+        }
+    }
 }


### PR DESCRIPTION
This PR solves the following categories of refactorings for Swift:

- if true, variable { } => if variable { }
- if variable, true { } => if variable { }
- if true, f() { } => if f() { }
- if f(), true { } => if f() { }
- if true, variable == f1() { } => if variable == f1() { }
- if variable == f1(), true { } => if variable == f1() { }
- if true, variable == someOtherVariable { } => if variable == someOtherVariable { }
- if variable == someOtherVariable, true { } => if variable == someOtherVariable { }
- if true, let variable = f1() { } => if let variable = f1() { }
- if let variable = f1(), true { } => if let variable = f1() { }
- if true, let variable == f1() { } => if let variable == f1() { }
- if let variable == f1(), true { } => if let variable = f1() { }