### PR TITLE
Gh/adarsh np/15/base - Var inline 3/n (Add tests for Adhoc var inline)

### DIFF
--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -19,6 +19,24 @@ from = "delete_variable_declaration"
 to = ["replace_identifier_with_value", "delete_parent_assignment"]
 
 [[edges]]
+scope = "Class"
+from = "delete_field_initialisation_init"
+to = [
+  "replace_self_identifier_with_value",
+  "replace_identifier_with_value",
+  "delete_field_declaration",
+]
+
+[[edges]]
+scope = "Class"
+from = "delete_field_initialisation"
+to = [
+  "replace_self_identifier_with_value",
+  "replace_identifier_with_value",
+  "delete_parent_assignment",
+]
+
+[[edges]]
 scope = "Parent"
 from = "replace_expression_with_boolean_literal"
 to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
@@ -26,7 +44,11 @@ to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
 [[edges]]
 scope = "Parent"
 from = "variable_inline_cleanup"
-to = ["delete_variable_declaration"]
+to = [
+  "delete_field_initialisation",
+  "delete_field_initialisation_init",
+  "delete_variable_declaration",
+]
 
 [[edges]]
 scope = "Parent"

--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -37,6 +37,11 @@ to = [
 ]
 
 [[edges]]
+scope = "Class"
+from = "delete_adhoc_declarations"
+to = ["replace_identifier_with_value", "delete_parent_assignment"]
+
+[[edges]]
 scope = "Parent"
 from = "replace_expression_with_boolean_literal"
 to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
@@ -45,6 +50,7 @@ to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
 scope = "Parent"
 from = "variable_inline_cleanup"
 to = [
+  "delete_adhoc_declarations",
   "delete_field_initialisation",
   "delete_field_initialisation_init",
   "delete_variable_declaration",

--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -37,11 +37,6 @@ to = [
 ]
 
 [[edges]]
-scope = "Class"
-from = "delete_adhoc_declarations"
-to = ["replace_identifier_with_value", "delete_parent_assignment"]
-
-[[edges]]
 scope = "Parent"
 from = "replace_expression_with_boolean_literal"
 to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
@@ -50,7 +45,6 @@ to = ["boolean_literal_cleanup", "variable_inline_cleanup"]
 scope = "Parent"
 from = "variable_inline_cleanup"
 to = [
-  "delete_adhoc_declarations",
   "delete_field_initialisation",
   "delete_field_initialisation_init",
   "delete_variable_declaration",

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -576,10 +576,10 @@ replace = ""
 holes = ["hvariable", "hvalue"]
 is_seed_rule = false
 
-# skip the rule if the variable is declared with a different value in the class scope
 [[rules.constraints]]
 matcher = "(class_declaration) @cd"
 queries = [
+  # skip the rule if the variable is declared with a different value in the class scope
   """(
         (property_declaration
             name: (pattern
@@ -609,6 +609,14 @@ queries = [
         (#eq? @var "@avariable")
         (#not-eq? @val "@avalue")
     )""",
+
+  # skip the rule if the variable is one of the parameters of some function
+  """(
+        (parameter
+            name: (simple_identifier) @c1var
+        )
+        (#eq? @c1var "@avariable")
+    )""",
 ]
 
 # rule to replace the identifier with the value with the mentioned constraints
@@ -623,20 +631,17 @@ replace = "@hvalue"
 holes = ["hvariable", "hvalue"]
 is_seed_rule = false
 
-# skip the rule if the variable is one of the parameters of the function
-[[rules.constraints]]
-matcher = "(function_declaration) @fd"
-queries = ["""(
-    (parameter
-        name: (simple_identifier) @var
-    )
-    (#eq? @var "@identifier")
-)"""]
-
-# skip the rule if there is a declaration of the same variable
 [[rules.constraints]]
 matcher = "(class_declaration) @cd"
 queries = [
+  # skip the rule if the variable is one of the parameters of some function
+  """(
+        (parameter
+            name: (simple_identifier) @c1var
+        )
+        (#eq? @c1var "@identifier")
+    )""",
+  # skip the rule if there is a declaration of the same variable
   """(
         (property_declaration
             name: (pattern
@@ -649,14 +654,201 @@ queries = [
 
   # skip the rule if it is accessed in the self.x manner
   """(
+        (navigation_expression
+            target: (self_expression)
+            suffix: (navigation_suffix
+                suffix: (simple_identifier) @variable
+            )
+        )
+        (#eq? @variable "@identifier")
+    )""",
+]
+
+[[rules]]
+name = "delete_field_declaration"
+query = """(
+            (property_declaration
+                name: (pattern
+                    bound_identifier: (simple_identifier) @avariable
+                )
+            ) @property_declaration
+    (#eq? @avariable "@hvariable")
+)"""
+replace_node = "property_declaration"
+replace = ""
+holes = ["hvariable"]
+is_seed_rule = false
+
+[[rules.constraints]]
+matcher = "(class_declaration) @ccd"
+# rule to replace field variable used as self.x subject to the mentioned constraints
+[[rules]]
+name = "replace_self_identifier_with_value"
+query = """(
     (navigation_expression
         target: (self_expression)
         suffix: (navigation_suffix
-            suffix: (simple_identifier) @variable
+            suffix: (simple_identifier) @identifier
         )
-    )
-    (#eq? @variable "@identifier")
-)""",
+    ) @rep
+    (#eq? @identifier "@hvariable")
+)"""
+replace_node = "rep"
+replace = "@hvalue"
+holes = ["hvariable", "hvalue"]
+is_seed_rule = false
+
+[[rules.constraints]]
+matcher = "(class_declaration) @cd"
+queries = [
+  # skip the rule if the variable is one of the parameters of some function
+  """(
+        (parameter
+            name: (simple_identifier) @c1var
+        )
+        (#eq? @c1var "@identifier")
+    )""",
+  # skip the rule if the variable declaration exists
+  """(
+        (property_declaration
+            name: (pattern
+                bound_identifier: (simple_identifier) @variable
+            )
+            value: (boolean_literal) @value
+        )
+        (#eq? @variable "@identifier")
+    )""",
+  # skip the rule if the variable is assigned a different value in the class scope
+  """( 
+        (assignment
+            target: (directly_assignable_expression
+                [   (navigation_expression
+                        target: (self_expression)
+                        suffix: (navigation_suffix
+                            suffix: (simple_identifier) @var
+                        )
+                    )
+                    (simple_identifier) @var
+                ]
+            )
+            result: (boolean_literal) @val
+        )
+        (#eq? @var "@hvariable")
+        (#not-eq? @val "@hvalue")
+    )""",
+]
+
+# rule to delete field initialisation: var a = true in class scope
+[[rules]]
+name = "delete_field_initialisation"
+query = """(
+            (property_declaration
+                name: (pattern
+                    bound_identifier: (simple_identifier) @hvariable
+                )
+                value: (boolean_literal) @hvalue
+            ) @property_declaration
+)"""
+replace_node = "property_declaration"
+replace = ""
+is_seed_rule = false
+
+[[rules.constraints]]
+matcher = "(class_declaration) @cd"
+queries = [
+  # skip the rule if the variable is one of the parameters of some function
+  """(
+        (parameter
+            name: (simple_identifier) @c1var
+        )
+        (#eq? @c1var "@hvariable")
+    )""",
+  # skip the rule if variable is assigned a different value than the initial in some method
+  """(
+        (assignment
+            target: (directly_assignable_expression
+                [ (navigation_expression
+                    target: (self_expression)
+                    suffix: (navigation_suffix
+                        suffix: (simple_identifier) @var
+                    )
+                    )
+                    (simple_identifier) @var
+                ]
+            )
+            result: (boolean_literal) @val
+        )
+        (#eq? @var "@hvariable")
+        (#not-eq? @val "@hvalue")
+    )""",
+]
+
+
+# rule to delete field initialised in the init subject to the mentioned constraints
+[[rules]]
+name = "delete_field_initialisation_init"
+query = """(
+            (assignment
+                target: (directly_assignable_expression
+                    [ (navigation_expression
+                        target: (self_expression)
+                        suffix: (navigation_suffix
+                            suffix: (simple_identifier) @hvariable
+                        )
+                        )
+                        (simple_identifier) @hvariable
+                    ]
+                    )
+                result: (boolean_literal) @hvalue
+            ) @assignment
+)"""
+replace_node = "assignment"
+replace = ""
+is_seed_rule = false
+
+[[rules.constraints]]
+matcher = "(init_declaration) @cid"
+
+
+[[rules.constraints]]
+matcher = "(class_declaration) @cd"
+queries = [
+  # skip the rule if the variable is one of the parameters of some function
+  """(
+        (parameter
+            name: (simple_identifier) @c1var
+        )
+        (#eq? @c1var "@hvariable")
+    )""",
+  # skip the rule if the target field is assigned somewhere with a different value
+  """( 
+        (assignment
+            target: (directly_assignable_expression
+                [   (navigation_expression
+                        target: (self_expression)
+                        suffix: (navigation_suffix
+                            suffix: (simple_identifier) @var
+                        )
+                    )
+                    (simple_identifier) @var
+                ]
+            )
+            result: (boolean_literal) @val
+        )
+        (#eq? @var "@hvariable")
+        (#not-eq? @val "@hvalue")
+    )""",
+  # skip the rule if the target variable is declared with some other value
+  """(
+        (property_declaration
+            name: (pattern
+                bound_identifier: (simple_identifier) @var
+            )
+            value: (boolean_literal) @val
+        )@property_declaration
+        (#eq? @var "@hvariable")
+        (#not-eq? @val "@hvalue")
+    )""",
 ]
 
 # Dummy rule that acts as a junction for all boolean based cleanups

--- a/src/cleanup_rules/swift/scope_config.toml
+++ b/src/cleanup_rules/swift/scope_config.toml
@@ -41,6 +41,22 @@ generator = """(
     (#eq? @parameters "@params")
 )"""
 
+[[scopes]]
+name = "Constructor"
+[[scopes.rules]]
+matcher = """(
+    (init_declaration
+        (parameter)? @params
+        body: (function_body)
+    )
+)"""
+generator = """(
+    (init_declaration)
+        (parameter)? @parameters
+        body: (function_body)
+    )
+    (#eq? @parameters "@params")
+)"""
 
 [[scopes]]
 name = "File"

--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -48,4 +48,6 @@ create_rewrite_tests! {
     cleanup_comments = true, delete_file_if_empty= false;
   test_field_variable_inline_file: "variable_inline/field_variable_inline", 1,
     cleanup_comments = true, delete_file_if_empty= false;
+  test_adhoc_variable_inline_file: "variable_inline/adhoc_variable_inline", 1,
+    cleanup_comments = true, delete_file_if_empty= false;
 }

--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -46,4 +46,6 @@ create_rewrite_tests! {
     cleanup_comments = true, delete_file_if_empty= false;
   test_local_variable_inline_file: "variable_inline/local_variable_inline", 1,
     cleanup_comments = true, delete_file_if_empty= false;
+  test_field_variable_inline_file: "variable_inline/field_variable_inline", 1,
+    cleanup_comments = true, delete_file_if_empty= false;
 }

--- a/test-resources/swift/variable_inline/adhoc_variable_inline/configurations/edges.toml
+++ b/test-resources/swift/variable_inline/adhoc_variable_inline/configurations/edges.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+scope = "Parent"
+from = "replace_expression_with_boolean_literal"
+to = ["variable_inline_cleanup"]

--- a/test-resources/swift/variable_inline/adhoc_variable_inline/configurations/rules.toml
+++ b/test-resources/swift/variable_inline/adhoc_variable_inline/configurations/rules.toml
@@ -1,0 +1,44 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# For @stale_flag_name = stale_flag and @treated = true
+# Before 
+#   placeholder_false
+# After 
+#   false
+#
+[[rules]]
+name = "test_rule_replace_false_placeholder"
+query = """(
+(simple_identifier) @variable
+(#eq? @variable "placeholder_false")
+)"""
+replace_node = "variable"
+replace = "false"
+groups = ["replace_expression_with_boolean_literal"]
+
+#
+# For @stale_flag_name = stale_flag and @treated = true
+# Before 
+#   placeholder_false
+# After 
+#   false
+#
+[[rules]]
+name = "test_rule_replace_true_placeholder"
+query = """(
+(simple_identifier) @variable
+(#eq? @variable "placeholder_true")
+)"""
+replace_node = "variable"
+replace = "true"
+groups = ["replace_expression_with_boolean_literal"]

--- a/test-resources/swift/variable_inline/adhoc_variable_inline/expected/AdhocVariableInlining.swift
+++ b/test-resources/swift/variable_inline/adhoc_variable_inline/expected/AdhocVariableInlining.swift
@@ -1,0 +1,22 @@
+class C1{
+    func f1(){
+        f.subscribe(
+            onNext: { x in 
+                
+            }
+        )
+    }
+}
+
+class C2{
+    var a
+
+    init(){
+        if something{
+            a = true
+            doSomething()
+        } else {
+            a = false
+        }
+    }
+}

--- a/test-resources/swift/variable_inline/adhoc_variable_inline/input/AdhocVariableInlining.swift
+++ b/test-resources/swift/variable_inline/adhoc_variable_inline/input/AdhocVariableInlining.swift
@@ -1,0 +1,29 @@
+class C1{
+    var a = placeholder_true
+    func f1(){
+        f.subscribe(
+            onNext: { x in 
+                var b = placeholder_false
+                if b {
+                    doSomething()
+                }
+            }
+        )
+    }
+}
+
+class C2{
+    var a
+
+    init(){
+        if something{
+            var b = placeholder_true
+            if b {
+                a = placeholder_true
+                doSomething()
+            }
+        } else {
+            a = false
+        }
+    }
+}

--- a/test-resources/swift/variable_inline/field_variable_inline/configurations/edges.toml
+++ b/test-resources/swift/variable_inline/field_variable_inline/configurations/edges.toml
@@ -10,6 +10,6 @@
 # limitations under the License.
 
 [[edges]]
-scope = "File"
+scope = "Parent"
 from = "replace_expression_with_boolean_literal"
 to = ["variable_inline_cleanup"]

--- a/test-resources/swift/variable_inline/field_variable_inline/configurations/edges.toml
+++ b/test-resources/swift/variable_inline/field_variable_inline/configurations/edges.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+scope = "File"
+from = "replace_expression_with_boolean_literal"
+to = ["variable_inline_cleanup"]

--- a/test-resources/swift/variable_inline/field_variable_inline/configurations/rules.toml
+++ b/test-resources/swift/variable_inline/field_variable_inline/configurations/rules.toml
@@ -1,0 +1,40 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Before 
+#   placeholder_false
+# After 
+#   false
+#
+[[rules]]
+name = "test_rule_replace_false_placeholder"
+query = """(
+(simple_identifier) @variable
+(#eq? @variable "placeholder_false")
+)"""
+replace_node = "variable"
+replace = "false"
+groups = ["replace_expression_with_boolean_literal"]
+
+# Before 
+#   placeholder_false
+# After 
+#   false
+#
+[[rules]]
+name = "test_rule_replace_true_placeholder"
+query = """(
+(simple_identifier) @variable
+(#eq? @variable "placeholder_true")
+)"""
+replace_node = "variable"
+replace = "true"
+groups = ["replace_expression_with_boolean_literal"]

--- a/test-resources/swift/variable_inline/field_variable_inline/expected/FieldVariableInline.swift
+++ b/test-resources/swift/variable_inline/field_variable_inline/expected/FieldVariableInline.swift
@@ -1,0 +1,296 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+
+// <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+// <p>http://www.apache.org/licenses/LICENSE-2.0
+
+// <p>Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+class C1{
+
+
+    init(){}
+
+    func f1(){
+
+    }
+}
+
+class C2{
+    var a = true
+
+    init(){}
+
+    func f2(){
+        a = false
+    }
+}
+
+class C3{
+
+
+    init(){}
+
+    func f3(){
+
+    }
+}
+
+class C4{
+    var a = true
+
+    init(){}
+
+    func f4(){
+        self.a = false
+    }
+}
+
+class C5{
+
+
+    func f5(){
+        doSomething()
+    }
+}
+
+class C6{
+
+
+    func f6(){
+        doSomething()
+    }
+}
+
+class C7{
+
+
+    func f7(){
+        doSomething()
+    }
+}
+
+class C8{
+
+
+    func f8(){
+        doSomething()
+    }
+}
+
+class C9{
+    var a = true
+
+    func f9a(){
+        a = false
+    }
+
+    func f9b(){
+        if a {
+            doSomething()
+        }
+    }
+}
+
+class C10{
+    var a = true
+
+    func f10a(){
+        self.a = false
+    }
+
+    func f10b(){
+        if self.a {
+            doSomething()
+        }
+    }
+}
+
+class C11{
+    var a = true
+
+    func f11a(){
+        a = true
+    }
+
+    func f11b(){
+        a = false
+    }
+}
+
+class C12{
+    var a
+    init(){
+        a = true
+        if a {
+            doSomething()
+        }
+    }
+
+    func f12(){
+        a = false
+    }
+}
+
+class C13{
+
+    init(){
+        doSomething()
+    }
+
+
+
+
+    func f13(){
+        doSomething()
+    }
+
+}
+
+class C14{
+
+    var a
+
+    init(a: Bool){
+
+        a = true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+    func f14(){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+class C15{
+
+    var a
+
+    init(){
+
+        a = true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+    func f15(a: Bool){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+class C16{
+
+    init(){
+        doSomething()
+    }
+
+    func f16(){
+        doSomething()
+
+    }
+
+}
+
+class C17{
+
+    var a
+
+    init(a: Bool){
+
+        self.a = true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+    func f17(){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+class C18{
+
+    var a
+
+    init(){
+
+        self.a = true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+    func f18(a: Bool){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+class C19{
+    var a = true
+
+    init(){
+        a = false
+    }
+}
+
+class C20{
+    var a
+
+    init(){
+        a = false
+    }
+
+    func f1(){
+        var a = true
+    }
+}

--- a/test-resources/swift/variable_inline/field_variable_inline/input/FieldVariableInline.swift
+++ b/test-resources/swift/variable_inline/field_variable_inline/input/FieldVariableInline.swift
@@ -1,0 +1,507 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+
+// <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+// <p>http://www.apache.org/licenses/LICENSE-2.0
+
+// <p>Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+class C1{
+
+    var a = placeholder_true
+
+
+
+
+    init(){}
+
+
+
+
+    func f1(){
+
+        a = placeholder_true
+
+    }
+
+}
+
+
+
+
+class C2{
+
+    var a = placeholder_true
+
+
+
+
+    init(){}
+
+
+
+
+    func f2(){
+
+        a = placeholder_false
+
+    }
+
+}
+
+
+
+
+class C3{
+
+    var a = placeholder_true
+
+
+
+
+    init(){}
+
+
+
+
+    func f3(){
+
+        self.a = placeholder_true
+
+    }
+
+}
+
+
+
+
+class C4{
+
+    var a = placeholder_true
+
+
+
+
+    init(){}
+
+
+
+
+    func f4(){
+
+        self.a = placeholder_false
+
+    }
+
+}
+
+
+
+
+class C5{
+
+    var a = placeholder_true
+
+    var b = placeholder_false
+
+    func f5(){
+
+        if a {
+
+            doSomething()
+
+        }
+
+        if b {
+
+            doSomethingElse()
+
+        }
+
+    }
+
+}
+
+
+
+
+class C6{
+
+    var a = placeholder_true
+
+    var b = placeholder_false
+
+    func f6(){
+
+        if self.a {
+
+            doSomething()
+
+        }
+
+        if self.b {
+
+            doSomethingElse()
+
+        }
+
+    }
+
+}
+
+
+
+
+class C7{
+
+    var a = placeholder_true
+
+
+
+
+    func f7(){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+
+
+
+class C8{
+
+    var a = placeholder_true
+
+
+
+
+    func f8(){
+
+        if self.a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+
+
+
+class C9{
+
+    var a = placeholder_true
+
+
+
+
+    func f9a(){
+
+        a = placeholder_false
+
+    }
+
+
+
+
+    func f9b(){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+
+
+
+class C10{
+
+    var a = placeholder_true
+
+
+
+
+    func f10a(){
+
+        self.a = placeholder_false
+
+    }
+
+
+
+
+    func f10b(){
+
+        if self.a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+
+
+
+class C11{
+
+    var a = placeholder_true
+
+
+
+
+    func f11a(){
+
+        a = placeholder_true
+
+    }
+
+
+
+
+    func f11b(){
+
+        a = placeholder_false
+
+    }
+
+}
+
+
+
+
+class C12{
+
+    var a
+
+    init(){
+
+        a = placeholder_true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+
+
+
+    func f12(){
+
+        a = placeholder_false
+
+    }
+
+}
+
+
+
+
+class C13{
+
+    var a
+
+    init(){
+
+        a = placeholder_true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+    func f13(){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+class C14{
+
+    var a
+
+    init(a: Bool){
+
+        a = placeholder_true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+    func f14(){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+class C15{
+
+    var a
+
+    init(){
+
+        a = placeholder_true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+    func f15(a: Bool){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+class C16{
+
+    var a
+
+    init(){
+
+        self.a = placeholder_true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+    func f16(){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+class C17{
+
+    var a
+
+    init(a: Bool){
+
+        self.a = placeholder_true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+    func f17(){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+class C18{
+
+    var a
+
+    init(){
+
+        self.a = placeholder_true
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+    func f18(a: Bool){
+
+        if a {
+
+            doSomething()
+
+        }
+
+    }
+
+}
+
+class C19{
+    var a = true
+
+    init(){
+        a = false
+    }
+}
+
+class C20{
+    var a
+
+    init(){
+        a = false
+    }
+
+    func f1(){
+        var a = true
+    }
+}


### PR DESCRIPTION
This is a shadow PR for #459.

Description: 
Add tests for adhoc variable inline. The rules are not there because local variable inline automatically handles the adhoc declaration anywhere inside the function due to the matcher function_declaration in constraint without any query.

