### PR TITLE
Var Inline [3/n]: Ad hoc var inline

### DIFF
--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -37,6 +37,11 @@ to = [
 ]
 
 [[edges]]
+scope = "Class"
+from = "delete_adhoc_declarations"
+to = ["replace_identifier_with_value", "delete_parent_assignment"]
+
+[[edges]]
 scope = "Parent"
 from = "replace_expression_with_boolean_literal"
 to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
@@ -45,6 +50,7 @@ to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
 scope = "Parent"
 from = "variable_inline_cleanup"
 to = [
+  "delete_adhoc_declarations",
   "delete_field_initialisation",
   "delete_field_initialisation_init",
   "delete_variable_declaration",

--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -37,11 +37,6 @@ to = [
 ]
 
 [[edges]]
-scope = "Class"
-from = "delete_adhoc_declarations"
-to = ["replace_identifier_with_value", "delete_parent_assignment"]
-
-[[edges]]
 scope = "Parent"
 from = "replace_expression_with_boolean_literal"
 to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
@@ -50,7 +45,6 @@ to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
 scope = "Parent"
 from = "variable_inline_cleanup"
 to = [
-  "delete_adhoc_declarations",
   "delete_field_initialisation",
   "delete_field_initialisation_init",
   "delete_variable_declaration",

--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -48,4 +48,6 @@ create_rewrite_tests! {
     cleanup_comments = true, delete_file_if_empty= false;
   test_field_variable_inline_file: "variable_inline/field_variable_inline", 1,
     cleanup_comments = true, delete_file_if_empty= false;
+  test_adhoc_variable_inline_file: "variable_inline/adhoc_variable_inline", 1,
+    cleanup_comments = true, delete_file_if_empty= false;
 }

--- a/test-resources/swift/variable_inline/adhoc_variable_inline/configurations/edges.toml
+++ b/test-resources/swift/variable_inline/adhoc_variable_inline/configurations/edges.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+scope = "Parent"
+from = "replace_expression_with_boolean_literal"
+to = ["variable_inline_cleanup"]

--- a/test-resources/swift/variable_inline/adhoc_variable_inline/configurations/rules.toml
+++ b/test-resources/swift/variable_inline/adhoc_variable_inline/configurations/rules.toml
@@ -1,0 +1,44 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# For @stale_flag_name = stale_flag and @treated = true
+# Before 
+#   placeholder_false
+# After 
+#   false
+#
+[[rules]]
+name = "test_rule_replace_false_placeholder"
+query = """(
+(simple_identifier) @variable
+(#eq? @variable "placeholder_false")
+)"""
+replace_node = "variable"
+replace = "false"
+groups = ["replace_expression_with_boolean_literal"]
+
+#
+# For @stale_flag_name = stale_flag and @treated = true
+# Before 
+#   placeholder_false
+# After 
+#   false
+#
+[[rules]]
+name = "test_rule_replace_true_placeholder"
+query = """(
+(simple_identifier) @variable
+(#eq? @variable "placeholder_true")
+)"""
+replace_node = "variable"
+replace = "true"
+groups = ["replace_expression_with_boolean_literal"]

--- a/test-resources/swift/variable_inline/adhoc_variable_inline/expected/AdhocVariableInlining.swift
+++ b/test-resources/swift/variable_inline/adhoc_variable_inline/expected/AdhocVariableInlining.swift
@@ -1,0 +1,22 @@
+class C1{
+    func f1(){
+        f.subscribe(
+            onNext: { x in 
+                
+            }
+        )
+    }
+}
+
+class C2{
+    var a
+
+    init(){
+        if something{
+            a = true
+            doSomething()
+        } else {
+            a = false
+        }
+    }
+}

--- a/test-resources/swift/variable_inline/adhoc_variable_inline/input/AdhocVariableInlining.swift
+++ b/test-resources/swift/variable_inline/adhoc_variable_inline/input/AdhocVariableInlining.swift
@@ -1,0 +1,29 @@
+class C1{
+    var a = placeholder_true
+    func f1(){
+        f.subscribe(
+            onNext: { x in 
+                var b = placeholder_false
+                if b {
+                    doSomething()
+                }
+            }
+        )
+    }
+}
+
+class C2{
+    var a
+
+    init(){
+        if something{
+            var b = placeholder_true
+            if b {
+                a = placeholder_true
+                doSomething()
+            }
+        } else {
+            a = false
+        }
+    }
+}


### PR DESCRIPTION
Add tests for adhoc variable inline. The rules are not there because local variable inline automatically handles the adhoc declaration anywhere inside the function due to the matcher `function_declaration` in constraint without any query. 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #459
* #458

