### PR TITLE
Fix Conditional Statements: Add nodes to capture comments

### DIFF
--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -250,7 +250,8 @@ name = "if_always_true"
 query = """ (
 (if_statement
     condition: (boolean_literal) @condition_literal
-    .(statements) @if_block
+    ((comment)*
+    .(statements)) @if_block
     ) @if_else_block
 (#eq? @condition_literal "true")
 )"""
@@ -275,7 +276,8 @@ query = """ (
 (else)
 (if_statement
     condition: (boolean_literal) @condition_literal
-    .(statements) @if_block
+    ((comment)*
+    .(statements)) @if_block
     ) @if_else_block
 (#eq? @condition_literal "true")
 )"""
@@ -299,8 +301,11 @@ query = """(
 (if_statement
     bound_identifier: (_)?
     condition: (boolean_literal) @condition_literal
-    .(statements) @if_block
-    [(statements) (if_statement)]? @alternatives 
+    ((comment)*
+    .(statements)) @if_block
+    ((comment)*
+    [(statements)
+     (if_statement)])? @alternatives 
     ) @if_else_block
 (#eq? @condition_literal "false")
 )"""
@@ -333,8 +338,10 @@ query = """(
 (if_statement
     bound_identifier: (_)?
     condition: (boolean_literal) @condition_literal
+    (comment)*
     .(statements) @if_block
-    (statements)? @alternatives 
+    ((comment)*
+    (statements)?) @alternatives 
     ) @if_else_block
 (#eq? @condition_literal "false")
 )"""
@@ -373,6 +380,7 @@ query = """(
 (if_statement
     bound_identifier: (_)?
     condition: (boolean_literal) @condition_literal
+    (comment)*
     .(statements) @if_block
     (if_statement) @alternatives 
     ) @if_else_block

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -164,6 +164,34 @@ class SampleClass {
         var value2 = 3
     }
 
+    func checkIfBooleanWithComments(){
+        // to be preserved
+        toBePreserved1()
+                  
+        if a {
+            // to be preserved
+            toBePreserved2()
+        }
+
+        if b {
+            // to be preserved
+            toBePreserved3a()
+        } else {
+            // to be preserved
+            toBePreserved3b()
+        }
+
+        // to be preserved
+        toBePreserved4()
+                
+
+        // to be preserved
+        toBePreserved5() 
+                    
+        // to be preserved
+        toBePreserved6()
+    }
+
     func checkIfShortCircuitStatementsWithBooleanPrefix() {
         if  let a1 = something1a{
             // some comment

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -165,30 +165,30 @@ class SampleClass {
     }
 
     func checkIfBooleanWithComments(){
-        // to be preserved
+        // to be preserved1
         toBePreserved1()
                   
         if a {
-            // to be preserved
+            // to be preserved2
             toBePreserved2()
         }
 
         if b {
-            // to be preserved
+            // to be preserved3a
             toBePreserved3a()
         } else {
-            // to be preserved
+            // to be preserved3b
             toBePreserved3b()
         }
 
-        // to be preserved
+        // to be preserved4
         toBePreserved4()
                 
 
-        // to be preserved
+        // to be preserved5
         toBePreserved5() 
                     
-        // to be preserved
+        // to be preserved6
         toBePreserved6()
     }
 

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -216,56 +216,56 @@ class SampleClass {
 
     func checkIfBooleanWithComments(){
          if !TestEnum.stale_flag_one.isEnabled {
-            // to be deleted
+            // to be deleted1
             toBeDeleted1()
          }else{
-            // to be preserved
+            // to be preserved1
             toBePreserved1()
          }
 
          if !TestEnum.stale_flag_one.isEnabled{
-            // to be deleted
+            // to be deleted2
             toBeDeleted2() 
          } else if a {
-            // to be preserved
+            // to be preserved2
             toBePreserved2()
          }
 
          if !TestEnum.stale_flag_one.isEnabled{
-            // to be deleted
+            // to be deleted3
             toBeDeleted3() 
          } else if b {
-            // to be preserved
+            // to be preserved3a
             toBePreserved3a()
          } else {
-            // to be preserved
+            // to be preserved3b
             toBePreserved3b()
          }
 
          if TestEnum.stale_flag_one.isEnabled{
-            // to be preserved
+            // to be preserved4
             toBePreserved4()
          } else{
-            // to be deleted
+            // to be deleted4
             toBeDeleted4()
          }
 
          if TestEnum.stale_flag_one.isEnabled{
-            // to be preserved
+            // to be preserved5
             toBePreserved5() 
          } else if c {
-            // to be deleted
+            // to be deleted5
             toBeDeleted5()
          }
 
          if TestEnum.stale_flag_one.isEnabled{
-            // to be preserved
+            // to be preserved6
             toBePreserved6() 
          } else if d {
-            // to be preserved
+            // to be deleted6a
             toBeDeleted6a()
          } else {
-            // to be preserved
+            // to be deleted6b
             toBeDeleted6b()
          }
     }

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -214,6 +214,62 @@ class SampleClass {
         var value2 =  placeholder_false ? 2 : 3
     }
 
+    func checkIfBooleanWithComments(){
+         if !TestEnum.stale_flag_one.isEnabled {
+            // to be deleted
+            toBeDeleted1()
+         }else{
+            // to be preserved
+            toBePreserved1()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled{
+            // to be deleted
+            toBeDeleted2() 
+         } else if a {
+            // to be preserved
+            toBePreserved2()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled{
+            // to be deleted
+            toBeDeleted3() 
+         } else if b {
+            // to be preserved
+            toBePreserved3a()
+         } else {
+            // to be preserved
+            toBePreserved3b()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled{
+            // to be preserved
+            toBePreserved4()
+         } else{
+            // to be deleted
+            toBeDeleted4()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled{
+            // to be preserved
+            toBePreserved5() 
+         } else if c {
+            // to be deleted
+            toBeDeleted5()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled{
+            // to be preserved
+            toBePreserved6() 
+         } else if d {
+            // to be preserved
+            toBeDeleted6a()
+         } else {
+            // to be preserved
+            toBeDeleted6b()
+         }
+    }
+
     func checkIfShortCircuitStatementsWithBooleanPrefix() {
         if TestEnum.stale_flag_one.isEnabled, let a1 = something1a{
             // some comment


### PR DESCRIPTION
This PR fixes the issue when the if cleanup rules were not working due to comments inside the blocks. Added comment nodes as optional to cover those scenarios.
