### PR TITLE
Add support for iOS String Resource file format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,10 @@ tree-sitter-typescript = "0.20.1"
 # TODO: Update after https://github.com/tree-sitter/tree-sitter-go/pull/103 lands
 tree-sitter-go = { git = "https://github.com/uber/tree-sitter-go.git", rev = "8f807196afab4a1a1256dbf62a011020c6fe7745" }
 tree-sitter-thrift = "0.5.0"
+tree-sitter-strings = { git = "https://github.com/ketkarameya/tree-sitter-strings.git" }
 derive_builder = "0.12.0"
 getset = "0.1.2"
-pyo3 = "0.18.2"
+pyo3 = "0.19.0"
 pyo3-log = "0.8.1"
 glob = "0.3.1"
 

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -29,6 +29,7 @@ pub const SWIFT: &str = "swift";
 pub const TYPESCRIPT: &str = "ts";
 pub const TSX: &str = "tsx";
 pub const THRIFT: &str = "thrift";
+pub const STRINGS: &str = "strings";
 
 #[cfg(test)]
 //FIXME: Remove this  hack by not passing PiranhaArguments to SourceCodeUnit

--- a/src/models/language.rs
+++ b/src/models/language.rs
@@ -20,7 +20,9 @@ use tree_sitter::{Parser, Query};
 use crate::utilities::parse_toml;
 
 use super::{
-  default_configs::{default_language, GO, JAVA, KOTLIN, PYTHON, SWIFT, THRIFT, TSX, TYPESCRIPT},
+  default_configs::{
+    default_language, GO, JAVA, KOTLIN, PYTHON, STRINGS, SWIFT, THRIFT, TSX, TYPESCRIPT,
+  },
   outgoing_edges::Edges,
   rule::Rules,
   scopes::{ScopeConfig, ScopeGenerator},
@@ -62,6 +64,7 @@ pub enum SupportedLanguage {
   Tsx,
   Python,
   Thrift,
+  Strings,
 }
 
 impl PiranhaLanguage {
@@ -211,6 +214,15 @@ impl std::str::FromStr for PiranhaLanguage {
         extension: language.to_string(),
         supported_language: SupportedLanguage::Thrift,
         language: tree_sitter_thrift::language(),
+        rules: None,
+        edges: None,
+        scopes: vec![],
+        comment_nodes: vec![],
+      }),
+      STRINGS => Ok(PiranhaLanguage {
+        extension: language.to_string(),
+        supported_language: SupportedLanguage::Strings,
+        language: tree_sitter_strings::language(),
         rules: None,
         edges: None,
         scopes: vec![],

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -35,6 +35,8 @@ mod test_piranha_tsx;
 
 mod test_piranha_thrift;
 
+mod test_piranha_strings;
+
 use std::sync::Once;
 
 static INIT: Once = Once::new();

--- a/src/tests/test_piranha_strings.rs
+++ b/src/tests/test_piranha_strings.rs
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/*
+ Copyright (c) 2023 Uber Technologies, Inc.
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+use crate::models::default_configs::STRINGS;
+
+use super::{create_rewrite_tests, substitutions};
+
+create_rewrite_tests! {
+    STRINGS,
+    test_strings_scenario_rules_with_holes: "sample_strings/",1,
+    substitutions=  substitutions! {
+        "stale_key" => "Make Rich Text"
+      };
+}

--- a/test-resources/strings/sample_strings/configurations/rules.toml
+++ b/test-resources/strings/sample_strings/configurations/rules.toml
@@ -1,0 +1,30 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains rules to the specific feature flag API.
+
+#
+# For @stale_flag_name = test_second_experiment and @treated = true
+# Before 
+# case test_second_experiment
+# After 
+#  
+#
+[[rules]]
+name = "delete_entry_by_key"
+query = """
+(
+(statement (assignment_statement left :(string_literal) @lhs)) @statement
+(#eq? @lhs "\\\"@stale_key\\\"")
+)"""
+replace_node = "statement"
+replace = ""
+holes = ["stale_key"]

--- a/test-resources/strings/sample_strings/expected/sample_en.strings
+++ b/test-resources/strings/sample_strings/expected/sample_en.strings
@@ -1,0 +1,5 @@
+/* Menu item to make the current document plain text */ 
+"Make Plain Text" = "Make Plain Text";
+
+/* Menu item to make the current document italic text */ 
+"Make Italic Text" = "Make Italic Text";  

--- a/test-resources/strings/sample_strings/input/sample_en.strings
+++ b/test-resources/strings/sample_strings/input/sample_en.strings
@@ -1,0 +1,11 @@
+/* Menu item to make the current document plain text */ 
+"Make Plain Text" = "Make Plain Text";  
+
+// Menu item to make the current document rich text 
+"Make Rich Text" = "Make Rich Text";
+
+/* Menu item to make the current document italic text */ 
+"Make Italic Text" = "Make Italic Text";  
+
+/* Menu item to make the current document rich text */
+"Make Rich Text" = "Make Rich Text";


### PR DESCRIPTION
Add suuport for iOS String Resource file format. I had written the grammar for this few months ago. We had this support at one point but i removed it because I was trying to make a release on crates, which I ultimately did not end up making.