### PR TITLE
Add new rules for Thrift RPC codes

### DIFF
--- a/demo/find_replace/thrift/sample.thrift
+++ b/demo/find_replace/thrift/sample.thrift
@@ -1,3 +1,89 @@
-exception InternalServerError { 
+exception Invalid {
 1: optional string message
 }
+
+exception BadRequest {
+1: optional string message
+}
+exception UserNotAllowed {
+1: optional string message
+}
+
+exception Precondition {
+1: optional string message
+}
+
+exception Range {
+1: optional string message
+}
+
+exception Unauthenticated {
+1: optional string message
+}
+
+exception Permission {
+1: optional string message
+}
+
+exception NotFound {
+1: optional string message
+}
+exception DoesNotExist {
+1: optional string message
+}
+
+exception Aborted {
+1: optional string message
+}
+
+exception Exists {
+1: optional string message
+}
+exception Exhausted {
+1: optional string message
+}
+
+exception Cancelled {
+1: optional string message
+}
+
+exception DataLoss {
+1: optional string message
+}
+
+exception UnknownException {
+1: optional string message
+}
+exception UnknownError {
+1: optional string message
+}
+exception InternalError {
+1: optional string message
+}
+exception InternalException {
+1: optional string message
+}
+exception ServiceError {
+1: optional string message
+}
+
+exception ServiceException {
+1: optional string message
+}
+exception ServerError {
+1: optional string message
+}
+exception ServerException {
+1: optional string message
+}
+
+exception Unimplemented {
+1: optional string message
+}
+exception Unavailable {
+1: optional string message
+}
+exception DeadlineExceeded {
+1: optional string message
+}
+

--- a/demo/find_replace/thrift/sample.thrift
+++ b/demo/find_replace/thrift/sample.thrift
@@ -86,4 +86,3 @@ exception Unavailable {
 exception DeadlineExceeded {
 1: optional string message
 }
-

--- a/demo/find_replace_demos.py
+++ b/demo/find_replace_demos.py
@@ -66,39 +66,9 @@ def java_demo():
     assert old_mtime < new_mtime
 
 
-def thrift_demo():
-
-    file_path = join(find_Replace_dir, "thrift", "sample.thrift")
-    r1 = Rule(
-        name="Match Exception Definition",
-        query="""(
-        (exception_definition (identifier) @exception_name) @exception_definition 
-        (#match? @exception_name "Internal")
-        )""",
-        replace_node="exception_definition",
-        replace="""@exception_definition (
-   rpc.code = "INTERNAL"
-)
-        """,
-        constraints={
-            Constraint(matcher="(exception_definition) @c_e",
-                       queries=["(annotation_definition) @ad"])
-        }
-    )
-    args = PiranhaArguments(
-        language="thrift",
-        path_to_codebase=file_path,
-        rule_graph=RuleGraph(rules=[r1], edges=[]),
-        substitutions={}
-    )
-    output = execute_piranha(args)
-    print(output)
-
-
 FORMAT = "%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
 logging.basicConfig(format=FORMAT)
 logging.getLogger().setLevel(logging.INFO)
 swift_demo()
 java_demo()
-thrift_demo()
 print("Completed running the Find/Replace demos")

--- a/demo/thrift_demos.py
+++ b/demo/thrift_demos.py
@@ -1,0 +1,70 @@
+from collections import Counter
+from os.path import join, dirname, getmtime
+from polyglot_piranha import Rule, RuleGraph, execute_piranha, PiranhaArguments, Constraint
+import logging
+from logging import info
+
+find_Replace_dir = join(dirname(__file__), "find_replace")
+
+def thrift_demo():
+
+    file_path = join(find_Replace_dir, "thrift", "sample.thrift")
+    r1 = Rule(
+        name="Match Exception Definition",
+        query="""(
+        (exception_definition (identifier) @exception_name) @exception_definition
+        (#match? @exception_name "@input_exception_name")
+        )""",
+        replace_node="exception_definition",
+        replace="""@exception_definition(
+    rpc.code = "@rpc_code"
+)""",
+        constraints={
+            Constraint(matcher="(exception_definition) @c_e",
+                       queries=["(annotation_definition) @ad"])
+        },
+        holes={
+            "input_exception_name", "rpc_code"
+        }
+    )
+    error_code_mapping = {  "Invalid" : "INVALID_ARGUMENT",
+                            "BadRequest" : "INVALID_ARGUMENT",
+                            "UserNotAllowed" : "INVALID_ARGUMENT",
+                            "Precondition" : "FAILED_PRECONDITION",
+                            "Range" : "OUT_OF_RANGE",
+                            "Unauthenticated" : "UNAUTHENTICATED",
+                            "Permission" : "PERMISSION_DENIED",
+                            "NotFound" : "NOT_FOUND",
+                            "DoesNotExist" : "NOT_FOUND",
+                            "Aborted" : "ABORTED",
+                            "Exists" : "ALREADY_EXISTS",
+                            "Exhausted" : "RESOURCE_EXHAUSTED",
+                            "Cancelled" : "CANCELLED",
+                            "DataLoss" : "DATA_LOSS",
+                            "UnknownError" : "UNKNOWN",
+                            "UnknownException" : "UNKNOWN",
+                            "InternalError" : "INTERNAL",
+                            "InternalException" : "INTERNAL",
+                            "ServiceError" : "INTERNAL",
+                            "ServiceException" : "INTERNAL",
+                            "ServerError" : "INTERNAL",
+                            "ServerException" : "INTERNAL",
+                            "Unimplemented" : "UNIMPLEMENTED",
+                            "Unavailable" : "UNAVAILABLE",
+                            "DeadlineExceeded" : "DEADLINE_EXCEEDED",
+                            }
+    for k, v in error_code_mapping.items() :
+        args = PiranhaArguments(
+            language="thrift",
+            path_to_codebase=file_path,
+            rule_graph=RuleGraph(rules=[r1], edges=[]),
+            substitutions={"input_exception_name" : k, "rpc_code" : v}
+        )
+        output = execute_piranha(args)
+        print(output)
+
+FORMAT = "%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
+logging.basicConfig(format=FORMAT)
+logging.getLogger().setLevel(logging.INFO)
+thrift_demo()
+print("Completed running Thrift refactoring")

--- a/demo/thrift_demos.py
+++ b/demo/thrift_demos.py
@@ -6,6 +6,7 @@ from logging import info
 
 find_Replace_dir = join(dirname(__file__), "find_replace")
 
+
 def thrift_demo():
 
     file_path = join(find_Replace_dir, "thrift", "sample.thrift")
@@ -27,41 +28,42 @@ def thrift_demo():
             "input_exception_name", "rpc_code"
         }
     )
-    error_code_mapping = {  "Invalid" : "INVALID_ARGUMENT",
-                            "BadRequest" : "INVALID_ARGUMENT",
-                            "UserNotAllowed" : "INVALID_ARGUMENT",
-                            "Precondition" : "FAILED_PRECONDITION",
-                            "Range" : "OUT_OF_RANGE",
-                            "Unauthenticated" : "UNAUTHENTICATED",
-                            "Permission" : "PERMISSION_DENIED",
-                            "NotFound" : "NOT_FOUND",
-                            "DoesNotExist" : "NOT_FOUND",
-                            "Aborted" : "ABORTED",
-                            "Exists" : "ALREADY_EXISTS",
-                            "Exhausted" : "RESOURCE_EXHAUSTED",
-                            "Cancelled" : "CANCELLED",
-                            "DataLoss" : "DATA_LOSS",
-                            "UnknownError" : "UNKNOWN",
-                            "UnknownException" : "UNKNOWN",
-                            "InternalError" : "INTERNAL",
-                            "InternalException" : "INTERNAL",
-                            "ServiceError" : "INTERNAL",
-                            "ServiceException" : "INTERNAL",
-                            "ServerError" : "INTERNAL",
-                            "ServerException" : "INTERNAL",
-                            "Unimplemented" : "UNIMPLEMENTED",
-                            "Unavailable" : "UNAVAILABLE",
-                            "DeadlineExceeded" : "DEADLINE_EXCEEDED",
-                            }
-    for k, v in error_code_mapping.items() :
+    error_code_mapping = {"Invalid": "INVALID_ARGUMENT",
+                          "BadRequest": "INVALID_ARGUMENT",
+                          "UserNotAllowed": "INVALID_ARGUMENT",
+                          "Precondition": "FAILED_PRECONDITION",
+                          "Range": "OUT_OF_RANGE",
+                          "Unauthenticated": "UNAUTHENTICATED",
+                          "Permission": "PERMISSION_DENIED",
+                          "NotFound": "NOT_FOUND",
+                          "DoesNotExist": "NOT_FOUND",
+                          "Aborted": "ABORTED",
+                          "Exists": "ALREADY_EXISTS",
+                          "Exhausted": "RESOURCE_EXHAUSTED",
+                          "Cancelled": "CANCELLED",
+                          "DataLoss": "DATA_LOSS",
+                          "UnknownError": "UNKNOWN",
+                          "UnknownException": "UNKNOWN",
+                          "InternalError": "INTERNAL",
+                          "InternalException": "INTERNAL",
+                          "ServiceError": "INTERNAL",
+                          "ServiceException": "INTERNAL",
+                          "ServerError": "INTERNAL",
+                          "ServerException": "INTERNAL",
+                          "Unimplemented": "UNIMPLEMENTED",
+                          "Unavailable": "UNAVAILABLE",
+                          "DeadlineExceeded": "DEADLINE_EXCEEDED",
+                          }
+    for k, v in error_code_mapping.items():
         args = PiranhaArguments(
             language="thrift",
             path_to_codebase=file_path,
             rule_graph=RuleGraph(rules=[r1], edges=[]),
-            substitutions={"input_exception_name" : k, "rpc_code" : v}
+            substitutions={"input_exception_name": k, "rpc_code": v}
         )
         output = execute_piranha(args)
         print(output)
+
 
 FORMAT = "%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
 logging.basicConfig(format=FORMAT)


### PR DESCRIPTION
This PR adds new rules to Thrift. It adds more tests in sample.thrift to cover a number of refactoring scenarios. It also separates thrift demos from other demos by updating find_replace_demos.py file.