### PR TITLE
Ignore long running test cases

### DIFF
--- a/.github/workflows/polyglot_build.yml
+++ b/.github/workflows/polyglot_build.yml
@@ -32,7 +32,7 @@ jobs:
           cargo install taplo-cli --locked
           pre-commit run --all-files
       - name: Run unit and integration tests
-        run: cargo build && cargo test
+        run: cargo build && cargo test -- --include-ignored
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/main.rs"
 name = "polyglot_piranha"
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
+doctest = false
 
 [build-dependencies]
 cc = "1.0.73"

--- a/src/models/constraint.rs
+++ b/src/models/constraint.rs
@@ -72,7 +72,7 @@ impl Constraint {
 ///
 /// Usage:
 ///
-/// ```ignore
+/// ```
 /// constraint! {
 ///   matcher = "(method_declaration) @md".to_string(),
 ///   queries=  ["(method_invocation name: (_) @name) @mi".to_string()]
@@ -81,7 +81,7 @@ impl Constraint {
 ///
 /// expands to
 ///
-/// ```ignore
+/// ```
 /// ConstraintBuilder::default()
 ///      .matcher("(method_declaration) @md".to_string())
 ///      .queries(vec!["(method_invocation name: (_) @name) @mi".to_string()])

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -106,7 +106,7 @@ impl Rule {
 ///
 /// Usage:
 ///
-/// ```ignore
+/// ```
 /// piranha_rule! {
 ///   name = "Some Rule".to_string(),
 ///   query= "(method_invocation name: (_) @name) @mi".to_string()
@@ -115,7 +115,7 @@ impl Rule {
 ///
 /// expands to
 ///
-/// ```ignore
+/// ```
 /// RuleBuilder::default()
 ///      .name("Some Rule".to_string())
 ///      .query("(method_invocation name: (_) @name) @mi".to_string)

--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -11,14 +11,18 @@ Copyright (c) 2023 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use super::{create_rewrite_tests, substitutions};
+use std::path::PathBuf;
 
-use crate::models::default_configs::SWIFT;
+use super::{create_rewrite_tests, execute_piranha_and_check_result, substitutions};
+
+use crate::models::{
+  default_configs::SWIFT, language::PiranhaLanguage, piranha_arguments::PiranhaArgumentsBuilder,
+};
 
 create_rewrite_tests! {
   SWIFT,
-  // Tests cascading file delete based on enum and type alias.
   // This scenario is "derived" from plugin cleanup.
+  // Tests cascading file delete based on enum and type alias.
   // This cleanup requires the concept of global tags
   test_cascading_delete_file:  "cascade_file_delete", 3,
     substitutions = substitutions! {
@@ -32,22 +36,102 @@ create_rewrite_tests! {
     cleanup_comments = true,
     global_tag_prefix ="universal_tag.".to_string(),
     cleanup_comments_buffer = 3, delete_file_if_empty= false;
-  test_cleanup_rules_file: "cleanup_rules", 1,
-    substitutions = substitutions! {
-      "stale_flag" => "stale_flag_one",
-      "treated" => "true",
-      "treated_complement" => "false"
-    },
-    cleanup_comments = true, delete_file_if_empty= false;
   test_leading_comma: "leading_comma", 1,
     substitutions = substitutions! {
       "stale_flag" => "one"
     },
     cleanup_comments = true, delete_file_if_empty= false;
-  test_local_variable_inline_file: "variable_inline/local_variable_inline", 1,
-    cleanup_comments = true, delete_file_if_empty= false;
-  test_field_variable_inline_file: "variable_inline/field_variable_inline", 1,
-    cleanup_comments = true, delete_file_if_empty= false;
-  test_adhoc_variable_inline_file: "variable_inline/adhoc_variable_inline", 1,
-    cleanup_comments = true, delete_file_if_empty= false;
+}
+
+#[test]
+#[ignore] // Long running test
+fn test_cleanup_rules_file() {
+  super::initialize();
+  let _path = PathBuf::from("test-resources")
+    .join(SWIFT)
+    .join("cleanup_rules");
+  let temp_dir = super::copy_folder_to_temp_dir(&_path.join("input"));
+
+  let piranha_arguments = PiranhaArgumentsBuilder::default()
+    .path_to_codebase(temp_dir.path().to_str().unwrap().to_string())
+    .path_to_configurations(_path.join("configurations").to_str().unwrap().to_string())
+    .language(PiranhaLanguage::from(SWIFT))
+    .cleanup_comments(true)
+    .substitutions(substitutions! {
+      "stale_flag" => "stale_flag_one",
+      "treated" => "true",
+      "treated_complement" => "false"
+    })
+    .delete_file_if_empty(false)
+    .build();
+
+  execute_piranha_and_check_result(&piranha_arguments, &_path.join("expected"), 1, true);
+  // Delete temp_dir
+  temp_dir.close().unwrap();
+}
+
+#[test]
+#[ignore] // Long running test
+fn test_local_variable_inline_file() {
+  super::initialize();
+  let _path = PathBuf::from("test-resources")
+    .join(SWIFT)
+    .join("variable_inline/local_variable_inline");
+  let temp_dir = super::copy_folder_to_temp_dir(&_path.join("input"));
+
+  let piranha_arguments = PiranhaArgumentsBuilder::default()
+    .path_to_codebase(temp_dir.path().to_str().unwrap().to_string())
+    .path_to_configurations(_path.join("configurations").to_str().unwrap().to_string())
+    .language(PiranhaLanguage::from(SWIFT))
+    .cleanup_comments(true)
+    .delete_file_if_empty(false)
+    .build();
+
+  execute_piranha_and_check_result(&piranha_arguments, &_path.join("expected"), 1, true);
+  // Delete temp_dir
+  temp_dir.close().unwrap();
+}
+
+#[test]
+#[ignore] // Long running test
+fn test_field_variable_inline_file() {
+  super::initialize();
+  let _path = PathBuf::from("test-resources")
+    .join(SWIFT)
+    .join("variable_inline/field_variable_inline");
+  let temp_dir = super::copy_folder_to_temp_dir(&_path.join("input"));
+
+  let piranha_arguments = PiranhaArgumentsBuilder::default()
+    .path_to_codebase(temp_dir.path().to_str().unwrap().to_string())
+    .path_to_configurations(_path.join("configurations").to_str().unwrap().to_string())
+    .language(PiranhaLanguage::from(SWIFT))
+    .cleanup_comments(true)
+    .delete_file_if_empty(false)
+    .build();
+
+  execute_piranha_and_check_result(&piranha_arguments, &_path.join("expected"), 1, true);
+  // Delete temp_dir
+  temp_dir.close().unwrap();
+}
+
+#[test]
+#[ignore] // Long running test
+fn test_adhoc_variable_inline_file() {
+  super::initialize();
+  let _path = PathBuf::from("test-resources")
+    .join(SWIFT)
+    .join("variable_inline/adhoc_variable_inline");
+  let temp_dir = super::copy_folder_to_temp_dir(&_path.join("input"));
+
+  let piranha_arguments = PiranhaArgumentsBuilder::default()
+    .path_to_codebase(temp_dir.path().to_str().unwrap().to_string())
+    .path_to_configurations(_path.join("configurations").to_str().unwrap().to_string())
+    .language(PiranhaLanguage::from(SWIFT))
+    .cleanup_comments(true)
+    .delete_file_if_empty(false)
+    .build();
+
+  execute_piranha_and_check_result(&piranha_arguments, &_path.join("expected"), 1, true);
+  // Delete temp_dir
+  temp_dir.close().unwrap();
 }


### PR DESCRIPTION
(Ok. I understand this is hacky, but this is the practice that they follow inside rust lang - [example](https://github.com/rust-lang/rust/blob/054b7b7/src/libcoretest/num/flt2dec/strategy/grisu.rs#L56) )

Context: 
Due to grammar issue, the tree-sitter swift queries take a lot of time to load (we are looking into it with the upstream owner). However, this implies that these swift tests cause a significant slow down in local development (was 20s before `swift` stuff was added now it is 2-4mins, which i a lot if u think about it).

So I am ignoring these tests. 
We will run these test in CI though (As updated in github workflow). These tests can be ran locally too by adding `--include-ignored` flag.


Oh, also! Instead of adding `'''ignore...` i use `doctest = false` in `Cargo.toml` (because I am ignoring all doc tests)

-----

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #468
* __->__ #467

