### PR TITLE
Add raw value cleanup

### DIFF
--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -44,4 +44,9 @@ create_rewrite_tests! {
       "stale_flag" => "one"
     },
     cleanup_comments = true, delete_file_if_empty= false;
+    test_raw_value_cleanup: "variable_raw_value_cleanup", 1,
+      substitutions = substitutions! {
+        "stale_flag" => "stale_flag"
+      },
+      cleanup_comments = true, delete_file_if_empty= false;
 }


### PR DESCRIPTION
This PR simplifies case.rawValue access APIs for cases that are being cleaned up. It replaces all the calls to rawValue API with the raw string value. Please refer to tests to understand the kind of changes.