### PR TITLE
Fix local variable inline for init declarations

### DIFF
--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -550,7 +550,7 @@ replace = ""
 is_seed_rule = false
 
 [[rules.constraints]]
-matcher = "(function_declaration) @cfd"
+matcher = "[(function_declaration) (init_declaration)] @cfd"
 
 # skip the rule if the variable is assigned with some other value in the class scope
 [[rules.constraints]]

--- a/test-resources/swift/variable_inline/local_variable_inline/expected/VariableInlining.swift
+++ b/test-resources/swift/variable_inline/local_variable_inline/expected/VariableInlining.swift
@@ -59,3 +59,15 @@ class C7 {
         doSomething()
     }
 }
+
+class C8 {
+    init(){
+        super.init(someParameter: someVar)
+    }
+}
+
+class C9 {
+    init(){
+        super.init(someParameter: someOtherVar)
+    }
+}

--- a/test-resources/swift/variable_inline/local_variable_inline/input/VariableInlining.swift
+++ b/test-resources/swift/variable_inline/local_variable_inline/input/VariableInlining.swift
@@ -77,3 +77,17 @@ class C7 {
         }
     }
 }
+
+class C8 {
+    init(){
+        let a = placeholder_true
+        super.init(someParameter: a ? someVar : someOtherVar)
+    }
+}
+
+class C9 {
+    init(){
+        let a = placeholder_false
+        super.init(someParameter: a ? someVar : someOtherVar)
+    }
+}


### PR DESCRIPTION
This PR fixes local variable inlining in case of init declarations as discussed in our issues. 

Before: 
```
class C1 {
    init(){
        let a = true
        someFunctionCall(someParameter: a ? someVar : someOtherVar)
    }
}
```

After:
```
class C1 {
    init(){
        someFunctionCall(someParameter: someVar)
    }
}
```