### PR TITLE
Swift: Fix Clean statements after return

### DIFF
--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -52,8 +52,22 @@ to = [
 
 [[edges]]
 scope = "Parent"
+from = "replace_identifier_with_value"
+to = ["boolean_literal_cleanup"]
+
+[[edges]]
+scope = "Parent"
+from = "replace_self_identifier_with_value"
+to = ["boolean_literal_cleanup"]
+
+[[edges]]
+scope = "Parent"
 from = "boolean_literal_cleanup"
-to = ["boolean_expression_simplify", "statement_cleanup"]
+to = [
+  "delete_all_statements_after_return",
+  "boolean_expression_simplify",
+  "statement_cleanup",
+]
 
 [[edges]]
 scope = "Parent"

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -806,7 +806,6 @@ not_contains = [
     )""",
 ]
 
-
 # rule to delete field initialised in the init subject to the mentioned filters
 [[rules]]
 name = "delete_field_initialisation_init"
@@ -873,6 +872,20 @@ not_contains = [
         (#not-eq? @val "@hvalue")
     )""",
 ]
+
+[[rules]]
+name = "delete_all_statements_after_return"
+query = """(
+    (  
+        (statements)* @st
+        (control_transfer_statement) @cts
+        (_)+ @extras
+    )
+)"""
+groups = ["if_cleanup"]
+replace_node = "extras"
+replace = ""
+is_seed_rule = false
 
 # Dummy rule that acts as a junction for all boolean based cleanups
 # Let's say you want to define rules from A -> B, A -> C, D -> B, D -> C, ... 

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -886,6 +886,7 @@ not_contains = [
     )""",
 ]
 
+# rule to delete unreachable code after return statement
 [[rules]]
 name = "delete_all_statements_after_return"
 query = """(

--- a/src/tests/test_piranha_swift.rs
+++ b/src/tests/test_piranha_swift.rs
@@ -92,3 +92,10 @@ fn test_adhoc_variable_inline_file() {
   super::initialize();
   execute_piranha_with_default_swift_args("variable_inline/adhoc_variable_inline", vec![]);
 }
+
+#[test]
+#[ignore] // Long running test
+fn test_delete_everything_after_return() {
+  super::initialize();
+  execute_piranha_with_default_swift_args("delete_statements_after_return", vec![]);
+}

--- a/test-resources/swift/delete_statements_after_return/configurations/rules.toml
+++ b/test-resources/swift/delete_statements_after_return/configurations/rules.toml
@@ -1,0 +1,44 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# For @stale_flag_name = stale_flag and @treated = true
+# Before 
+#   placeholder_false
+# After 
+#   false
+#
+[[rules]]
+name = "test_rule_replace_false_placeholder"
+query = """(
+(simple_identifier) @variable
+(#eq? @variable "placeholder_false")
+)"""
+replace_node = "variable"
+replace = "false"
+groups = ["replace_expression_with_boolean_literal"]
+
+#
+# For @stale_flag_name = stale_flag and @treated = true
+# Before 
+#   placeholder_false
+# After 
+#   false
+#
+[[rules]]
+name = "test_rule_replace_true_placeholder"
+query = """(
+(simple_identifier) @variable
+(#eq? @variable "placeholder_true")
+)"""
+replace_node = "variable"
+replace = "true"
+groups = ["replace_expression_with_boolean_literal"]

--- a/test-resources/swift/delete_statements_after_return/expected/SampleClass.swift
+++ b/test-resources/swift/delete_statements_after_return/expected/SampleClass.swift
@@ -1,0 +1,29 @@
+class C1 {
+    func f1(){
+        // some function call
+        doSomething()
+        return some_return_value_1
+    }
+
+
+    func f2(){
+        return some_return_value_2
+    }
+}
+
+enum E1 {
+
+    case a
+    case b
+
+
+    var someComputedProperty: String? {
+        switch self{
+            case a:
+                return "some_return_value"
+            case b:
+                return "some_other_return_value"
+            default: "return_default_value"
+        }
+    }
+}

--- a/test-resources/swift/delete_statements_after_return/input/SampleClass.swift
+++ b/test-resources/swift/delete_statements_after_return/input/SampleClass.swift
@@ -1,0 +1,47 @@
+class C1 {
+    func f1(){
+        var a = placeholder_true
+        
+        // some function call
+        doSomething()
+
+        if a {
+            return some_return_value_1
+        }else {
+            doNothing()
+        }
+
+        // some function call
+        doSomethingElse()
+    }
+
+
+    func f2(){
+        // some comment
+        var b = placeholder_false
+
+        guard b else {
+            return some_return_value_2
+        }
+
+        // some function call
+        doSomething()
+    }
+}
+
+enum E1 {
+
+    case a
+    case b
+
+
+    var someComputedProperty: String? {
+        switch self{
+            case a:
+                return "some_return_value"
+            case b:
+                return "some_other_return_value"
+            default: "return_default_value"
+        }
+    }
+}

--- a/test-resources/swift/delete_statements_after_return/input/SampleClass.swift
+++ b/test-resources/swift/delete_statements_after_return/input/SampleClass.swift
@@ -13,6 +13,14 @@ class C1 {
 
         // some function call
         doSomethingElse()
+        
+        // some declarations
+        var b = "declaration"
+        if b == "test"{
+            dummyFunctionCall()
+        } else {
+            anotherDummyFunctionCall()
+        }
     }
 
 
@@ -26,6 +34,11 @@ class C1 {
 
         // some function call
         doSomething()
+
+        var c = doSomethingElse()
+        
+        // some comment
+        var d = c ? 1 : 0
     }
 }
 


### PR DESCRIPTION
This PR adds rules and tests to enable cleaning up the unreachable code after return statements inside various scopes for swift. Please refer to tests to know some use cases. 