### PR TITLE
Cleanup Rules Swift: Fix the issue in short circuit rule

### DIFF
--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -397,18 +397,39 @@ query = """(
     [
         (if_statement
             condition: (boolean_literal) @boollc
-            (_)
-            .(statements)
-        )
-        (if_statement
-            (_)
-            condition: (boolean_literal) @boollc
-            .(statements)
-        )
-        (if_statement
-            condition: (boolean_literal) @boollc
             bound_identifier: (simple_identifier)
             (statements)
+        )
+        (if_statement
+            bound_identifier: (simple_identifier)
+            condition: (boolean_literal) @boollc
+            (statements)
+        )
+        (if_statement
+            condition: (boolean_literal) @boollc
+            condition: (equality_expression) @exprec
+            (statements)
+        )
+        (if_statement
+            condition: (equality_expression) @exprec
+            condition: (boolean_literal) @boollc
+            (statements) 
+        )
+        (if_statement
+            condition: (boolean_literal) @boollc
+            condition: [
+                (call_expression) 
+                (simple_identifier)
+            ]
+            (statements) 
+        )
+        (if_statement
+            condition: [
+                (call_expression)
+                (simple_identifier)
+            ]
+            condition: (boolean_literal) @boollc
+            (statements) 
         )
     ] @ifstl
     (#eq? @boollc "true")

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -166,7 +166,11 @@ class SampleClass {
 
     func checkIfShortCircuitStatementsWithBooleanPrefix() {
         if  let a1 = something1a{
+            // some comment
+            // some other comment
             doSomething1a()
+            // another comment
+            doSomethingElse()
         }
 
         if  let b1 = something2a(){
@@ -192,7 +196,11 @@ class SampleClass {
 
     func checkIfShortCircuitStatementsWithBooleanSuffix() {
         if let a2 = something1{
+            // some comment
+            // some other comment
             doSomething1b()
+            // another comment
+            doSomethingElse()
         }
 
         if let b2 = something2(){

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -216,7 +216,11 @@ class SampleClass {
 
     func checkIfShortCircuitStatementsWithBooleanPrefix() {
         if TestEnum.stale_flag_one.isEnabled, let a1 = something1a{
+            // some comment
+            // some other comment
             doSomething1a()
+            // another comment
+            doSomethingElse()
         }
 
         if TestEnum.stale_flag_one.isEnabled, let b1 = something2a(){
@@ -242,7 +246,11 @@ class SampleClass {
 
     func checkIfShortCircuitStatementsWithBooleanSuffix() {
         if let a2 = something1, TestEnum.stale_flag_one.isEnabled{
+            // some comment
+            // some other comment
             doSomething1b()
+            // another comment
+            doSomethingElse()
         }
 
         if let b2 = something2(), TestEnum.stale_flag_one.isEnabled{


### PR DESCRIPTION
Short circuit cleanup rules were not running properly in case of multiple cleanups that were caught as statements instead and were causing the rules to not replace the nodes properly. 

This PR adds the specific nodes in query to solve the issue for short circuit if statements. 