### PR TITLE
Rename constraints to filter #229

### DIFF
--- a/POLYGLOT_README.md
+++ b/POLYGLOT_README.md
@@ -364,9 +364,9 @@ Currently, Piranha provides deep clean-ups for edits that belong the groups - `r
 
 Setting the `is_seed_rule=False` ensures that the user defined rule is treated as a cleanup rule not as a seed rule (For more details refer to `demo/find_replace_custom_cleanup`).
 
-A user can also define exclusion filters for a rule (`rules.constraints`). These constraints allow matching against the context of the primary match. For instance, we can write a rule that matches the expression `new ArrayList<>()` and exclude all instances that occur inside static methods (For more details, refer to the `demo/match_only`).
+A user can also define exclusion filters for a rule (`rules.filters`). These filters allow matching against the context of the primary match. For instance, we can write a rule that matches the expression `new ArrayList<>()` and exclude all instances that occur inside static methods (For more details, refer to the `demo/match_only`).
 
-At a higher level, we can say that - Piranha first selects AST nodes matching `rules.query`, excluding those that match **any of** the `rules.constraints.queries` (within `rules.constraints.matcher`). It then replaces the node identified as `rules.replace_node` with the formatted (using matched tags) content of `rules.replace`.
+At a higher level, we can say that - Piranha first selects AST nodes matching `rules.query`, excluding those that match **any of** the `rules.filters.queries` (within `rules.filters.matcher`). It then replaces the node identified as `rules.replace_node` with the formatted (using matched tags) content of `rules.replace`.
 
 <h3> Parameterizing the behavior of the feature flag API </h3>
 

--- a/POLYGLOT_README.md
+++ b/POLYGLOT_README.md
@@ -354,7 +354,7 @@ groups = [ "replace_expression_with_boolean_literal"]
 holes = ["treated", "stale_flag_name"]
 ```
 This specifies a rule that matches against expressions like `exp.isTreated(SOME_FLAG_NAME)` and replaces it with `true` or `false`.
-The `query` property of the rule contains a [tree-sitter query](https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries) that is matched against the source code.
+The `query` property of the rule contains a [tree-sitter query](https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-not_contains) that is matched against the source code.
 The node captured by the tag-name specified in the `replace_node` property is replaced with the pattern specified in the `replace` property.
 The `replace` pattern can use the tags from the `query` to construct a replacement based on the match (like [regex-replace](https://docs.microsoft.com/en-us/visualstudio/ide/using-regular-expressions-in-visual-studio?view=vs-2022)).
 
@@ -366,7 +366,7 @@ Setting the `is_seed_rule=False` ensures that the user defined rule is treated a
 
 A user can also define exclusion filters for a rule (`rules.filters`). These filters allow matching against the context of the primary match. For instance, we can write a rule that matches the expression `new ArrayList<>()` and exclude all instances that occur inside static methods (For more details, refer to the `demo/match_only`).
 
-At a higher level, we can say that - Piranha first selects AST nodes matching `rules.query`, excluding those that match **any of** the `rules.filters.queries` (within `rules.filters.matcher`). It then replaces the node identified as `rules.replace_node` with the formatted (using matched tags) content of `rules.replace`.
+At a higher level, we can say that - Piranha first selects AST nodes matching `rules.query`, excluding those that match **any of** the `rules.filters.not_contains` (within `rules.filters.matcher`). It then replaces the node identified as `rules.replace_node` with the formatted (using matched tags) content of `rules.replace`.
 
 <h3> Parameterizing the behavior of the feature flag API </h3>
 

--- a/POLYGLOT_README.md
+++ b/POLYGLOT_README.md
@@ -366,7 +366,7 @@ Setting the `is_seed_rule=False` ensures that the user defined rule is treated a
 
 A user can also define exclusion filters for a rule (`rules.filters`). These filters allow matching against the context of the primary match. For instance, we can write a rule that matches the expression `new ArrayList<>()` and exclude all instances that occur inside static methods (For more details, refer to the `demo/match_only`).
 
-At a higher level, we can say that - Piranha first selects AST nodes matching `rules.query`, excluding those that match **any of** the `rules.filters.not_contains` (within `rules.filters.matcher`). It then replaces the node identified as `rules.replace_node` with the formatted (using matched tags) content of `rules.replace`.
+At a higher level, we can say that - Piranha first selects AST nodes matching `rules.query`, excluding those that match **any of** the `rules.filters.not_contains` (within `rules.filters.enclosing_node`). It then replaces the node identified as `rules.replace_node` with the formatted (using matched tags) content of `rules.replace`.
 
 <h3> Parameterizing the behavior of the feature flag API </h3>
 

--- a/POLYGLOT_README.md
+++ b/POLYGLOT_README.md
@@ -354,7 +354,7 @@ groups = [ "replace_expression_with_boolean_literal"]
 holes = ["treated", "stale_flag_name"]
 ```
 This specifies a rule that matches against expressions like `exp.isTreated(SOME_FLAG_NAME)` and replaces it with `true` or `false`.
-The `query` property of the rule contains a [tree-sitter query](https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-not_contains) that is matched against the source code.
+The `query` property of the rule contains a [tree-sitter query](https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries) that is matched against the source code.
 The node captured by the tag-name specified in the `replace_node` property is replaced with the pattern specified in the `replace` property.
 The `replace` pattern can use the tags from the `query` to construct a replacement based on the match (like [regex-replace](https://docs.microsoft.com/en-us/visualstudio/ide/using-regular-expressions-in-visual-studio?view=vs-2022)).
 

--- a/demo/find_replace_custom_cleanup/java/configurations/rules.toml
+++ b/demo/find_replace_custom_cleanup/java/configurations/rules.toml
@@ -30,7 +30,7 @@ replace_node = "package_declaration"
 replace = "@package_declaration\nimport java.util.Collections;\n"
 groups = ["Cleanup Rule"]
 [[rules.constraints]]
-matcher = "((program) @cu)"
+enclosing_node = "((program) @cu)"
 queries = [
   """(
 ((import_declaration (scoped_identifier (scoped_identifier) @type_qualifier (identifier)@type_name) @imported_type) @import)

--- a/demo/find_replace_custom_cleanup/java/configurations/rules.toml
+++ b/demo/find_replace_custom_cleanup/java/configurations/rules.toml
@@ -31,7 +31,7 @@ replace = "@package_declaration\nimport java.util.Collections;\n"
 groups = ["Cleanup Rule"]
 [[rules.filters]]
 enclosing_node = "((program) @cu)"
-queries = [
+not_contains = [
   """(
 ((import_declaration (scoped_identifier (scoped_identifier) @type_qualifier (identifier)@type_name) @imported_type) @import)
 (#eq? @imported_type "java.util.Collections")

--- a/demo/find_replace_custom_cleanup/java/configurations/rules.toml
+++ b/demo/find_replace_custom_cleanup/java/configurations/rules.toml
@@ -29,7 +29,7 @@ query = "(package_declaration (_)@package_name) @package_declaration"
 replace_node = "package_declaration"
 replace = "@package_declaration\nimport java.util.Collections;\n"
 groups = ["Cleanup Rule"]
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "((program) @cu)"
 queries = [
   """(

--- a/demo/find_replace_demos.py
+++ b/demo/find_replace_demos.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from os.path import join, dirname, getmtime
-from polyglot_piranha import Rule, RuleGraph, execute_piranha, PiranhaArguments, filter
+from polyglot_piranha import Rule, RuleGraph, execute_piranha, PiranhaArguments, Filter
 import logging
 from logging import info
 

--- a/demo/find_replace_demos.py
+++ b/demo/find_replace_demos.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from os.path import join, dirname, getmtime
-from polyglot_piranha import Rule, RuleGraph, execute_piranha, PiranhaArguments, Constraint
+from polyglot_piranha import Rule, RuleGraph, execute_piranha, PiranhaArguments, filter
 import logging
 from logging import info
 

--- a/demo/match_only/go/configurations/rules.toml
+++ b/demo/match_only/go/configurations/rules.toml
@@ -17,7 +17,7 @@ query = """
 )
 """
 [[rules.constraints]]
-matcher = "(for_statement) @fs"
+enclosing_node = "(for_statement) @fs"
 
 
 [[rules]]

--- a/demo/match_only/go/configurations/rules.toml
+++ b/demo/match_only/go/configurations/rules.toml
@@ -16,7 +16,7 @@ query = """
     (go_statement) @go_stmt
 )
 """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(for_statement) @fs"
 
 

--- a/demo/match_only/java/configurations/rules.toml
+++ b/demo/match_only/java/configurations/rules.toml
@@ -36,7 +36,7 @@ query = """((
 ))"""
 [[rules.filters]]
 enclosing_node = "(method_declaration) @md"
-queries = ["""(
+not_contains = ["""(
   (modifiers) @modifiers
   (#match? @modifiers ".*static.*")
   )"""]

--- a/demo/match_only/java/configurations/rules.toml
+++ b/demo/match_only/java/configurations/rules.toml
@@ -34,7 +34,7 @@ query = """((
 )
 (#eq? @name "barFoo")
 ))"""
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(method_declaration) @md"
 queries = ["""(
   (modifiers) @modifiers

--- a/demo/match_only/java/configurations/rules.toml
+++ b/demo/match_only/java/configurations/rules.toml
@@ -35,7 +35,7 @@ query = """((
 (#eq? @name "barFoo")
 ))"""
 [[rules.constraints]]
-matcher = "(method_declaration) @md"
+enclosing_node = "(method_declaration) @md"
 queries = ["""(
   (modifiers) @modifiers
   (#match? @modifiers ".*static.*")

--- a/demo/match_only/ts/configurations/rules.toml
+++ b/demo/match_only/ts/configurations/rules.toml
@@ -37,7 +37,7 @@ query = """
 """
 [[rules.filters]]
 enclosing_node = "(function_declaration) @fs"
-queries = ["""
+not_contains = ["""
 (
     (while_statement) @while_stmt
 )

--- a/demo/match_only/ts/configurations/rules.toml
+++ b/demo/match_only/ts/configurations/rules.toml
@@ -24,7 +24,7 @@ query = """
     (for_statement) @for_stmt
 )
 """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(function_declaration) @fs"
 
 
@@ -35,7 +35,7 @@ query = """
     (for_statement) @for_stmt
 )
 """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(function_declaration) @fs"
 queries = ["""
 (

--- a/demo/match_only/ts/configurations/rules.toml
+++ b/demo/match_only/ts/configurations/rules.toml
@@ -25,7 +25,7 @@ query = """
 )
 """
 [[rules.constraints]]
-matcher = "(function_declaration) @fs"
+enclosing_node = "(function_declaration) @fs"
 
 
 [[rules]]
@@ -36,7 +36,7 @@ query = """
 )
 """
 [[rules.constraints]]
-matcher = "(function_declaration) @fs"
+enclosing_node = "(function_declaration) @fs"
 queries = ["""
 (
     (while_statement) @while_stmt

--- a/demo/match_only/tsx/configurations/rules.toml
+++ b/demo/match_only/tsx/configurations/rules.toml
@@ -52,7 +52,7 @@ enclosing_node = """
     (variable_declarator) @vd
 )
 """
-queries = ["""
+not_contains = ["""
 (
     (jsx_element
         open_tag: (jsx_opening_element

--- a/demo/match_only/tsx/configurations/rules.toml
+++ b/demo/match_only/tsx/configurations/rules.toml
@@ -25,7 +25,7 @@ query = """
     (#eq? @identifier "props")
 )
 """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = """
 (
     (jsx_element
@@ -46,7 +46,7 @@ query = """
     (#eq? @identifier "props")
 )
 """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = """
 (
     (variable_declarator) @vd

--- a/demo/match_only/tsx/configurations/rules.toml
+++ b/demo/match_only/tsx/configurations/rules.toml
@@ -26,7 +26,7 @@ query = """
 )
 """
 [[rules.constraints]]
-matcher = """
+enclosing_node = """
 (
     (jsx_element
         open_tag: (jsx_opening_element
@@ -47,7 +47,7 @@ query = """
 )
 """
 [[rules.constraints]]
-matcher = """
+enclosing_node = """
 (
     (variable_declarator) @vd
 )

--- a/demo/thrift_demos.py
+++ b/demo/thrift_demos.py
@@ -21,7 +21,7 @@ def thrift_demo():
     rpc.code = "@rpc_code"
 )""",
         filters={
-            filter(matcher="(exception_definition) @c_e",
+            Filter(matcher="(exception_definition) @c_e",
                    not_contains=["(annotation_definition) @ad"])
         },
         holes={

--- a/demo/thrift_demos.py
+++ b/demo/thrift_demos.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from os.path import join, dirname, getmtime
-from polyglot_piranha import Rule, RuleGraph, execute_piranha, PiranhaArguments, Constraint
+from polyglot_piranha import Rule, RuleGraph, execute_piranha, PiranhaArguments, filter
 import logging
 from logging import info
 
@@ -20,9 +20,9 @@ def thrift_demo():
         replace="""@exception_definition(
     rpc.code = "@rpc_code"
 )""",
-        constraints={
-            Constraint(matcher="(exception_definition) @c_e",
-                       queries=["(annotation_definition) @ad"])
+        filters={
+            filter(matcher="(exception_definition) @c_e",
+                   queries=["(annotation_definition) @ad"])
         },
         holes={
             "input_exception_name", "rpc_code"

--- a/demo/thrift_demos.py
+++ b/demo/thrift_demos.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from os.path import join, dirname, getmtime
-from polyglot_piranha import Rule, RuleGraph, execute_piranha, PiranhaArguments, filter
+from polyglot_piranha import Rule, RuleGraph, execute_piranha, PiranhaArguments, Filter
 import logging
 from logging import info
 

--- a/demo/thrift_demos.py
+++ b/demo/thrift_demos.py
@@ -22,7 +22,7 @@ def thrift_demo():
 )""",
         filters={
             filter(matcher="(exception_definition) @c_e",
-                   queries=["(annotation_definition) @ad"])
+                   not_contains=["(annotation_definition) @ad"])
         },
         holes={
             "input_exception_name", "rpc_code"

--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -163,13 +163,13 @@ class Filter:
     """
     enclosing_node: TSQuery
     "Scope in which the filter query has to be applied"
-    queries: list[TSQuery]
+    not_contains: list[TSQuery]
     "The Tree-sitter queries that need to be applied in the `enclosing_node` scope"
 
     def __init__(
         self,
         enclosing_node: str,
-        queries: list[str] = []
+        not_contains: list[str] = []
     ):
         """
         Constructs `Filter`
@@ -178,7 +178,7 @@ class Filter:
         ------------
             enclosing_node: str
                 Scope in which the filter query has to be applied
-            queries: list[str]
+            not_contains: list[str]
                  The Tree-sitter queries that need to be applied in the `enclosing_node` scope
         """
         ...

--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -158,28 +158,28 @@ class Point:
     row: int
     column: int
 
-class Constraint:
-    """ A class to capture Constraints of a Piranha Rule
+class Filter:
+    """ A class to capture filters of a Piranha Rule
     """
-    matcher: TSQuery
+    enclosing_node: TSQuery
     "Scope in which the constraint query has to be applied"
     queries: list[TSQuery]
-    "The Tree-sitter queries that need to be applied in the `matcher` scope"
+    "The Tree-sitter queries that need to be applied in the `enclosing_node` scope"
 
     def __init__(
         self,
-        matcher: str,
+        enclosing_node: str,
         queries: list[str] = []
     ):
         """
-        Constructs `Constraint`
+        Constructs `Filter`
 
         Parameters
         ------------
-            matcher: str
-                Scope in which the constraint query has to be applied
+            enclosing_node: str
+                Scope in which the filter query has to be applied
             queries: list[str]
-                 The Tree-sitter queries that need to be applied in the `matcher` scope
+                 The Tree-sitter queries that need to be applied in the `enclosing_node` scope
         """
         ...
 
@@ -198,8 +198,8 @@ class Rule:
     "Group(s) to which the rule belongs"
     holes: set[str]
     "Holes that need to be filled, in order to instantiate a rule"
-    constraints: set[Constraint]
-    "Additional constraints for matching the rule"
+    filters: set[Filter]
+    "Additional filters for matching the rule"
 
     def __init__(
         self,
@@ -209,7 +209,7 @@ class Rule:
         replace: Optional[str] = None,
         groups: set[str] = set(),
         holes: set[str] = set(),
-        constraints: set[Constraint] = set(),
+        filters: set[Filter] = set(),
         is_seed_rule: bool = True,
     ):
         """
@@ -229,8 +229,8 @@ class Rule:
                 Group(s) to which the rule belongs
             holes: set[str]
                 Holes that need to be filled, in order to instantiate a rule
-            constraints: set[Constraint]
-                Additional constraints for matching the rule
+            filters: set[Filter]
+                Additional filters for matching the rule
         """
         ...
 

--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -162,7 +162,7 @@ class Filter:
     """ A class to capture filters of a Piranha Rule
     """
     enclosing_node: TSQuery
-    "Scope in which the constraint query has to be applied"
+    "Scope in which the filter query has to be applied"
     queries: list[TSQuery]
     "The Tree-sitter queries that need to be applied in the `enclosing_node` scope"
 

--- a/src/cleanup_rules/go/rules.toml
+++ b/src/cleanup_rules/go/rules.toml
@@ -455,7 +455,7 @@ is_seed_rule = false
 # the filter is against an assigment_statement
 [[rules.filters]]
 enclosing_node = "(block) @block"
-queries = ["""
+not_contains = ["""
 (
     (assignment_statement
         left: (expression_list
@@ -484,7 +484,7 @@ holes = ["variable_name", "value"]
 is_seed_rule = false
 [[rules.filters]]
 enclosing_node = "(block) @block"
-queries = ["""
+not_contains = ["""
 (
     [
         (short_var_declaration

--- a/src/cleanup_rules/go/rules.toml
+++ b/src/cleanup_rules/go/rules.toml
@@ -452,8 +452,8 @@ replace_node = "short_v_decl"
 is_seed_rule = false
 # Check if there is an assignment to @variable_name with a value other than @value
 # Note that the query is against a short_var_declaration while
-# the constraint is against an assigment_statement
-[[rules.constraints]]
+# the filter is against an assigment_statement
+[[rules.filters]]
 enclosing_node = "(block) @block"
 queries = ["""
 (
@@ -482,7 +482,7 @@ replace = "@value"
 replace_node = "identifier"
 holes = ["variable_name", "value"]
 is_seed_rule = false
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(block) @block"
 queries = ["""
 (

--- a/src/cleanup_rules/go/rules.toml
+++ b/src/cleanup_rules/go/rules.toml
@@ -454,7 +454,7 @@ is_seed_rule = false
 # Note that the query is against a short_var_declaration while
 # the constraint is against an assigment_statement
 [[rules.constraints]]
-matcher = "(block) @block"
+enclosing_node = "(block) @block"
 queries = ["""
 (
     (assignment_statement
@@ -483,7 +483,7 @@ replace_node = "identifier"
 holes = ["variable_name", "value"]
 is_seed_rule = false
 [[rules.constraints]]
-matcher = "(block) @block"
+enclosing_node = "(block) @block"
 queries = ["""
 (
     [

--- a/src/cleanup_rules/go/scope_config.toml
+++ b/src/cleanup_rules/go/scope_config.toml
@@ -12,7 +12,7 @@
 [[scopes]]
 name = "File"
 [[scopes.rules]]
-matcher = """
+enclosing_node = """
 (source_file) @source_file
 """
 generator = """(source_file) @sf"""
@@ -20,7 +20,7 @@ generator = """(source_file) @sf"""
 [[scopes]]
 name = "Function-Method"
 [[scopes.rules]]
-matcher = """
+enclosing_node = """
 (
     (
         [

--- a/src/cleanup_rules/java/rules.toml
+++ b/src/cleanup_rules/java/rules.toml
@@ -486,7 +486,7 @@ query = """
 replace = ""
 replace_node = "enum_declaration"
 is_seed_rule = false
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(enum_declaration) @ed"
 queries = ["(enum_constant) @ec"]
 
@@ -503,7 +503,7 @@ query = """(
 replace = ""
 replace_node = "program"
 is_seed_rule = false
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(program) @c_program"
 queries = [
   "(enum_declaration) @c_enum_declaration",
@@ -555,9 +555,9 @@ is_seed_rule = false
 
 # Check if there is no assignment where the variable @variable_name is 
 # assigned to a value other than @init, within the method body
-# Please note that the tree-sitter queries in the constraint uses holes (i.e. `@variable_name` and `@init`).
+# Please note that the tree-sitter queries in the filter uses holes (i.e. `@variable_name` and `@init`).
 # These holes will be filled contextually based on the code snippet matched to `rule.query
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "[(method_declaration) (constructor_declaration)] @md"
 queries = ["""
 (
@@ -586,7 +586,7 @@ is_seed_rule = false
 
 # Check if there is no assignment where the variable @variable_name is 
 # assigned to a value other than @init, within the method body
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
 queries = ["""(
 ((assignment_expression
@@ -617,7 +617,7 @@ is_seed_rule = false
 holes = ["variable_name", "init"]
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"
 # which is initialized to "@init".
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "[(method_declaration) (constructor_declaration)] @md"
 queries = ["""(
 ((local_variable_declaration 
@@ -645,7 +645,7 @@ replace = ""
 replace_node = "expression_statement"
 is_seed_rule = false
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(method_declaration) @md"
 queries = [
   """(
@@ -656,7 +656,7 @@ queries = [
 (#eq? @vdcl.lhs "@variable_name")
 )""",
 ]
-[[rules.constraints]]
+[[rules.filters]]
 # There should exist no field declaration named `@variable_name` and
 # there should be no assignments to @variable_name that are not same as `@init`.
 enclosing_node = "(class_declaration) @cd"
@@ -677,7 +677,7 @@ queries = ["""(
 
 # Replace identifier with value if :
 # (i) There is no local variable declaration in the enclosing method with the name as the identifier 
-# TODO: Add field constraint
+# TODO: Add field filter
 [[rules]]
 name = "replace_identifier_with_value"
 query = """
@@ -690,7 +690,7 @@ replace = "@init"
 replace_node = "identifier"
 holes = ["variable_name", "init"]
 is_seed_rule = false
-[[rules.constraints]]
+[[rules.filters]]
 # There should exist no local variable declaration named `@identifer`
 enclosing_node = "[(method_declaration) (constructor_declaration)] @md"
 queries = ["""(

--- a/src/cleanup_rules/java/rules.toml
+++ b/src/cleanup_rules/java/rules.toml
@@ -487,7 +487,7 @@ replace = ""
 replace_node = "enum_declaration"
 is_seed_rule = false
 [[rules.constraints]]
-matcher = "(enum_declaration) @ed"
+enclosing_node = "(enum_declaration) @ed"
 queries = ["(enum_constant) @ec"]
 
 
@@ -504,7 +504,7 @@ replace = ""
 replace_node = "program"
 is_seed_rule = false
 [[rules.constraints]]
-matcher = "(program) @c_program"
+enclosing_node = "(program) @c_program"
 queries = [
   "(enum_declaration) @c_enum_declaration",
   "(class_declaration) @c_class_declaration",
@@ -558,7 +558,7 @@ is_seed_rule = false
 # Please note that the tree-sitter queries in the constraint uses holes (i.e. `@variable_name` and `@init`).
 # These holes will be filled contextually based on the code snippet matched to `rule.query
 [[rules.constraints]]
-matcher = "[(method_declaration) (constructor_declaration)] @md"
+enclosing_node = "[(method_declaration) (constructor_declaration)] @md"
 queries = ["""
 (
 ((assignment_expression
@@ -587,7 +587,7 @@ is_seed_rule = false
 # Check if there is no assignment where the variable @variable_name is 
 # assigned to a value other than @init, within the method body
 [[rules.constraints]]
-matcher = "(class_declaration) @cd"
+enclosing_node = "(class_declaration) @cd"
 queries = ["""(
 ((assignment_expression
                     left: (_) @a.lhs
@@ -618,7 +618,7 @@ holes = ["variable_name", "init"]
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"
 # which is initialized to "@init".
 [[rules.constraints]]
-matcher = "[(method_declaration) (constructor_declaration)] @md"
+enclosing_node = "[(method_declaration) (constructor_declaration)] @md"
 queries = ["""(
 ((local_variable_declaration 
                 declarator: (variable_declarator 
@@ -646,7 +646,7 @@ replace_node = "expression_statement"
 is_seed_rule = false
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"
 [[rules.constraints]]
-matcher = "(method_declaration) @md"
+enclosing_node = "(method_declaration) @md"
 queries = [
   """(
 ((local_variable_declaration
@@ -659,7 +659,7 @@ queries = [
 [[rules.constraints]]
 # There should exist no field declaration named `@variable_name` and
 # there should be no assignments to @variable_name that are not same as `@init`.
-matcher = "(class_declaration) @cd"
+enclosing_node = "(class_declaration) @cd"
 queries = ["""(
 ((assignment_expression
                     left: (_) @a.lhs
@@ -692,7 +692,7 @@ holes = ["variable_name", "init"]
 is_seed_rule = false
 [[rules.constraints]]
 # There should exist no local variable declaration named `@identifer`
-matcher = "[(method_declaration) (constructor_declaration)] @md"
+enclosing_node = "[(method_declaration) (constructor_declaration)] @md"
 queries = ["""(
 ((local_variable_declaration 
                 declarator: (variable_declarator 

--- a/src/cleanup_rules/java/rules.toml
+++ b/src/cleanup_rules/java/rules.toml
@@ -488,7 +488,7 @@ replace_node = "enum_declaration"
 is_seed_rule = false
 [[rules.filters]]
 enclosing_node = "(enum_declaration) @ed"
-queries = ["(enum_constant) @ec"]
+not_contains = ["(enum_constant) @ec"]
 
 
 # This rule deltes all the content of the file if it contains 
@@ -505,7 +505,7 @@ replace_node = "program"
 is_seed_rule = false
 [[rules.filters]]
 enclosing_node = "(program) @c_program"
-queries = [
+not_contains = [
   "(enum_declaration) @c_enum_declaration",
   "(class_declaration) @c_class_declaration",
   "(interface_declaration) @c_interface_declaration",
@@ -559,7 +559,7 @@ is_seed_rule = false
 # These holes will be filled contextually based on the code snippet matched to `rule.query
 [[rules.filters]]
 enclosing_node = "[(method_declaration) (constructor_declaration)] @md"
-queries = ["""
+not_contains = ["""
 (
 ((assignment_expression
                     left: (_) @a.lhs
@@ -588,7 +588,7 @@ is_seed_rule = false
 # assigned to a value other than @init, within the method body
 [[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
-queries = ["""(
+not_contains = ["""(
 ((assignment_expression
                     left: (_) @a.lhs
                     right: (_) @a.rhs) @assignment)
@@ -619,7 +619,7 @@ holes = ["variable_name", "init"]
 # which is initialized to "@init".
 [[rules.filters]]
 enclosing_node = "[(method_declaration) (constructor_declaration)] @md"
-queries = ["""(
+not_contains = ["""(
 ((local_variable_declaration 
                 declarator: (variable_declarator 
                                     name: (_) @vdcl.lhs
@@ -647,7 +647,7 @@ is_seed_rule = false
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"
 [[rules.filters]]
 enclosing_node = "(method_declaration) @md"
-queries = [
+not_contains = [
   """(
 ((local_variable_declaration
                 declarator: (variable_declarator 
@@ -660,7 +660,7 @@ queries = [
 # There should exist no field declaration named `@variable_name` and
 # there should be no assignments to @variable_name that are not same as `@init`.
 enclosing_node = "(class_declaration) @cd"
-queries = ["""(
+not_contains = ["""(
 ((assignment_expression
                     left: (_) @a.lhs
                     right: (_) @a.rhs) @a)
@@ -693,7 +693,7 @@ is_seed_rule = false
 [[rules.filters]]
 # There should exist no local variable declaration named `@identifer`
 enclosing_node = "[(method_declaration) (constructor_declaration)] @md"
-queries = ["""(
+not_contains = ["""(
 ((local_variable_declaration 
                 declarator: (variable_declarator 
                                     name: (_) @vdcl.lhs

--- a/src/cleanup_rules/java/scope_config.toml
+++ b/src/cleanup_rules/java/scope_config.toml
@@ -45,7 +45,7 @@ name = "Method"
 # (#eq? @tp "int a, int b, int c, int d, int e")
 # )
 #
-matcher = """
+enclosing_node = """
 (
   [(method_declaration 
             name : (_) @n
@@ -77,7 +77,7 @@ generator = """
 [[scopes]]
 name = "Class"
 [[scopes.rules]]
-matcher = """(
+enclosing_node = """(
   [
     (class_declaration name:(_) @n) @c
     (enum_declaration name:(_) @n) @c
@@ -96,7 +96,7 @@ generator = """(
 [[scopes]]
 name = "File"
 [[scopes.rules]]
-matcher = """
+enclosing_node = """
 (program) @c_u
 """
 generator = "(program) @compilation_unit"

--- a/src/cleanup_rules/kt/rules.toml
+++ b/src/cleanup_rules/kt/rules.toml
@@ -480,7 +480,7 @@ is_seed_rule = false
 [[rules.filters]]
 enclosing_node = """(class_declaration (_) @nm
     (enum_class_body)) @ed"""
-queries = ["(enum_entry) @ee"]
+not_contains = ["(enum_entry) @ee"]
 
 # Delete all file contents if 
 [[rules]]
@@ -492,7 +492,7 @@ replace_node = "program"
 is_seed_rule = false
 [[rules.filters]]
 enclosing_node = "(source_file) @sf"
-queries = [
+not_contains = [
   "(class_declaration) @cd",
   "(object_declaration) @od",
   "(function_declaration) @fd",
@@ -552,10 +552,10 @@ is_seed_rule = false
 # These holes will be filled contextually based on the code snippet matched to `rule.query
 # [[rules.filters]]
 # enclosing_node =  "(function_declaration) @md"
-# queries = [] 
+# not_contains = []
 [[rules.filters]]
 enclosing_node = "(function_declaration) @md"
-queries = [
+not_contains = [
   """(
 (assignment (directly_assignable_expression (simple_identifier)@a.lhs) (_)@a.rhs)    @assignment
 (#eq? @a.lhs "@variable_name")
@@ -578,7 +578,7 @@ is_seed_rule = false
 # assigned to a value other than @init, within the method body
 [[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
-queries = [
+not_contains = [
   """(
 (assignment (directly_assignable_expression (simple_identifier)@a.lhs) (_)@a.rhs)    @assignment
 (#eq? @a.lhs "@variable_name")
@@ -607,7 +607,7 @@ is_seed_rule = false
 # which is initialized to "@init".
 [[rules.filters]]
 enclosing_node = "(function_declaration) @md"
-queries = [
+not_contains = [
   """(
 (property_declaration (variable_declaration (simple_identifier)@vdcl.lhs ) 
                                  (boolean_literal)  @vdcl.init) @property_declaration
@@ -632,7 +632,7 @@ is_seed_rule = false
 # which is initialized to "@init".
 [[rules.filters]]
 enclosing_node = "(class_declaration) @md"
-queries = [
+not_contains = [
   """(
 (property_declaration (variable_declaration (simple_identifier)@vdcl.lhs ) 
                                  (boolean_literal)  @vdcl.init) @property_declaration
@@ -656,7 +656,7 @@ is_seed_rule = false
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"\
 [[rules.filters]]
 enclosing_node = "(function_declaration) @md"
-queries = ["""(
+not_contains = ["""(
 (property_declaration (variable_declaration (simple_identifier)@f_vdcl.lhs ) 
                                  (_)@f_vdcl.init) @property_declaration
   (#eq? @f_vdcl.lhs "@variable_name")
@@ -665,7 +665,7 @@ queries = ["""(
 
 [[rules.filters]]
 enclosing_node = "(function_declaration) @md"
-queries = [
+not_contains = [
   """(
 (assignment (directly_assignable_expression (simple_identifier)@a.lhs) (_)@a.rhs)    @f_assignment
   (#eq? @a.lhs "@variable_name")
@@ -675,7 +675,7 @@ queries = [
 
 [[rules.filters]]
 enclosing_node = "(class_declaration) @md"
-queries = ["""(
+not_contains = ["""(
 (property_declaration (variable_declaration (simple_identifier)@vdcl.lhs ) 
                                  (_)@vdcl.init ) @property_declaration
 (#eq? @vdcl.lhs "@variable_name")
@@ -684,7 +684,7 @@ queries = ["""(
 
 [[rules.filters]]
 enclosing_node = "(class_declaration) @md"
-queries = [
+not_contains = [
   """(
 (assignment (directly_assignable_expression (simple_identifier)@a.lhs) (_)@a.rhs)    @c_assignment
   (#eq? @a.lhs "@variable_name")
@@ -711,7 +711,7 @@ is_seed_rule = false
 # [[rules.filters]]
 # There should exist no local variable declaration named `@identifer`
 # enclosing_node =  "(function_declaration) @md"
-# queries = [
+# not_contains = [
 #   """(
 # (property_declaration (variable_declaration (simple_identifier)@vdcl.lhs ) 
 #                                  [(boolean_literal)  @vdcl.init ( parenthesized_expression (boolean_literal) @vdcl.init)]) @property_declaration

--- a/src/cleanup_rules/kt/rules.toml
+++ b/src/cleanup_rules/kt/rules.toml
@@ -477,7 +477,7 @@ query = """
 replace = ""
 replace_node = "enum_declaration"
 is_seed_rule = false
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = """(class_declaration (_) @nm
     (enum_class_body)) @ed"""
 queries = ["(enum_entry) @ee"]
@@ -490,7 +490,7 @@ query = """
 replace = ""
 replace_node = "program"
 is_seed_rule = false
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(source_file) @sf"
 queries = [
   "(class_declaration) @cd",
@@ -548,12 +548,12 @@ is_seed_rule = false
 
 # Check if there is no assignment where the variable @variable_name is 
 # assigned to a value other than @init, within the method body
-# Please note that the tree-sitter queries in the constraint uses holes (i.e. `@variable_name` and `@init`).
+# Please note that the tree-sitter queries in the filter uses holes (i.e. `@variable_name` and `@init`).
 # These holes will be filled contextually based on the code snippet matched to `rule.query
-# [[rules.constraints]]
+# [[rules.filters]]
 # enclosing_node =  "(function_declaration) @md"
 # queries = [] 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(function_declaration) @md"
 queries = [
   """(
@@ -576,7 +576,7 @@ replace_node = "property_declaration"
 is_seed_rule = false
 # Check if there is no assignment where the variable @variable_name is 
 # assigned to a value other than @init, within the method body
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
 queries = [
   """(
@@ -605,7 +605,7 @@ holes = ["variable_name", "init"]
 is_seed_rule = false
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"
 # which is initialized to "@init".
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(function_declaration) @md"
 queries = [
   """(
@@ -630,7 +630,7 @@ holes = ["variable_name", "init"]
 is_seed_rule = false
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"
 # which is initialized to "@init".
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @md"
 queries = [
   """(
@@ -654,7 +654,7 @@ replace = ""
 replace_node = "assignment"
 is_seed_rule = false
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"\
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(function_declaration) @md"
 queries = ["""(
 (property_declaration (variable_declaration (simple_identifier)@f_vdcl.lhs ) 
@@ -663,7 +663,7 @@ queries = ["""(
   (#not-eq? @f_vdcl.init "@init")
 )"""]
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(function_declaration) @md"
 queries = [
   """(
@@ -673,7 +673,7 @@ queries = [
 )""",
 ]
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @md"
 queries = ["""(
 (property_declaration (variable_declaration (simple_identifier)@vdcl.lhs ) 
@@ -682,7 +682,7 @@ queries = ["""(
 (#not-eq? @vdcl.init "@init")
 )"""]
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @md"
 queries = [
   """(
@@ -695,7 +695,7 @@ queries = [
 
 # Replace identifier with value if :
 # (i) There is no local variable declaration in the enclosing method with the name as the identifier 
-# TODO: Add field constraint
+# TODO: Add field filter
 [[rules]]
 holes = ["variable_name", "init"]
 name = "replace_identifier_with_value"
@@ -708,7 +708,7 @@ query = """
 replace = "@init"
 replace_node = "identifier"
 is_seed_rule = false
-# [[rules.constraints]]
+# [[rules.filters]]
 # There should exist no local variable declaration named `@identifer`
 # enclosing_node =  "(function_declaration) @md"
 # queries = [

--- a/src/cleanup_rules/kt/rules.toml
+++ b/src/cleanup_rules/kt/rules.toml
@@ -478,7 +478,7 @@ replace = ""
 replace_node = "enum_declaration"
 is_seed_rule = false
 [[rules.constraints]]
-matcher = """(class_declaration (_) @nm
+enclosing_node = """(class_declaration (_) @nm
     (enum_class_body)) @ed"""
 queries = ["(enum_entry) @ee"]
 
@@ -491,7 +491,7 @@ replace = ""
 replace_node = "program"
 is_seed_rule = false
 [[rules.constraints]]
-matcher = "(source_file) @sf"
+enclosing_node = "(source_file) @sf"
 queries = [
   "(class_declaration) @cd",
   "(object_declaration) @od",
@@ -551,10 +551,10 @@ is_seed_rule = false
 # Please note that the tree-sitter queries in the constraint uses holes (i.e. `@variable_name` and `@init`).
 # These holes will be filled contextually based on the code snippet matched to `rule.query
 # [[rules.constraints]]
-# matcher = "(function_declaration) @md"
+# enclosing_node =  "(function_declaration) @md"
 # queries = [] 
 [[rules.constraints]]
-matcher = "(function_declaration) @md"
+enclosing_node = "(function_declaration) @md"
 queries = [
   """(
 (assignment (directly_assignable_expression (simple_identifier)@a.lhs) (_)@a.rhs)    @assignment
@@ -577,7 +577,7 @@ is_seed_rule = false
 # Check if there is no assignment where the variable @variable_name is 
 # assigned to a value other than @init, within the method body
 [[rules.constraints]]
-matcher = "(class_declaration) @cd"
+enclosing_node = "(class_declaration) @cd"
 queries = [
   """(
 (assignment (directly_assignable_expression (simple_identifier)@a.lhs) (_)@a.rhs)    @assignment
@@ -606,7 +606,7 @@ is_seed_rule = false
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"
 # which is initialized to "@init".
 [[rules.constraints]]
-matcher = "(function_declaration) @md"
+enclosing_node = "(function_declaration) @md"
 queries = [
   """(
 (property_declaration (variable_declaration (simple_identifier)@vdcl.lhs ) 
@@ -631,7 +631,7 @@ is_seed_rule = false
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"
 # which is initialized to "@init".
 [[rules.constraints]]
-matcher = "(class_declaration) @md"
+enclosing_node = "(class_declaration) @md"
 queries = [
   """(
 (property_declaration (variable_declaration (simple_identifier)@vdcl.lhs ) 
@@ -655,7 +655,7 @@ replace_node = "assignment"
 is_seed_rule = false
 # The enclosing methode declaration should not contain a local variable decalration named "@variable_name"\
 [[rules.constraints]]
-matcher = "(function_declaration) @md"
+enclosing_node = "(function_declaration) @md"
 queries = ["""(
 (property_declaration (variable_declaration (simple_identifier)@f_vdcl.lhs ) 
                                  (_)@f_vdcl.init) @property_declaration
@@ -664,7 +664,7 @@ queries = ["""(
 )"""]
 
 [[rules.constraints]]
-matcher = "(function_declaration) @md"
+enclosing_node = "(function_declaration) @md"
 queries = [
   """(
 (assignment (directly_assignable_expression (simple_identifier)@a.lhs) (_)@a.rhs)    @f_assignment
@@ -674,7 +674,7 @@ queries = [
 ]
 
 [[rules.constraints]]
-matcher = "(class_declaration) @md"
+enclosing_node = "(class_declaration) @md"
 queries = ["""(
 (property_declaration (variable_declaration (simple_identifier)@vdcl.lhs ) 
                                  (_)@vdcl.init ) @property_declaration
@@ -683,7 +683,7 @@ queries = ["""(
 )"""]
 
 [[rules.constraints]]
-matcher = "(class_declaration) @md"
+enclosing_node = "(class_declaration) @md"
 queries = [
   """(
 (assignment (directly_assignable_expression (simple_identifier)@a.lhs) (_)@a.rhs)    @c_assignment
@@ -710,7 +710,7 @@ replace_node = "identifier"
 is_seed_rule = false
 # [[rules.constraints]]
 # There should exist no local variable declaration named `@identifer`
-# matcher = "(function_declaration) @md"
+# enclosing_node =  "(function_declaration) @md"
 # queries = [
 #   """(
 # (property_declaration (variable_declaration (simple_identifier)@vdcl.lhs ) 

--- a/src/cleanup_rules/kt/scope_config.toml
+++ b/src/cleanup_rules/kt/scope_config.toml
@@ -32,7 +32,7 @@
 [[scopes]]
 name = "Function"
 [[scopes.rules]]
-matcher = """
+enclosing_node = """
 ((function_declaration (simple_identifier) @n  (function_value_parameters) @sign (function_body) @fb) @qd5)
 """
 generator = """(
@@ -45,7 +45,7 @@ generator = """(
 [[scopes]]
 name = "Class"
 [[scopes.rules]]
-matcher = "(class_declaration (type_identifier) @n) @c"
+enclosing_node = "(class_declaration (type_identifier) @n) @c"
 generator = """
 (
 ((class_declaration (type_identifier) @z) @qc)
@@ -58,7 +58,7 @@ generator = """
 [[scopes]]
 name = "File"
 [[scopes.rules]]
-matcher = """
+enclosing_node = """
 (source_file) @s_f
 """
 generator = "(source_file) @source_file"

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -549,11 +549,11 @@ replace_node = "property_declaration"
 replace = ""
 is_seed_rule = false
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "[(function_declaration) (init_declaration)] @cfd"
 
 # skip the rule if the variable is assigned with some other value in the class scope
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
 queries = ["""(
     (assignment
@@ -573,7 +573,7 @@ queries = ["""(
     (#not-eq? @val "@hvalue")
 )"""]
 
-# rule to delete assignments like a = true subject to the mentioned constraints
+# rule to delete assignments like a = true subject to the mentioned filters
 [[rules]]
 name = "delete_parent_assignment"
 query = """(
@@ -597,7 +597,7 @@ replace = ""
 holes = ["hvariable", "hvalue"]
 is_seed_rule = false
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
 queries = [
   # skip the rule if the variable is declared with a different value in the class scope
@@ -640,7 +640,7 @@ queries = [
     )""",
 ]
 
-# rule to replace the identifier with the value with the mentioned constraints
+# rule to replace the identifier with the value with the mentioned filters
 [[rules]]
 name = "replace_identifier_with_value"
 query = """(
@@ -652,7 +652,7 @@ replace = "@hvalue"
 holes = ["hvariable", "hvalue"]
 is_seed_rule = false
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
 queries = [
   # skip the rule if the variable is one of the parameters of some function
@@ -701,10 +701,10 @@ replace = ""
 holes = ["hvariable"]
 is_seed_rule = false
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @ccd"
 
-# rule to replace field variable used as self.x subject to the mentioned constraints
+# rule to replace field variable used as self.x subject to the mentioned filters
 [[rules]]
 name = "replace_self_identifier_with_value"
 query = """(
@@ -721,7 +721,7 @@ replace = "@hvalue"
 holes = ["hvariable", "hvalue"]
 is_seed_rule = false
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
 queries = [
   # skip the rule if the variable is one of the parameters of some function
@@ -776,7 +776,7 @@ replace_node = "property_declaration"
 replace = ""
 is_seed_rule = false
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
 queries = [
   # skip the rule if the variable is one of the parameters of some function
@@ -807,7 +807,7 @@ queries = [
 ]
 
 
-# rule to delete field initialised in the init subject to the mentioned constraints
+# rule to delete field initialised in the init subject to the mentioned filters
 [[rules]]
 name = "delete_field_initialisation_init"
 query = """(
@@ -829,11 +829,11 @@ replace_node = "assignment"
 replace = ""
 is_seed_rule = false
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(init_declaration) @cid"
 
 
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
 queries = [
   # skip the rule if the variable is one of the parameters of some function

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -555,7 +555,7 @@ enclosing_node = "[(function_declaration) (init_declaration)] @cfd"
 # skip the rule if the variable is assigned with some other value in the class scope
 [[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
-queries = ["""(
+not_contains = ["""(
     (assignment
         target: (directly_assignable_expression
             [ (navigation_expression
@@ -599,7 +599,7 @@ is_seed_rule = false
 
 [[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
-queries = [
+not_contains = [
   # skip the rule if the variable is declared with a different value in the class scope
   """(
         (property_declaration
@@ -654,7 +654,7 @@ is_seed_rule = false
 
 [[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
-queries = [
+not_contains = [
   # skip the rule if the variable is one of the parameters of some function
   """(
         (parameter
@@ -723,7 +723,7 @@ is_seed_rule = false
 
 [[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
-queries = [
+not_contains = [
   # skip the rule if the variable is one of the parameters of some function
   """(
         (parameter
@@ -778,7 +778,7 @@ is_seed_rule = false
 
 [[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
-queries = [
+not_contains = [
   # skip the rule if the variable is one of the parameters of some function
   """(
         (parameter
@@ -835,7 +835,7 @@ enclosing_node = "(init_declaration) @cid"
 
 [[rules.filters]]
 enclosing_node = "(class_declaration) @cd"
-queries = [
+not_contains = [
   # skip the rule if the variable is one of the parameters of some function
   """(
         (parameter

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -550,11 +550,11 @@ replace = ""
 is_seed_rule = false
 
 [[rules.constraints]]
-matcher = "[(function_declaration) (init_declaration)] @cfd"
+enclosing_node = "[(function_declaration) (init_declaration)] @cfd"
 
 # skip the rule if the variable is assigned with some other value in the class scope
 [[rules.constraints]]
-matcher = "(class_declaration) @cd"
+enclosing_node = "(class_declaration) @cd"
 queries = ["""(
     (assignment
         target: (directly_assignable_expression
@@ -598,7 +598,7 @@ holes = ["hvariable", "hvalue"]
 is_seed_rule = false
 
 [[rules.constraints]]
-matcher = "(class_declaration) @cd"
+enclosing_node = "(class_declaration) @cd"
 queries = [
   # skip the rule if the variable is declared with a different value in the class scope
   """(
@@ -653,7 +653,7 @@ holes = ["hvariable", "hvalue"]
 is_seed_rule = false
 
 [[rules.constraints]]
-matcher = "(class_declaration) @cd"
+enclosing_node = "(class_declaration) @cd"
 queries = [
   # skip the rule if the variable is one of the parameters of some function
   """(
@@ -702,7 +702,7 @@ holes = ["hvariable"]
 is_seed_rule = false
 
 [[rules.constraints]]
-matcher = "(class_declaration) @ccd"
+enclosing_node = "(class_declaration) @ccd"
 
 # rule to replace field variable used as self.x subject to the mentioned constraints
 [[rules]]
@@ -722,7 +722,7 @@ holes = ["hvariable", "hvalue"]
 is_seed_rule = false
 
 [[rules.constraints]]
-matcher = "(class_declaration) @cd"
+enclosing_node = "(class_declaration) @cd"
 queries = [
   # skip the rule if the variable is one of the parameters of some function
   """(
@@ -777,7 +777,7 @@ replace = ""
 is_seed_rule = false
 
 [[rules.constraints]]
-matcher = "(class_declaration) @cd"
+enclosing_node = "(class_declaration) @cd"
 queries = [
   # skip the rule if the variable is one of the parameters of some function
   """(
@@ -830,11 +830,11 @@ replace = ""
 is_seed_rule = false
 
 [[rules.constraints]]
-matcher = "(init_declaration) @cid"
+enclosing_node = "(init_declaration) @cid"
 
 
 [[rules.constraints]]
-matcher = "(class_declaration) @cd"
+enclosing_node = "(class_declaration) @cd"
 queries = [
   # skip the rule if the variable is one of the parameters of some function
   """(

--- a/src/cleanup_rules/swift/scope_config.toml
+++ b/src/cleanup_rules/swift/scope_config.toml
@@ -13,7 +13,7 @@
 [[scopes]]
 name = "Class"
 [[scopes.rules]]
-matcher = """
+enclosing_node = """
 (class_declaration name: (_) @cls_name) @class
 """
 generator = """(
@@ -24,7 +24,7 @@ generator = """(
 [[scopes]]
 name = "Function"
 [[scopes.rules]]
-matcher = """(
+enclosing_node = """(
     (function_declaration
         name: (simple_identifier)? @name
         (parameter)? @params
@@ -44,7 +44,7 @@ generator = """(
 [[scopes]]
 name = "Constructor"
 [[scopes.rules]]
-matcher = """(
+enclosing_node = """(
     (init_declaration
         (parameter)? @params
         body: (function_body)
@@ -61,7 +61,7 @@ generator = """(
 [[scopes]]
 name = "File"
 [[scopes.rules]]
-matcher = """
+enclosing_node = """
 (source_file) @source_file
 """
 generator = """(source_file) @sf"""

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ Copyright (c) 2023 Uber Technologies, Inc.
 
 #![allow(deprecated)] // This prevents cargo clippy throwing warning for deprecated use.
 use models::{
-  constraint::Filter, edit::Edit, matches::Match, outgoing_edges::OutgoingEdges,
+  edit::Edit, filter::Filter, matches::Match, outgoing_edges::OutgoingEdges,
   piranha_arguments::PiranhaArguments, piranha_output::PiranhaOutputSummary, rule::Rule,
   rule_graph::RuleGraph, source_code_unit::SourceCodeUnit,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ Copyright (c) 2023 Uber Technologies, Inc.
 
 #![allow(deprecated)] // This prevents cargo clippy throwing warning for deprecated use.
 use models::{
-  constraint::Constraint, edit::Edit, matches::Match, outgoing_edges::OutgoingEdges,
+  constraint::Filter, edit::Edit, matches::Match, outgoing_edges::OutgoingEdges,
   piranha_arguments::PiranhaArguments, piranha_output::PiranhaOutputSummary, rule::Rule,
   rule_graph::RuleGraph, source_code_unit::SourceCodeUnit,
 };
@@ -45,7 +45,7 @@ fn polyglot_piranha(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
   m.add_class::<RuleGraph>()?;
   m.add_class::<Rule>()?;
   m.add_class::<OutgoingEdges>()?;
-  m.add_class::<Constraint>()?;
+  m.add_class::<Filter>()?;
   Ok(())
 }
 

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -122,7 +122,7 @@ pub(crate) fn default_groups() -> HashSet<String> {
   HashSet::new()
 }
 
-pub(crate) fn default_constraints() -> HashSet<Filter> {
+pub(crate) fn default_filters() -> HashSet<Filter> {
   HashSet::new()
 }
 

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use glob::Pattern;
 
 use super::{
-  constraint::Filter, language::PiranhaLanguage, outgoing_edges::OutgoingEdges, rule::Rule,
+  filter::Filter, language::PiranhaLanguage, outgoing_edges::OutgoingEdges, rule::Rule,
   rule_graph::RuleGraph,
 };
 use crate::utilities::tree_sitter_utilities::TSQuery;

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -138,7 +138,7 @@ pub(crate) fn default_queries() -> Vec<TSQuery> {
   Vec::new()
 }
 
-pub(crate) fn default_matcher() -> TSQuery {
+pub(crate) fn default_enclosing_node() -> TSQuery {
   TSQuery::new(String::new())
 }
 

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use glob::Pattern;
 
 use super::{
-  constraint::Constraint, language::PiranhaLanguage, outgoing_edges::OutgoingEdges, rule::Rule,
+  constraint::Filter, language::PiranhaLanguage, outgoing_edges::OutgoingEdges, rule::Rule,
   rule_graph::RuleGraph,
 };
 use crate::utilities::tree_sitter_utilities::TSQuery;
@@ -122,7 +122,7 @@ pub(crate) fn default_groups() -> HashSet<String> {
   HashSet::new()
 }
 
-pub(crate) fn default_constraints() -> HashSet<Constraint> {
+pub(crate) fn default_constraints() -> HashSet<Filter> {
   HashSet::new()
 }
 

--- a/src/models/filter.rs
+++ b/src/models/filter.rs
@@ -124,15 +124,15 @@ impl SourceCodeUnit {
     rule
       .filters()
       .iter()
-      .all(|filter| self._is_satisfied(filter.clone(), node, rule_store, &updated_substitutions))
+      .all(|filter| self._check(filter.clone(), node, rule_store, &updated_substitutions))
   }
 
   /// Checks if the node satisfies the filters.
-  /// filter has two parts (i) `filter.enclosing_node` (ii) `filter.query`.
+  /// filter has two parts (i) `filter.enclosing_node` (ii) `filter.not_contains`.
   /// This function traverses the ancestors of the given `node` until `filter.enclosing_node` matches
   /// i.e. finds scope for filter.
-  /// Within this scope it checks if the `filter.query` DOES NOT MATCH any sub-tree.
-  fn _is_satisfied(
+  /// Within this scope it checks if the `filter.not_contains` DOES NOT MATCH any sub-tree.
+  fn _check(
     &self, filter: Filter, node: Node, rule_store: &mut RuleStore,
     substitutions: &HashMap<String, String>,
   ) -> bool {

--- a/src/models/filter.rs
+++ b/src/models/filter.rs
@@ -142,7 +142,7 @@ impl SourceCodeUnit {
     if node.child_count() > 0 {
       current_node = node.child(0).unwrap();
     }
-    // Get the scope_node of the filter (`scope.enclosing_node`)
+    // Get the enclosing node matching the pattern specified in the filter (`filter.enclosing_node`)
     let mut matched_enclosing_node = false;
     while let Some(parent) = current_node.parent() {
       let instantiated_filter = filter.instantiate(substitutions);

--- a/src/models/filter.rs
+++ b/src/models/filter.rs
@@ -90,7 +90,7 @@ impl Filter {
 ///
 macro_rules! constraint {
   (matcher = $matcher:expr, queries= [$($q:expr,)*]) => {
-    $crate::models::constraint::FilterBuilder::default()
+    $crate::models::filter::FilterBuilder::default()
       .matcher($crate::utilities::tree_sitter_utilities::TSQuery::new($matcher.to_string()))
       .queries(vec![$($crate::utilities::tree_sitter_utilities::TSQuery::new($q.to_string()),)*])
       .build().unwrap()

--- a/src/models/filter.rs
+++ b/src/models/filter.rs
@@ -34,7 +34,7 @@ use super::default_configs::{default_enclosing_node, default_queries};
 #[derive(Deserialize, Debug, Clone, Hash, PartialEq, Eq, Getters, Builder)]
 #[pyclass]
 pub struct Filter {
-  /// Scope in which the filter query has to be applied
+  /// AST patterns that some ancestor node of the primary match should comply
   #[builder(default = "default_enclosing_node()")]
   #[get = "pub"]
   #[pyo3(get)]

--- a/src/models/matches.rs
+++ b/src/models/matches.rs
@@ -298,7 +298,7 @@ impl SourceCodeUnit {
       replace_node_tag,
     );
 
-    // Return the first match that satisfies constraint of the rule
+    // Return the first match that satisfies filter of the rule
     for p_match in all_query_matches.iter_mut() {
       let matched_node = get_node_for_range(
         self.root_node(),

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -11,9 +11,9 @@ Copyright (c) 2023 Uber Technologies, Inc.
  limitations under the License.
 */
 
-pub(crate) mod constraint;
 pub(crate) mod default_configs;
 pub(crate) mod edit;
+pub(crate) mod filter;
 pub(crate) mod language;
 pub(crate) mod matches;
 pub(crate) mod outgoing_edges;

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -23,7 +23,7 @@ use crate::utilities::{gen_py_str_methods, tree_sitter_utilities::TSQuery, Insta
 
 use super::{
   default_configs::{
-    default_constraints, default_groups, default_holes, default_is_seed_rule, default_query,
+    default_filters, default_groups, default_holes, default_is_seed_rule, default_query,
     default_replace, default_replace_node, default_rule_name,
   },
   filter::Filter,
@@ -73,14 +73,14 @@ pub struct Rule {
   #[get = "pub"]
   #[pyo3(get)]
   holes: HashSet<String>,
-  /// Additional constraints for matching the rule
-  #[builder(default = "default_constraints()")]
-  #[serde(default = "default_constraints")]
+  /// Additional filters for matching the rule
+  #[builder(default = "default_filters()")]
+  #[serde(default = "default_filters")]
   #[get = "pub"]
   #[pyo3(get)]
-  constraints: HashSet<Filter>,
+  filters: HashSet<Filter>,
 
-  /// Additional constraints for matching the rule
+  /// Additional filters for matching the rule
   #[builder(default = "default_is_seed_rule()")]
   #[serde(default = "default_is_seed_rule")]
   #[get = "pub"]
@@ -130,7 +130,7 @@ macro_rules! piranha_rule {
                 $(, holes = [$($hole: expr)*])?
                 $(, is_seed_rule = $is_seed_rule:expr)?
                 $(, groups = [$($group_name: expr)*])?
-                $(, constraints = [$($constraint:tt)*])?
+                $(, filters = [$($filter:tt)*])?
               ) => {
     $crate::models::rule::RuleBuilder::default()
     .name($name.to_string())
@@ -139,7 +139,7 @@ macro_rules! piranha_rule {
     $(.replace($replace.to_string()))?
     $(.holes(std::collections::HashSet::from([$($hole.to_string(),)*])))?
     $(.groups(std::collections::HashSet::from([$($group_name.to_string(),)*])))?
-    $(.constraints(std::collections::HashSet::from([$($constraint)*])))?
+    $(.filters(std::collections::HashSet::from([$($filter)*])))?
     .build().unwrap()
   };
 }
@@ -150,7 +150,7 @@ impl Rule {
   fn py_new(
     name: String, query: String, replace: Option<String>, replace_node: Option<String>,
     holes: Option<HashSet<String>>, groups: Option<HashSet<String>>,
-    constraints: Option<HashSet<Filter>>, is_seed_rule: Option<bool>,
+    filters: Option<HashSet<Filter>>, is_seed_rule: Option<bool>,
   ) -> Self {
     let mut rule_builder = RuleBuilder::default();
     rule_builder.name(name).query(TSQuery::new(query));
@@ -170,8 +170,8 @@ impl Rule {
       rule_builder.groups(groups);
     }
 
-    if let Some(constraints) = constraints {
-      rule_builder.constraints(constraints);
+    if let Some(filters) = filters {
+      rule_builder.filters(filters);
     }
 
     if let Some(is_seed_rule) = is_seed_rule {
@@ -233,8 +233,8 @@ impl InstantiatedRule {
     self.rule().holes()
   }
 
-  pub fn constraints(&self) -> &HashSet<Filter> {
-    self.rule().constraints()
+  pub fn filters(&self) -> &HashSet<Filter> {
+    self.rule().filters()
   }
 }
 

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -22,7 +22,7 @@ use serde_derive::Deserialize;
 use crate::utilities::{gen_py_str_methods, tree_sitter_utilities::TSQuery, Instantiate};
 
 use super::{
-  constraint::Constraint,
+  constraint::Filter,
   default_configs::{
     default_constraints, default_groups, default_holes, default_is_seed_rule, default_query,
     default_replace, default_replace_node, default_rule_name,
@@ -78,7 +78,7 @@ pub struct Rule {
   #[serde(default = "default_constraints")]
   #[get = "pub"]
   #[pyo3(get)]
-  constraints: HashSet<Constraint>,
+  constraints: HashSet<Filter>,
 
   /// Additional constraints for matching the rule
   #[builder(default = "default_is_seed_rule()")]
@@ -150,7 +150,7 @@ impl Rule {
   fn py_new(
     name: String, query: String, replace: Option<String>, replace_node: Option<String>,
     holes: Option<HashSet<String>>, groups: Option<HashSet<String>>,
-    constraints: Option<HashSet<Constraint>>, is_seed_rule: Option<bool>,
+    constraints: Option<HashSet<Filter>>, is_seed_rule: Option<bool>,
   ) -> Self {
     let mut rule_builder = RuleBuilder::default();
     rule_builder.name(name).query(TSQuery::new(query));
@@ -233,7 +233,7 @@ impl InstantiatedRule {
     self.rule().holes()
   }
 
-  pub fn constraints(&self) -> &HashSet<Constraint> {
+  pub fn constraints(&self) -> &HashSet<Filter> {
     self.rule().constraints()
   }
 }

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -73,7 +73,7 @@ pub struct Rule {
   #[get = "pub"]
   #[pyo3(get)]
   holes: HashSet<String>,
-  /// Additional filters for matching the rule
+  /// Filters to test before applying a rule
   #[builder(default = "default_filters()")]
   #[serde(default = "default_filters")]
   #[get = "pub"]

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -22,11 +22,11 @@ use serde_derive::Deserialize;
 use crate::utilities::{gen_py_str_methods, tree_sitter_utilities::TSQuery, Instantiate};
 
 use super::{
-  constraint::Filter,
   default_configs::{
     default_constraints, default_groups, default_holes, default_is_seed_rule, default_query,
     default_replace, default_replace_node, default_rule_name,
   },
+  filter::Filter,
 };
 
 #[derive(Deserialize, Debug, Clone, Default, PartialEq)]

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -80,7 +80,7 @@ pub struct Rule {
   #[pyo3(get)]
   filters: HashSet<Filter>,
 
-  /// Additional filters for matching the rule
+  /// Marks a rule as a seed rule
   #[builder(default = "default_is_seed_rule()")]
   #[serde(default = "default_is_seed_rule")]
   #[get = "pub"]

--- a/src/models/scopes.rs
+++ b/src/models/scopes.rs
@@ -40,7 +40,7 @@ pub(crate) struct ScopeGenerator {
 #[derive(Deserialize, Debug, Clone, Hash, PartialEq, Eq, Default, Getters, Builder)]
 pub(crate) struct ScopeQueryGenerator {
   #[get = "pub"]
-  matcher: TSQuery, // a tree-sitter query matching some enclosing AST pattern (like method or class)
+  enclosing_node: TSQuery, // a tree-sitter query matching some enclosing AST pattern (like method or class)
   #[get = "pub"]
   generator: TSQuery, // a tree-sitter query matching the exact AST node
 }
@@ -54,21 +54,21 @@ impl SourceCodeUnit {
   ) -> TSQuery {
     let root_node = self.root_node();
     let mut changed_node = get_node_for_range(root_node, start_byte, end_byte);
-    // Get the scope matchers for `scope_level` from the `scope_config.toml`.
-    let scope_matchers = rules_store.get_scope_query_generators(scope_level);
+    // Get the scope enclosing_nodes for `scope_level` from the `scope_config.toml`.
+    let scope_enclosing_nodes = rules_store.get_scope_query_generators(scope_level);
 
-    // Match the `scope_matcher.matcher` to the parent
+    // Match the `scope_enclosing_node.enclosing_node` to the parent
     loop {
       trace!(
         "Getting scope {} for node kind {}",
         scope_level,
         changed_node.kind()
       );
-      for m in &scope_matchers {
+      for m in &scope_enclosing_nodes {
         if let Some(p_match) = get_match_for_query(
           &changed_node,
           self.code(),
-          rules_store.query(m.matcher()),
+          rules_store.query(m.enclosing_node()),
           false,
         ) {
           // Generate the scope query for the specific context by substituting the

--- a/src/models/unit_tests/rule_test.rs
+++ b/src/models/unit_tests/rule_test.rs
@@ -81,7 +81,7 @@ fn test_get_edit_positive_recursive() {
     filters =[
         filter! {
           enclosing_node= "(method_declaration) @md",
-          queries = [
+          not_contains = [
             "(
               ((assignment_expression
                 left: (_) @a.lhs
@@ -141,7 +141,7 @@ fn test_get_edit_negative_recursive() {
     replace = "",
     filters =  [filter! {
           enclosing_node= "(method_declaration) @md",
-          queries = [
+          not_contains = [
             "(
               ((assignment_expression
                 left: (_) @a.lhs

--- a/src/models/unit_tests/rule_test.rs
+++ b/src/models/unit_tests/rule_test.rs
@@ -11,7 +11,7 @@ Copyright (c) 2023 Uber Technologies, Inc.
  limitations under the License.
 */
 use crate::{
-  constraint,
+  filter,
   models::{default_configs::UNUSED_CODE_PATH, piranha_arguments::PiranhaArgumentsBuilder},
   utilities::eq_without_whitespace,
 };
@@ -78,8 +78,8 @@ fn test_get_edit_positive_recursive() {
      )",
     replace_node = "variable_declaration",
     replace = "",
-    constraints =[
-        constraint! {
+    filters =[
+        filter! {
           enclosing_node= "(method_declaration) @md",
           queries = [
             "(
@@ -139,7 +139,7 @@ fn test_get_edit_negative_recursive() {
       )",
     replace_node = "variable_declaration",
     replace = "",
-    constraints =  [constraint! {
+    filters =  [filter! {
           enclosing_node= "(method_declaration) @md",
           queries = [
             "(

--- a/src/models/unit_tests/rule_test.rs
+++ b/src/models/unit_tests/rule_test.rs
@@ -80,7 +80,7 @@ fn test_get_edit_positive_recursive() {
     replace = "",
     constraints =[
         constraint! {
-          matcher= "(method_declaration) @md",
+          enclosing_node= "(method_declaration) @md",
           queries = [
             "(
               ((assignment_expression
@@ -140,7 +140,7 @@ fn test_get_edit_negative_recursive() {
     replace_node = "variable_declaration",
     replace = "",
     constraints =  [constraint! {
-          matcher= "(method_declaration) @md",
+          enclosing_node= "(method_declaration) @md",
           queries = [
             "(
               ((assignment_expression

--- a/src/models/unit_tests/scopes_test.rs
+++ b/src/models/unit_tests/scopes_test.rs
@@ -43,7 +43,7 @@ use {
 
 fn _get_class_scope() -> ScopeGenerator {
   let scope_query_generator_class: ScopeQueryGenerator = ScopeQueryGeneratorBuilder::default()
-    .matcher(TSQuery::new(
+    .enclosing_node(TSQuery::new(
       "(class_declaration name:(_) @n) @c".to_string(),
     ))
     .generator(TSQuery::new(
@@ -64,7 +64,7 @@ fn _get_class_scope() -> ScopeGenerator {
 
 fn _get_method_scope() -> ScopeGenerator {
   let scope_query_generator_method: ScopeQueryGenerator = ScopeQueryGeneratorBuilder::default()
-    .matcher(TSQuery::new(
+    .enclosing_node(TSQuery::new(
       "(
     [(method_declaration 
               name : (_) @n

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -14,7 +14,7 @@ Copyright (c) 2023 Uber Technologies, Inc.
 use tree_sitter::Parser;
 
 use crate::{
-  constraint,
+  filter,
   models::{
     default_configs::{JAVA, UNUSED_CODE_PATH},
     language::PiranhaLanguage,
@@ -124,7 +124,7 @@ fn test_apply_edit_negative() {
 }
 
 #[test]
-fn test_satisfies_constraints_positive() {
+fn test_satisfies_filters_positive() {
   let _rule = piranha_rule! {
     name= "test",
     query= "(
@@ -135,7 +135,7 @@ fn test_satisfies_constraints_positive() {
       )",
     replace_node= "variable_declaration",
     replace= "",
-    constraints= [constraint!{
+    filters= [filter!{
       enclosing_node= "(method_declaration) @md",
       queries= ["(
         ((assignment_expression
@@ -190,7 +190,7 @@ fn test_satisfies_constraints_positive() {
 }
 
 #[test]
-fn test_satisfies_constraints_negative() {
+fn test_satisfies_filters_negative() {
   let _rule = piranha_rule! {
     name= "test",
     query= "(
@@ -201,7 +201,7 @@ fn test_satisfies_constraints_negative() {
       )",
     replace_node= "variable_declaration",
     replace= "",
-    constraints= [constraint!{
+    filters= [filter!{
       enclosing_node= "(method_declaration) @md",
       queries= ["(
         ((assignment_expression

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -137,7 +137,7 @@ fn test_satisfies_filters_positive() {
     replace= "",
     filters= [filter!{
       enclosing_node= "(method_declaration) @md",
-      queries= ["(
+      not_contains= ["(
         ((assignment_expression
                         left: (_) @a.lhs
                         right: (_) @a.rhs) @assignment)
@@ -203,7 +203,7 @@ fn test_satisfies_filters_negative() {
     replace= "",
     filters= [filter!{
       enclosing_node= "(method_declaration) @md",
-      queries= ["(
+      not_contains= ["(
         ((assignment_expression
                         left: (_) @a.lhs
                         right: (_) @a.rhs) @assignment)

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -136,7 +136,7 @@ fn test_satisfies_constraints_positive() {
     replace_node= "variable_declaration",
     replace= "",
     constraints= [constraint!{
-      matcher= "(method_declaration) @md",
+      enclosing_node= "(method_declaration) @md",
       queries= ["(
         ((assignment_expression
                         left: (_) @a.lhs
@@ -202,7 +202,7 @@ fn test_satisfies_constraints_negative() {
     replace_node= "variable_declaration",
     replace= "",
     constraints= [constraint!{
-      matcher= "(method_declaration) @md",
+      enclosing_node= "(method_declaration) @md",
       queries= ["(
         ((assignment_expression
                         left: (_) @a.lhs

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -236,7 +236,7 @@ fn test_consecutive_scope_level_rules() {
       filters = [
         filter! {
           enclosing_node =  "(class_declaration ) @c_cd",
-          queries = ["(
+          not_contains = ["(
             (class_declaration name:(_) @name ) @cd
             (#eq? @name \"InnerFooBar\")
             )",]
@@ -256,7 +256,7 @@ fn test_consecutive_scope_level_rules() {
       filters = [
         filter! {
           enclosing_node =  "(class_declaration ) @c_cd",
-          queries = ["(
+          not_contains = ["(
           (field_declaration (variable_declarator name:(_) @name )) @field
           (#eq? @name \"address\")
           )",]

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -18,7 +18,7 @@ use super::{
   execute_piranha_and_check_result, initialize, substitutions,
 };
 use crate::{
-  constraint, edges, execute_piranha,
+  edges, execute_piranha, filter,
   models::{
     default_configs::JAVA, language::PiranhaLanguage, piranha_arguments::PiranhaArgumentsBuilder,
     rule_graph::RuleGraphBuilder,
@@ -233,8 +233,8 @@ fn test_consecutive_scope_level_rules() {
             private String name;
         }  
         }",
-      constraints = [
-        constraint! {
+      filters = [
+        filter! {
           enclosing_node =  "(class_declaration ) @c_cd",
           queries = ["(
             (class_declaration name:(_) @name ) @cd
@@ -253,8 +253,8 @@ fn test_consecutive_scope_level_rules() {
       replace_node = "class_body",
       replace = "{\n private String address;\n @class_members \n}",
       is_seed_rule= false,
-      constraints = [
-        constraint! {
+      filters = [
+        filter! {
           enclosing_node =  "(class_declaration ) @c_cd",
           queries = ["(
           (field_declaration (variable_declarator name:(_) @name )) @field

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -235,7 +235,7 @@ fn test_consecutive_scope_level_rules() {
         }",
       constraints = [
         constraint! {
-          matcher = "(class_declaration ) @c_cd",
+          enclosing_node =  "(class_declaration ) @c_cd",
           queries = ["(
             (class_declaration name:(_) @name ) @cd
             (#eq? @name \"InnerFooBar\")
@@ -255,7 +255,7 @@ fn test_consecutive_scope_level_rules() {
       is_seed_rule= false,
       constraints = [
         constraint! {
-          matcher = "(class_declaration ) @c_cd",
+          enclosing_node =  "(class_declaration ) @c_cd",
           queries = ["(
           (field_declaration (variable_declarator name:(_) @name )) @field
           (#eq? @name \"address\")

--- a/test-resources/go/structural_find/go_stmt_for_loop/configurations/rules.toml
+++ b/test-resources/go/structural_find/go_stmt_for_loop/configurations/rules.toml
@@ -16,5 +16,5 @@ query = """
     (go_statement) @go_stmt
 )
 """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(for_statement) @fs"

--- a/test-resources/go/structural_find/go_stmt_for_loop/configurations/rules.toml
+++ b/test-resources/go/structural_find/go_stmt_for_loop/configurations/rules.toml
@@ -17,4 +17,4 @@ query = """
 )
 """
 [[rules.constraints]]
-matcher = "(for_statement) @fs"
+enclosing_node = "(for_statement) @fs"

--- a/test-resources/java/insert_field_and_initializer/configurations/rules.toml
+++ b/test-resources/java/insert_field_and_initializer/configurations/rules.toml
@@ -28,7 +28,7 @@ query = """(
 )"""
 replace_node = "class_body"
 replace = "{\n private List<String> names;\n @class_members \n}"
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(class_declaration ) @c_cd"
 queries = ["""(
 (field_declaration (variable_declarator name:(_) @name )) @field
@@ -43,7 +43,7 @@ query = """
 replace_node = "pkg_dcl"
 replace = "@pkg_dcl \n import java.util.List;"
 is_seed_rule = false
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(program ) @prgrm"
 queries = ["""(
 (import_declaration (scoped_identifier) @type ) @import

--- a/test-resources/java/insert_field_and_initializer/configurations/rules.toml
+++ b/test-resources/java/insert_field_and_initializer/configurations/rules.toml
@@ -29,7 +29,7 @@ query = """(
 replace_node = "class_body"
 replace = "{\n private List<String> names;\n @class_members \n}"
 [[rules.constraints]]
-matcher = "(class_declaration ) @c_cd"
+enclosing_node = "(class_declaration ) @c_cd"
 queries = ["""(
 (field_declaration (variable_declarator name:(_) @name )) @field
 (#eq? @name "names")
@@ -44,7 +44,7 @@ replace_node = "pkg_dcl"
 replace = "@pkg_dcl \n import java.util.List;"
 is_seed_rule = false
 [[rules.constraints]]
-matcher = "(program ) @prgrm"
+enclosing_node = "(program ) @prgrm"
 queries = ["""(
 (import_declaration (scoped_identifier) @type ) @import
 (#eq? @type "java.util.List")

--- a/test-resources/java/insert_field_and_initializer/configurations/rules.toml
+++ b/test-resources/java/insert_field_and_initializer/configurations/rules.toml
@@ -30,7 +30,7 @@ replace_node = "class_body"
 replace = "{\n private List<String> names;\n @class_members \n}"
 [[rules.filters]]
 enclosing_node = "(class_declaration ) @c_cd"
-queries = ["""(
+not_contains = ["""(
 (field_declaration (variable_declarator name:(_) @name )) @field
 (#eq? @name "names")
 )"""]
@@ -45,7 +45,7 @@ replace = "@pkg_dcl \n import java.util.List;"
 is_seed_rule = false
 [[rules.filters]]
 enclosing_node = "(program ) @prgrm"
-queries = ["""(
+not_contains = ["""(
 (import_declaration (scoped_identifier) @type ) @import
 (#eq? @type "java.util.List")
 )"""]

--- a/test-resources/java/non_seed_user_rule/configurations/rules.toml
+++ b/test-resources/java/non_seed_user_rule/configurations/rules.toml
@@ -29,7 +29,7 @@ query = "(package_declaration (_)@package_name) @package_declaration"
 replace_node = "package_declaration"
 replace = "@package_declaration\nimport java.util.Collections;\n"
 is_seed_rule = false
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "((program) @cu)"
 queries = [
   """(

--- a/test-resources/java/non_seed_user_rule/configurations/rules.toml
+++ b/test-resources/java/non_seed_user_rule/configurations/rules.toml
@@ -30,7 +30,7 @@ replace_node = "package_declaration"
 replace = "@package_declaration\nimport java.util.Collections;\n"
 is_seed_rule = false
 [[rules.constraints]]
-matcher = "((program) @cu)"
+enclosing_node = "((program) @cu)"
 queries = [
   """(
 ((import_declaration (scoped_identifier (scoped_identifier) @type_qualifier (identifier)@type_name) @imported_type) @import)

--- a/test-resources/java/non_seed_user_rule/configurations/rules.toml
+++ b/test-resources/java/non_seed_user_rule/configurations/rules.toml
@@ -31,7 +31,7 @@ replace = "@package_declaration\nimport java.util.Collections;\n"
 is_seed_rule = false
 [[rules.filters]]
 enclosing_node = "((program) @cu)"
-queries = [
+not_contains = [
   """(
 ((import_declaration (scoped_identifier (scoped_identifier) @type_qualifier (identifier)@type_name) @imported_type) @import)
 (#eq? @imported_type "java.util.Collections")

--- a/test-resources/kt/feature_flag_system_2/control/configurations/rules.toml
+++ b/test-resources/kt/feature_flag_system_2/control/configurations/rules.toml
@@ -78,7 +78,7 @@ replace_node = "function_declaration"
 replace = ""
 groups = ["delete_property_declaration"]
 holes = ["stale_flag_name", "namespace"]
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = """(
 (class_declaration 
      (modifiers (annotation (constructor_invocation (_)@interface_annotation_name (value_arguments

--- a/test-resources/kt/feature_flag_system_2/control/configurations/rules.toml
+++ b/test-resources/kt/feature_flag_system_2/control/configurations/rules.toml
@@ -79,7 +79,7 @@ replace = ""
 groups = ["delete_property_declaration"]
 holes = ["stale_flag_name", "namespace"]
 [[rules.constraints]]
-matcher = """(
+enclosing_node = """(
 (class_declaration 
      (modifiers (annotation (constructor_invocation (_)@interface_annotation_name (value_arguments
                                                          (value_argument (_)@clhs (_)@crhs)))))) @cd

--- a/test-resources/kt/feature_flag_system_2/treated/configurations/rules.toml
+++ b/test-resources/kt/feature_flag_system_2/treated/configurations/rules.toml
@@ -78,7 +78,7 @@ replace_node = "function_declaration"
 replace = ""
 groups = ["delete_property_declaration"]
 holes = ["stale_flag_name", "namespace"]
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = """(
 (class_declaration 
      (modifiers (annotation (constructor_invocation (_)@interface_annotation_name (value_arguments

--- a/test-resources/kt/feature_flag_system_2/treated/configurations/rules.toml
+++ b/test-resources/kt/feature_flag_system_2/treated/configurations/rules.toml
@@ -79,7 +79,7 @@ replace = ""
 groups = ["delete_property_declaration"]
 holes = ["stale_flag_name", "namespace"]
 [[rules.constraints]]
-matcher = """(
+enclosing_node = """(
 (class_declaration 
      (modifiers (annotation (constructor_invocation (_)@interface_annotation_name (value_arguments
                                                          (value_argument (_)@clhs (_)@crhs)))))) @cd

--- a/test-resources/kt/file_scoped_chain_rules/configurations/rules.toml
+++ b/test-resources/kt/file_scoped_chain_rules/configurations/rules.toml
@@ -28,7 +28,7 @@ query = """
 replace_node = "call_expr"
 replace = "@parameter_interfaceProvider.create(@cache_parameters)"
 [[rules.constraints]]
-matcher = """(
+enclosing_node = """(
 (function_declaration (simple_identifier) @name) @md
 (#eq? @name "create")
 )"""

--- a/test-resources/kt/file_scoped_chain_rules/configurations/rules.toml
+++ b/test-resources/kt/file_scoped_chain_rules/configurations/rules.toml
@@ -27,7 +27,7 @@ query = """
 """
 replace_node = "call_expr"
 replace = "@parameter_interfaceProvider.create(@cache_parameters)"
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = """(
 (function_declaration (simple_identifier) @name) @md
 (#eq? @name "create")

--- a/test-resources/thrift/match_exception_type/configurations/rules.toml
+++ b/test-resources/thrift/match_exception_type/configurations/rules.toml
@@ -10,5 +10,5 @@ replace = """@exception_definition (
 )
         """
 [[rules.constraints]]
-matcher = "(exception_definition) @c_e"
+enclosing_node = "(exception_definition) @c_e"
 queries = ["(annotation_definition) @ad"]

--- a/test-resources/thrift/match_exception_type/configurations/rules.toml
+++ b/test-resources/thrift/match_exception_type/configurations/rules.toml
@@ -11,4 +11,4 @@ replace = """@exception_definition (
         """
 [[rules.filters]]
 enclosing_node = "(exception_definition) @c_e"
-queries = ["(annotation_definition) @ad"]
+not_contains = ["(annotation_definition) @ad"]

--- a/test-resources/thrift/match_exception_type/configurations/rules.toml
+++ b/test-resources/thrift/match_exception_type/configurations/rules.toml
@@ -9,6 +9,6 @@ replace = """@exception_definition (
    rpc.code = "INTERNAL"
 )
         """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(exception_definition) @c_e"
 queries = ["(annotation_definition) @ad"]

--- a/test-resources/ts/structural_find/find_fors_within_functions/configurations/rules.toml
+++ b/test-resources/ts/structural_find/find_fors_within_functions/configurations/rules.toml
@@ -17,4 +17,4 @@ query = """
 )
 """
 [[rules.constraints]]
-matcher = "(function_declaration) @fs"
+enclosing_node = "(function_declaration) @fs"

--- a/test-resources/ts/structural_find/find_fors_within_functions/configurations/rules.toml
+++ b/test-resources/ts/structural_find/find_fors_within_functions/configurations/rules.toml
@@ -16,5 +16,5 @@ query = """
     (for_statement) @for_stmt
 )
 """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(function_declaration) @fs"

--- a/test-resources/ts/structural_find/find_fors_within_functions_not_within_whiles/configurations/rules.toml
+++ b/test-resources/ts/structural_find/find_fors_within_functions_not_within_whiles/configurations/rules.toml
@@ -17,7 +17,7 @@ query = """
 )
 """
 [[rules.constraints]]
-matcher = "(function_declaration) @fs"
+enclosing_node = "(function_declaration) @fs"
 queries = ["""
 (
     (while_statement) @while_stmt

--- a/test-resources/ts/structural_find/find_fors_within_functions_not_within_whiles/configurations/rules.toml
+++ b/test-resources/ts/structural_find/find_fors_within_functions_not_within_whiles/configurations/rules.toml
@@ -16,7 +16,7 @@ query = """
     (for_statement) @for_stmt
 )
 """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = "(function_declaration) @fs"
 queries = ["""
 (

--- a/test-resources/ts/structural_find/find_fors_within_functions_not_within_whiles/configurations/rules.toml
+++ b/test-resources/ts/structural_find/find_fors_within_functions_not_within_whiles/configurations/rules.toml
@@ -18,7 +18,7 @@ query = """
 """
 [[rules.filters]]
 enclosing_node = "(function_declaration) @fs"
-queries = ["""
+not_contains = ["""
 (
     (while_statement) @while_stmt
 )

--- a/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/rules.toml
+++ b/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/rules.toml
@@ -17,7 +17,7 @@ query = """
     (#eq? @identifier "props")
 )
 """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = """
 (
     (jsx_element

--- a/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/rules.toml
+++ b/test-resources/tsx/structural_find/find_props_identifiers_within_b_jsx_elements/configurations/rules.toml
@@ -18,7 +18,7 @@ query = """
 )
 """
 [[rules.constraints]]
-matcher = """
+enclosing_node = """
 (
     (jsx_element
         open_tag: (jsx_opening_element

--- a/test-resources/tsx/structural_find/find_props_identifiers_within_variable_declarators_not_within_divs/configurations/rules.toml
+++ b/test-resources/tsx/structural_find/find_props_identifiers_within_variable_declarators_not_within_divs/configurations/rules.toml
@@ -18,7 +18,7 @@ query = """
 )
 """
 [[rules.constraints]]
-matcher = """
+enclosing_node = """
 (
     (variable_declarator) @vd
 )

--- a/test-resources/tsx/structural_find/find_props_identifiers_within_variable_declarators_not_within_divs/configurations/rules.toml
+++ b/test-resources/tsx/structural_find/find_props_identifiers_within_variable_declarators_not_within_divs/configurations/rules.toml
@@ -23,7 +23,7 @@ enclosing_node = """
     (variable_declarator) @vd
 )
 """
-queries = ["""
+not_contains = ["""
 (
     (jsx_element
         open_tag: (jsx_opening_element

--- a/test-resources/tsx/structural_find/find_props_identifiers_within_variable_declarators_not_within_divs/configurations/rules.toml
+++ b/test-resources/tsx/structural_find/find_props_identifiers_within_variable_declarators_not_within_divs/configurations/rules.toml
@@ -17,7 +17,7 @@ query = """
     (#eq? @identifier "props")
 )
 """
-[[rules.constraints]]
+[[rules.filters]]
 enclosing_node = """
 (
     (variable_declarator) @vd

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,7 +12,7 @@
 
 
 from pathlib import Path
-from polyglot_piranha import Constraint, execute_piranha, PiranhaArguments, PiranhaOutputSummary, Rule, RuleGraph, OutgoingEdges
+from polyglot_piranha import Filter, execute_piranha, PiranhaArguments, PiranhaOutputSummary, Rule, RuleGraph, OutgoingEdges
 from os.path import join, basename
 from os import listdir
 import re
@@ -83,9 +83,9 @@ def test_insert_field_add_import():
         replace="""{
   private List<String> names;\n @class_members
 }""",
-        constraints= set([
-            Constraint(
-                matcher= "(class_declaration ) @c_cd",
+        filters= set([
+            Filter(
+                enclosing_node= "(class_declaration ) @c_cd",
                 queries = ["""(
                     (field_declaration (variable_declarator name:(_) @name )) @field
                     (#eq? @name "names")
@@ -101,9 +101,9 @@ def test_insert_field_add_import():
         replace="""@pkg_dcl
 import java.util.List;
 """,
-        constraints= set([
-            Constraint(
-                matcher= "(program ) @prgrm",
+        filters= set([
+            Filter(
+                enclosing_node= "(program ) @prgrm",
                 queries = ["""
                 (
                     (import_declaration (scoped_identifier) @type ) @import

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -86,7 +86,7 @@ def test_insert_field_add_import():
         filters= set([
             Filter(
                 enclosing_node= "(class_declaration ) @c_cd",
-                queries = ["""(
+                not_contains = ["""(
                     (field_declaration (variable_declarator name:(_) @name )) @field
                     (#eq? @name "names")
                 )"""]
@@ -104,7 +104,7 @@ import java.util.List;
         filters= set([
             Filter(
                 enclosing_node= "(program ) @prgrm",
-                queries = ["""
+                not_contains = ["""
                 (
                     (import_declaration (scoped_identifier) @type ) @import
                     (#eq? @type "java.util.List")


### PR DESCRIPTION
Renamed constraints to filter #229 . Let me know if I missed something

- [x] update the field name, getter / setter ... in [rules]
- [x]  rename the file and contents of [constraints.rs](https://github.com/uber/piranha/blob/master/src/models/constraints.rs) to filter.rs and Constraints to Filter (and so on)
- [x] Update the code comments, variable names and method names with the pattern (constraint(s) -> filter(s), matcher -> enclosing_node and queries -> not_contains
- [x] Update README.md
(https://github.com/uber/piranha/blob/master/POLYGLOT_README.md)