### PR TITLE
Fix demo files for the new PiranhaArguments signature

### DIFF
--- a/demo/find_replace_custom_cleanup_demos.py
+++ b/demo/find_replace_custom_cleanup_demos.py
@@ -24,7 +24,7 @@ def java_demo():
 
     args = PiranhaArguments(
         "java",
-        {
+        substitutions={
             "input_type_name": "ArrayList",
         },
         path_to_configurations=configuration_path,
@@ -56,7 +56,7 @@ def python_demo():
 
     args = PiranhaArguments(
         "py",
-        {
+        substitutions={
             "str_literal": "dependency2",
             "str_to_replace": "dependency1",
             "str_replacement": "dependency1_1"

--- a/demo/find_replace_demos.py
+++ b/demo/find_replace_demos.py
@@ -21,7 +21,7 @@ def swift_demo():
 
     args = PiranhaArguments(
         "swift",
-        {
+        substitutions={
             "stale_flag_name": "test_second_experiment",
         },
         path_to_configurations=configuration_path,
@@ -52,7 +52,7 @@ def java_demo():
 
     args = PiranhaArguments(
         "java",
-        {
+        substitutions={
             "stale_flag_name": "STALE_FLAG",
         },
         path_to_configurations=configuration_path,

--- a/demo/match_only_demos.py
+++ b/demo/match_only_demos.py
@@ -11,7 +11,7 @@ def java_demo():
     info("Running the Match-only demo for Java")
     args = PiranhaArguments(
         "java",
-        {},
+        substitutions={},
         path_to_codebase=join(match_only_dir, "java"),
         path_to_configurations=join(match_only_dir, "java/configurations"),
     )

--- a/demo/match_only_demos.py
+++ b/demo/match_only_demos.py
@@ -30,7 +30,7 @@ def go_demo():
 
     args = PiranhaArguments(
         "go",
-        {},
+        substitutions={},
         path_to_codebase=join(match_only_dir, "go"),
         path_to_configurations=join(match_only_dir, "go/configurations"),
     )
@@ -48,7 +48,7 @@ def ts_demo():
 
     args = PiranhaArguments(
         "ts",
-        {},
+        substitutions={},
         path_to_codebase=join(match_only_dir, "ts"),
         path_to_configurations=join(match_only_dir, "ts/configurations"),
     )
@@ -66,7 +66,7 @@ def tsx_demo():
     info("Running the Match-only demo for TypeScript with React")
     args = PiranhaArguments(
         "tsx",
-        {},
+        substitutions={},
         path_to_codebase=join(match_only_dir, "tsx"),
         path_to_configurations=join(match_only_dir, "tsx/configurations"),
     )

--- a/demo/stale_feature_flag_cleanup_demos.py
+++ b/demo/stale_feature_flag_cleanup_demos.py
@@ -18,7 +18,7 @@ def run_java_ff_demo():
 
     args = PiranhaArguments(
         "java",
-        {
+        substitutions={
             "stale_flag_name": "SAMPLE_STALE_FLAG",
             "treated": "true",
             "treated_complement": "false",
@@ -51,7 +51,7 @@ def run_kt_ff_demo():
 
     args = PiranhaArguments(
         "kt",
-        {
+        substitutions={
             "stale_flag_name": "SAMPLE_STALE_FLAG",
             "treated": "true",
             "treated_complement": "false",

--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -33,7 +33,7 @@ class PiranhaArguments:
     def __init__(
         self,
         language: str,
-        path_to_codebase: str,
+        path_to_codebase: Optional[str] = None,
         include: Optional[List[str]] = None,
         exclude: Optional[List[str]] = None,
         substitutions: Optional[dict] = None,

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -177,7 +177,7 @@ impl PiranhaArguments {
   /// Returns PiranhaArgument.
   #[new]
   fn py_new(
-    language: String, path_to_codebase: String, include: Option<Vec<String>>,
+    language: String, path_to_codebase: Option<String>, include: Option<Vec<String>>,
     exclude: Option<Vec<String>>, substitutions: Option<&PyDict>,
     path_to_configurations: Option<String>, rule_graph: Option<RuleGraph>,
     code_snippet: Option<String>, dry_run: Option<bool>, cleanup_comments: Option<bool>,
@@ -198,7 +198,7 @@ impl PiranhaArguments {
 
     let rg = rule_graph.unwrap_or_else(|| RuleGraphBuilder::default().build());
     PiranhaArgumentsBuilder::default()
-      .path_to_codebase(path_to_codebase)
+      .path_to_codebase(path_to_codebase.unwrap_or_else(default_path_to_codebase))
       .include(
         include
           .unwrap_or_default()

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -177,8 +177,8 @@ impl PiranhaArguments {
   /// Returns PiranhaArgument.
   #[new]
   fn py_new(
-    language: String, substitutions: Option<&PyDict>, path_to_codebase: Option<String>,
-    include: Option<Vec<String>>, exclude: Option<Vec<String>>,
+    language: String, path_to_codebase: Option<String>, include: Option<Vec<String>>,
+    exclude: Option<Vec<String>>, substitutions: Option<&PyDict>,
     path_to_configurations: Option<String>, rule_graph: Option<RuleGraph>,
     code_snippet: Option<String>, dry_run: Option<bool>, cleanup_comments: Option<bool>,
     cleanup_comments_buffer: Option<i32>, number_of_ancestors_in_parent_scope: Option<u8>,

--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -177,8 +177,8 @@ impl PiranhaArguments {
   /// Returns PiranhaArgument.
   #[new]
   fn py_new(
-    language: String, path_to_codebase: Option<String>, include: Option<Vec<String>>,
-    exclude: Option<Vec<String>>, substitutions: Option<&PyDict>,
+    language: String, substitutions: Option<&PyDict>, path_to_codebase: Option<String>,
+    include: Option<Vec<String>>, exclude: Option<Vec<String>>,
     path_to_configurations: Option<String>, rule_graph: Option<RuleGraph>,
     code_snippet: Option<String>, dry_run: Option<bool>, cleanup_comments: Option<bool>,
     cleanup_comments_buffer: Option<i32>, number_of_ancestors_in_parent_scope: Option<u8>,


### PR DESCRIPTION
I was trying to run the demos, but they were failing w/

```INFO root 2023-05-16 14:44:31,514 find_replace_demos.py:15 Running the Find/Replace demo for Swift
Traceback (most recent call last):
  File "/Users/danielrr/piranha/demo/find_replace_demos.py", line 72, in <module>
    swift_demo()
  File "/Users/danielrr/piranha/demo/find_replace_demos.py", line 22, in swift_demo
    args = PiranhaArguments(
TypeError: PiranhaArguments.__new__() got multiple values for argument 'path_to_codebase'
```

I'm guessing they were never updated to work with the new python bindings? It should be working now.
For reference I just used these rules:

```
comby "PiranhaArguments(:[lang], {:[subs]}, path_to_codebase=:[path], :[rest])" "PiranhaArguments(:[lang], :[path], substitutions={:[subs]}, :[rest])" -f .py
comby "PiranhaArguments(:[lang], {:[subs]}, :[rest], path_to_codebase=:[path], :[rest1])" "PiranhaArguments(:[lang], :[path], :[rest], substitutions={:[subs]}, :[rest1])" -f .py
comby "PiranhaArguments(:[lang], {:[subs]}, :[rest], path_to_codebase=:[path])" "PiranhaArguments(:[lang], :[path], :[rest], substitutions={:[subs]})" -f .py
```

