### PR TITLE
Swift: Fix Equality conditions evaluation

### DIFF
--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -874,6 +874,214 @@ not_contains = [
     )""",
 ]
 
+[[rules]]
+name = "de_parenthesize_literals"
+query = """(
+    (tuple_expression
+        [
+            (integer_literal)
+            (hex_literal)
+            (oct_literal)
+            (bin_literal)
+            (real_literal)
+            (boolean_literal)
+            (line_string_literal)
+            (regex_literal)
+        ] @tvalue
+    ) @texp
+)"""
+groups = ["boolean_expression_simplify"]
+replace_node = "texp"
+replace = "@tvalue"
+is_seed_rule = false
+#
+# Before 
+# equality expression with same lhs and rhs for following:
+# integer_literal
+# hex_literal
+# oct_literal
+# bin_literal
+# real_literal
+# boolean_literal
+# _string_literal
+# regex_literal
+# After 
+#   true
+#
+[[rules]]
+name = "boolean_equality_expression_same_literals"
+query = """(
+    (equality_expression
+            lhs: [
+                (integer_literal)
+                (hex_literal)
+                (oct_literal)
+                (bin_literal)
+                (real_literal)
+                (boolean_literal)
+                (line_string_literal)
+                (regex_literal)
+            ] @left
+            rhs: [
+                (integer_literal)
+                (hex_literal)
+                (oct_literal)
+                (bin_literal)
+                (real_literal)
+                (boolean_literal)
+                (line_string_literal)
+                (regex_literal)
+            ] @right
+    ) @cond
+    (#eq? @left @right)
+)"""
+groups = ["boolean_expression_simplify"]
+replace_node = "cond"
+replace = "true"
+is_seed_rule = false
+
+#
+# Before 
+# equality expression with different lhs and rhs for following:
+# integer_literal
+# hex_literal
+# oct_literal
+# bin_literal
+# real_literal
+# boolean_literal
+# _string_literal
+# regex_literal
+# After 
+#   false
+#
+[[rules]]
+name = "boolean_equality_expression_opposite_literals"
+query = """(
+    (equality_expression
+            lhs: [
+                (integer_literal)
+                (hex_literal)
+                (oct_literal)
+                (bin_literal)
+                (real_literal)
+                (boolean_literal)
+                (line_string_literal)
+                (regex_literal)
+            ] @left
+            rhs: [
+                (integer_literal)
+                (hex_literal)
+                (oct_literal)
+                (bin_literal)
+                (real_literal)
+                (boolean_literal)
+                (line_string_literal)
+                (regex_literal)
+            ] @right
+    ) @cond
+    (#not-eq? @left @right)
+)"""
+groups = ["boolean_expression_simplify"]
+replace_node = "cond"
+replace = "false"
+is_seed_rule = false
+
+#
+# Before 
+# inequality expression (infix expression with custom_operator = '!='') with same lhs and rhs for following:
+# integer_literal
+# hex_literal
+# oct_literal
+# bin_literal
+# real_literal
+# boolean_literal
+# _string_literal
+# regex_literal
+# After 
+#   false
+#
+[[rules]]
+name = "boolean_inequality_expression_same_literals"
+query = """(
+    (infix_expression
+            lhs: [
+                (integer_literal)
+                (hex_literal)
+                (oct_literal)
+                (bin_literal)
+                (real_literal)
+                (boolean_literal)
+                (line_string_literal)
+                (regex_literal)
+            ] @left
+            op: (custom_operator) @ops
+            rhs: [
+                (integer_literal)
+                (hex_literal)
+                (oct_literal)
+                (bin_literal)
+                (real_literal)
+                (boolean_literal)
+                (line_string_literal)
+                (regex_literal)
+            ] @right
+    ) @cond
+    (#eq? @ops "!=")
+    (#eq? @left @right)
+)"""
+groups = ["boolean_expression_simplify"]
+replace_node = "cond"
+replace = "false"
+is_seed_rule = false
+
+#
+# Before 
+# inequality expression (infix expression with custom_operator = '!='') with different lhs and rhs for following:
+# integer_literal
+# hex_literal
+# oct_literal
+# bin_literal
+# real_literal
+# boolean_literal
+# _string_literal
+# regex_literal
+# After 
+#   true
+#
+[[rules]]
+name = "boolean_inequality_expression_opposite_literals"
+query = """(
+    (infix_expression
+            lhs: [
+                (integer_literal)
+                (hex_literal)
+                (oct_literal)
+                (bin_literal)
+                (real_literal)
+                (boolean_literal)
+                (line_string_literal)
+                (regex_literal)
+            ] @left
+            op: (custom_operator) @ops
+            rhs: [
+                (integer_literal)
+                (hex_literal)
+                (oct_literal)
+                (bin_literal)
+                (real_literal)
+                (boolean_literal)
+                (line_string_literal)
+                (regex_literal)
+            ] @right
+    ) @cond
+    (#eq? @ops "!=")
+    (#not-eq? @left @right)
+)"""
+groups = ["boolean_expression_simplify"]
+replace_node = "cond"
+replace = "true"
+is_seed_rule = false
+
 # Dummy rule that acts as a junction for all boolean based cleanups
 # Let's say you want to define rules from A -> B, A -> C, D -> B, D -> C, ... 
 # A pattern here is - if there is an outgoing edge to B there is another to C.

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -223,4 +223,82 @@ class SampleClass {
             doSomething6b()
         }
     }
+
+    func refactorBooleanLiteralEqualityExpressionInIfConditions(){
+
+        toBePreservedEquality1()
+
+        toBePreservedEquality2()
+
+        toBePreservedEquality3() 
+
+        toBePreservedEquality4()
+
+        toBePreservedEquality5()
+
+        toBePreservedEquality6()
+
+        toBePreservedEquality7()
+
+        if a {
+        toBePreservedEquality8()
+        }
+
+        if b {
+        toBePreservedEquality9a()
+        } else {
+        toBePreservedEquality9b()
+        }
+
+        toBePreservedEquality10()
+
+        if c {
+            toBePreservedEquality11()
+        }
+
+        if d {
+            toBePreservedEquality12a()
+        } else {
+        toBePreservedEquality12b()
+        }
+    }
+
+    func refactorBooleanLiteralInequalityExpressionInIfConditions(){
+
+        toBePreservedInequality1()
+
+        if a {
+            toBePreservedInequality2()
+         }
+
+        if b {
+            toBePreservedInequality3a()
+        } else {
+            toBePreservedInequality3b()
+        }
+
+        toBePreservedInequality4()
+
+        if c {
+            toBePreservedInequality5()
+        }
+
+        if d {
+            toBePreservedInequality6a()
+        } else {
+            toBePreservedInequality6b()
+        }
+
+        toBePreservedInequality7()
+
+        toBePreservedInequality8() 
+
+        toBePreservedInequality9() 
+
+        toBePreservedInequality10()
+
+        toBePreservedInequality11() 
+
+        toBePreservedInequality12() 
+    }
 }

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -273,4 +273,168 @@ class SampleClass {
             doSomething6b()
         }
     }
+
+    func refactorBooleanLiteralEqualityExpressionInIfConditions(){
+         if !TestEnum.stale_flag_one.isEnabled == !TestEnum.stale_flag_one.isEnabled  {
+            toBePreservedEquality1()
+         }else{
+            toBeDeletedEquality1()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled == !TestEnum.stale_flag_one.isEnabled{
+            toBePreservedEquality2() 
+         } else if a {
+            toBeDeletedEquality2()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled == !TestEnum.stale_flag_one.isEnabled{
+            toBePreservedEquality3() 
+         } else if b {
+            toBeDeletedEquality3a()
+         } else {
+            toBeDeletedEquality3b()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled == TestEnum.stale_flag_one.isEnabled{
+            toBePreservedEquality4()
+         } else{
+            toBeDeletedEquality4()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled == TestEnum.stale_flag_one.isEnabled{
+            toBePreservedEquality5() 
+         } else if c {
+            toBeDeletedEquality5()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled == TestEnum.stale_flag_one.isEnabled{
+            toBePreservedEquality6() 
+         } else if d {
+            toBeDeletedEquality6a()
+         } else {
+            toBeDeletedEquality6b()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled == TestEnum.stale_flag_one.isEnabled  {
+            toBeDeletedEquality7()
+         }else{
+            toBePreservedEquality7()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled == TestEnum.stale_flag_one.isEnabled{
+            toBeDeletedEquality8() 
+         } else if a {
+            toBePreservedEquality8()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled == TestEnum.stale_flag_one.isEnabled{
+            toBeDeletedEquality9() 
+         } else if b {
+            toBePreservedEquality9a()
+         } else {
+            toBePreservedEquality9b()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled == !TestEnum.stale_flag_one.isEnabled{
+            toBeDeletedEquality10()
+         } else{
+            toBePreservedEquality10()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled == !TestEnum.stale_flag_one.isEnabled{
+            toBeDeletedEquality11() 
+         } else if c {
+            toBePreservedEquality11()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled == !TestEnum.stale_flag_one.isEnabled{
+            toBeDeletedEquality12() 
+         } else if d {
+            toBePreservedEquality12a()
+         } else {
+            toBePreservedEquality12b()
+         }
+    }
+
+    func refactorBooleanLiteralInequalityExpressionInIfConditions(){
+         if !TestEnum.stale_flag_one.isEnabled != !TestEnum.stale_flag_one.isEnabled  {
+            toBeDeletedInequality1()
+         }else{
+            toBePreservedInequality1()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled != (!TestEnum.stale_flag_one.isEnabled){
+            toBeDeletedInequality2() 
+         } else if a {
+            toBePreservedInequality2()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled != !TestEnum.stale_flag_one.isEnabled{
+            toBeDeletedInequality3() 
+         } else if b {
+            toBePreservedInequality3a()
+         } else {
+            toBePreservedInequality3b()
+         }
+
+         if (TestEnum.stale_flag_one.isEnabled != TestEnum.stale_flag_one.isEnabled){
+            toBeDeletedInequality4()
+         } else{
+            toBePreservedInequality4()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled != TestEnum.stale_flag_one.isEnabled{
+            toBeDeletedInequality5() 
+         } else if c {
+            toBePreservedInequality5()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled != TestEnum.stale_flag_one.isEnabled{
+            toBeDeletedInequality6() 
+         } else if d {
+            toBePreservedInequality6a()
+         } else {
+            toBePreservedInequality6b()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled != TestEnum.stale_flag_one.isEnabled  {
+            toBePreservedInequality7()
+         }else{
+            toBeDeletedInequality7()
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled != TestEnum.stale_flag_one.isEnabled{
+            toBePreservedInequality8() 
+         } else if a {
+            toBeDeletedInequality8() 
+         }
+
+         if !TestEnum.stale_flag_one.isEnabled != TestEnum.stale_flag_one.isEnabled{
+            toBePreservedInequality9() 
+         } else if b {
+            toBeDeletedInequality9a()
+         } else {
+            toBeDeletedInequality9b()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled != !TestEnum.stale_flag_one.isEnabled{
+            toBePreservedInequality10()
+         } else{
+            toBeDeletedInequality10()
+         }
+
+         if TestEnum.stale_flag_one.isEnabled != !TestEnum.stale_flag_one.isEnabled{
+            toBePreservedInequality11() 
+         } else if c {
+            toBeDeletedInequality11()
+         }
+
+         if (TestEnum.stale_flag_one.isEnabled) != !TestEnum.stale_flag_one.isEnabled{
+            toBePreservedInequality12() 
+         } else if d {
+            toBeDeletedInequality12a()
+         } else {
+            toBeDeletedInequality12b()
+         }
+    }
 }


### PR DESCRIPTION
This PR fixes the equality expression evaluation where both lhs and rhs were boolean literals. The solution is to evaluate the equality and replace with the boolean literal so that it can be cleaned up by the other rules already in place. 