### PR TITLE
Enhance Go cleanups

### DIFF
--- a/src/cleanup_rules/go/edges.toml
+++ b/src/cleanup_rules/go/edges.toml
@@ -38,7 +38,18 @@ to = ["if_cleanup"]
 [[edges]]
 scope = "Function-Method"
 from = "statement_cleanup"
-to = ["delete_variable_declaration"]
+to = ["delete_variable_declaration", "delete_variable_declaration_with_nil"]
+
+[[edges]]
+scope = "Function-Method"
+from = "delete_variable_declaration_with_nil"
+to = ["replace_identifier_with_value", "replace_identifier_with_nil"]
+
+[[edges]]
+scope = "Parent"
+from = "replace_identifier_with_nil"
+to = ["simplify_identity_equal", "simplify_identity_not_equal"]
+
 
 [[edges]]
 scope = "Function-Method"

--- a/src/cleanup_rules/go/rules.toml
+++ b/src/cleanup_rules/go/rules.toml
@@ -470,6 +470,55 @@ not_contains = ["""
 )
 """]
 
+# Before: 
+# enabled, err = true, nil 
+
+# After: 
+# <>
+[[rules]]
+name = "delete_variable_declaration_with_nil"
+query = """
+(
+    (
+        (short_var_declaration
+            left: (expression_list
+                (identifier) @variable_name
+                (identifier) @err
+            )
+            right: (expression_list
+                ([
+                    (true)
+                    (false)
+                ]) @value
+                (nil) @nil
+            )
+        )
+    ) @short_v_decl
+)
+"""
+replace = ""
+replace_node = "short_v_decl"
+is_seed_rule = false
+# Check if there is an assignment to @variable_name with a value other than @value
+# Note that the query is against a short_var_declaration while
+# the filter is against an assigment_statement
+[[rules.filters]]
+enclosing_node = "(block) @block"
+not_contains = ["""
+(
+    (assignment_statement
+        left: (expression_list
+            (identifier) @a.lhs
+        )
+        right: (expression_list
+            (_) @a.rhs
+        )
+    ) @assignment
+    (#eq? @a.lhs "@variable_name")
+    (#not-eq? @a.rhs "@value")
+)
+"""]
+
 [[rules]]
 name = "replace_identifier_with_value"
 query = """
@@ -504,5 +553,47 @@ not_contains = ["""
         ) @assignment
     ]
     (#eq? @vn "@variable_name")
+)
+"""]
+
+# for @err = "err"
+# Before: 
+# err 
+# After :
+# nil
+[[rules]]
+name = "replace_identifier_with_nil"
+query = """
+(
+    (identifier) @identifier
+    (#eq? @identifier "@err")
+)
+"""
+replace = "nil"
+replace_node = "identifier"
+holes = ["err"]
+is_seed_rule = false
+[[rules.filters]]
+enclosing_node = "(block) @block"
+not_contains = ["""
+(
+    [
+        (short_var_declaration
+            left: (expression_list
+                (identifier) @vn
+            )
+        ) @assignment
+        (var_declaration
+            (var_spec
+                name: (identifier) @vn
+            )
+        ) @assignment
+        (assignment_statement
+            left: (expression_list
+                (identifier) @vn
+            )
+        ) @assignment
+    ]
+    (#eq? @vn "@err")
 )
 """]

--- a/test-resources/go/feature_flag/builtin_rules/statement_cleanup/expected/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/statement_cleanup/expected/sample.go
@@ -42,6 +42,15 @@ func after_return1() string {
     return "not enabled"
 }
 
+func after_return_nil_1() string {
+    fmt.Println("Retain")
+    return "not enabled"
+}
+
+func after_return_nil_2() string {
+    return "not enabled"
+}
+
 func after_return2(a bool) string {
     if a {
         fmt.Println("not enabled")

--- a/test-resources/go/feature_flag/builtin_rules/statement_cleanup/input/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/statement_cleanup/input/sample.go
@@ -61,6 +61,33 @@ func after_return1() string {
     return "enabled"
 }
 
+func after_return_nil_1() string {
+    enabled, err := exp.BoolValue("false"), nil
+    if enabled {
+        return "enabled"
+    }
+
+    if err == nil {
+        fmt.Println("Retain")
+    }
+
+    return "not enabled"
+}
+
+
+func after_return_nil_2() string {
+    enabled, err := exp.BoolValue("true"), nil
+    if !enabled {
+        return "enabled"
+    }
+
+    if err != nil {
+        fmt.Println("Retain")
+    }
+
+    return "not enabled"
+}
+
 func after_return2(a bool) string {
     if a {
         enabled := exp.BoolValue("false")


### PR DESCRIPTION
Add rules that handle the scenario where the lhs of the variable declaration has two vars