### PR TITLE
Validate Rule graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ tree-sitter-typescript = "0.20.1"
 tree-sitter-go = { git = "https://github.com/uber/tree-sitter-go.git", rev = "8f807196afab4a1a1256dbf62a011020c6fe7745" }
 tree-sitter-thrift = "0.5.0"
 tree-sitter-strings = { git = "https://github.com/ketkarameya/tree-sitter-strings.git" }
+tree-sitter-query = "0.1.0"
 derive_builder = "0.12.0"
 getset = "0.1.2"
 pyo3 = "0.19.0"

--- a/src/cleanup_rules/kt/rules.toml
+++ b/src/cleanup_rules/kt/rules.toml
@@ -197,7 +197,7 @@ query = """
 (
 (prefix_expression (boolean_literal) @exp) @prefix_expression
 (#eq? @exp "false")
-(#match @prefix_expression "!.*")  
+(#match? @prefix_expression "!.*")  
 )
 """
 replace = "true"
@@ -216,7 +216,7 @@ query = """
 (
 (prefix_expression (boolean_literal) @exp) @prefix_expression
 (#eq? @exp "true")
-(#match @prefix_expression "!.*")  
+(#match? @prefix_expression "!.*")  
 )
 """
 replace = "false"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ use std::{collections::HashMap, fs::File, io::Write, path::PathBuf};
 
 use itertools::Itertools;
 use log::{debug, info};
-use tree_sitter::Parser;
 
 use crate::models::rule_store::RuleStore;
 
@@ -111,11 +110,9 @@ impl Piranha {
   /// Performs cleanup related to stale flags
   fn perform_cleanup(&mut self) {
     // Setup the parser for the specific language
-    let mut parser = Parser::new();
     let piranha_args = &self.piranha_arguments;
-    parser
-      .set_language(*piranha_args.language().language())
-      .expect("Could not set the language for the parser.");
+
+    let mut parser = piranha_args.language().parser();
 
     let mut path_to_codebase = self.piranha_arguments.path_to_codebase().to_string();
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -24,3 +24,7 @@ pub(crate) mod rule_graph;
 pub(crate) mod rule_store;
 pub(crate) mod scopes;
 pub(crate) mod source_code_unit;
+
+pub(crate) trait Validator {
+  fn validate(&self) -> Result<(), String>;
+}

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -27,6 +27,7 @@ use super::{
     default_replace, default_replace_node, default_rule_name,
   },
   filter::Filter,
+  Validator,
 };
 
 #[derive(Deserialize, Debug, Clone, Default, PartialEq)]
@@ -182,6 +183,16 @@ impl Rule {
   }
 
   gen_py_str_methods!();
+}
+
+impl Validator for Rule {
+  fn validate(&self) -> Result<(), String> {
+    let validation = self
+      .query()
+      .validate()
+      .and_then(|_: ()| self.filters().iter().try_for_each(|f| f.validate()));
+    validation
+  }
 }
 
 pub use piranha_rule;

--- a/src/models/source_code_unit.rs
+++ b/src/models/source_code_unit.rs
@@ -20,12 +20,12 @@ use itertools::Itertools;
 use log::{debug, error};
 
 use tree_sitter::{InputEdit, Node, Parser, Range, Tree};
-use tree_sitter_traversal::{traverse, Order};
 
 use crate::{
   models::rule_graph::{GLOBAL, PARENT},
   utilities::tree_sitter_utilities::{
-    get_match_for_query, get_node_for_range, get_replace_range, get_tree_sitter_edit, TSQuery,
+    get_match_for_query, get_node_for_range, get_replace_range, get_tree_sitter_edit,
+    number_of_errors, TSQuery,
   },
 };
 
@@ -358,11 +358,9 @@ impl SourceCodeUnit {
     panic!("{}", msg);
   }
 
-  /// Returns the number of errors in the AST
+  /// Returns the number of errors in this source code unit
   fn _number_of_errors(&self) -> usize {
-    traverse(self.root_node().walk(), Order::Post)
-      .filter(|node| node.is_error() || node.is_missing())
-      .count()
+    number_of_errors(&self.root_node())
   }
 
   // Replaces the content of the current file with the new content and re-parses the AST

--- a/src/models/unit_tests/source_code_unit_test.rs
+++ b/src/models/unit_tests/source_code_unit_test.rs
@@ -14,6 +14,8 @@ Copyright (c) 2023 Uber Technologies, Inc.
 use tree_sitter::{Parser, Point};
 
 use crate::models::filter::FilterBuilder;
+
+use crate::models::rule_graph::RuleGraphBuilder;
 use crate::utilities::tree_sitter_utilities::TSQuery;
 use crate::{
   filter,
@@ -605,5 +607,47 @@ fn test_filter_bad_range() {
     .contains(TSQuery::new(String::from("(if_statement) @if_stmt")))
     .at_least(5)
     .at_most(4)
+    .build();
+}
+
+#[test]
+#[should_panic(expected = "Cannot parse")]
+fn test_filter_syntactically_incorrect_contains() {
+  FilterBuilder::default()
+    .contains(TSQuery::new(String::from("(if_statement @if_stmt")))
+    .build();
+}
+
+#[test]
+#[should_panic(expected = "Cannot parse")]
+fn test_filter_syntactically_incorrect_not_contains() {
+  FilterBuilder::default()
+    .not_contains(vec![TSQuery::new(String::from("(if_statement @if_stmt"))])
+    .build();
+}
+
+#[test]
+#[should_panic(expected = "Cannot parse")]
+fn test_filter_syntactically_incorrect_enclosing_node() {
+  FilterBuilder::default()
+    .enclosing_node(TSQuery::new(String::from("(if_statement @if_stmt")))
+    .build();
+}
+
+#[test]
+#[should_panic(expected = "Cannot parse")]
+fn test_filter_syntactically_incorrect_not_enclosing_node() {
+  FilterBuilder::default()
+    .not_enclosing_node(TSQuery::new(String::from("(if_statement @if_stmt")))
+    .build();
+}
+
+#[test]
+#[should_panic(expected = "Cannot parse")]
+fn test_rule_graph_incorrect_query() {
+  RuleGraphBuilder::default()
+    .rules(vec![
+      piranha_rule! {name = "Test rule", query = "(if_statement"},
+    ])
     .build();
 }

--- a/src/tests/test_piranha_java.rs
+++ b/src/tests/test_piranha_java.rs
@@ -376,3 +376,21 @@ fn test_handle_syntactically_incorrect_tree_panic() {
   // Delete temp_dir
   temp_dir.close().unwrap();
 }
+
+#[test]
+#[should_panic(expected = "Cannot parse")]
+fn test_incorrect_rule() {
+  initialize();
+  let _path = PathBuf::from("test-resources")
+    .join(JAVA)
+    .join("incorrect_rule");
+  let path_to_codebase = _path.join("input").to_str().unwrap().to_string();
+  let path_to_configurations = _path.join("configurations").to_str().unwrap().to_string();
+  let piranha_arguments = PiranhaArgumentsBuilder::default()
+    .path_to_codebase(path_to_codebase)
+    .path_to_configurations(path_to_configurations)
+    .language(PiranhaLanguage::from(JAVA))
+    .build();
+
+  let _ = execute_piranha(&piranha_arguments);
+}

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -304,6 +304,7 @@ pub(crate) fn get_replace_range(input_edit: InputEdit) -> Range {
   }
 }
 
+/// Returns the (tree-sitter) parser for the tree-sitter query DSL
 pub(crate) fn get_ts_query_parser() -> Parser {
   let mut parser = Parser::new();
   parser

--- a/src/utilities/tree_sitter_utilities.rs
+++ b/src/utilities/tree_sitter_utilities.rs
@@ -15,7 +15,7 @@ Copyright (c) 2023 Uber Technologies, Inc.
 
 use super::eq_without_whitespace;
 use crate::{
-  models::{edit::Edit, matches::Match},
+  models::{edit::Edit, matches::Match, Validator},
   utilities::MapOfVec,
 };
 use itertools::Itertools;
@@ -23,7 +23,8 @@ use log::debug;
 use pyo3::prelude::pyclass;
 use serde_derive::Deserialize;
 use std::collections::HashMap;
-use tree_sitter::{InputEdit, Node, Point, Query, QueryCapture, QueryCursor, Range};
+use tree_sitter::{InputEdit, Node, Parser, Point, Query, QueryCapture, QueryCursor, Range};
+use tree_sitter_traversal::{traverse, Order};
 
 /// Applies the query upon the given node, and gets all the matches
 /// # Arguments
@@ -303,6 +304,21 @@ pub(crate) fn get_replace_range(input_edit: InputEdit) -> Range {
   }
 }
 
+pub(crate) fn get_ts_query_parser() -> Parser {
+  let mut parser = Parser::new();
+  parser
+    .set_language(tree_sitter_query::language())
+    .expect("Could not set the language for the parser.");
+  parser
+}
+
+/// Returns the number of errors in the AST
+pub(crate) fn number_of_errors(node: &Node) -> usize {
+  traverse(node.walk(), Order::Post)
+    .filter(|node| node.is_error() || node.is_missing())
+    .count()
+}
+
 #[pyclass]
 #[derive(Deserialize, Debug, Clone, Default, PartialEq, Hash, Eq)]
 pub struct TSQuery(String);
@@ -314,6 +330,17 @@ impl TSQuery {
 
   pub(crate) fn get_query(&self) -> String {
     self.0.to_string()
+  }
+}
+
+impl Validator for TSQuery {
+  fn validate(&self) -> Result<(), String> {
+    let mut parser = get_ts_query_parser();
+    parser
+      .parse(self.get_query(), None)
+      .filter(|x| number_of_errors(&x.root_node()) == 0)
+      .map(|_| Ok(()))
+      .unwrap_or(Err(format!("Cannot parse - {}", self.get_query())))
   }
 }
 

--- a/test-resources/java/incorrect_rule/configurations/rules.toml
+++ b/test-resources/java/incorrect_rule/configurations/rules.toml
@@ -1,0 +1,19 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+# 
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+# 
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains rules to the specific feature flag API.
+
+[[rules]]
+name = "Match import statement"
+# This rules is purposefully syntactically incorrect (for testing)
+query = """(
+(import_declaration @import
+)"""

--- a/test-resources/java/incorrect_rule/input/Sample.java
+++ b/test-resources/java/incorrect_rule/input/Sample.java
@@ -1,0 +1,9 @@
+package com.uber.piranha ;
+
+import java.util.List;
+
+class A {
+
+   List<String> names;
+
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -13,7 +13,7 @@ from polyglot_piranha import Filter, execute_piranha, PiranhaArguments, PiranhaO
 from os.path import join, basename
 from os import listdir
 import re
-
+import pytest
 
 def test_piranha_rewrite():
     args = PiranhaArguments(
@@ -176,6 +176,23 @@ def test_delete_unused_field():
         "test-resources/java/delete_unused_field/", output_summaries
     )
 
+
+def test_incorrect_import():
+    delete_unused_field = Rule (
+        name= "delete_unused_field",
+        query=
+        """(
+        (import_declaration @import_decl
+        )
+        """,
+    )
+
+    
+    with pytest.raises(BaseException, match = "Incorrect Rule Graph - Cannot parse") as e:
+        rule_graph = RuleGraph(
+            rules= [delete_unused_field],
+            edges = []
+            )
 
 def is_as_expected(path_to_scenario, output_summary):
     expected_output = join(path_to_scenario, "expected")


### PR DESCRIPTION
This PR introduces very basic validation for our RuleGraphs. At this moment we make sure that (i) All tree-sitter queries are syntactically correct (ii) Filter fields are configured correctly (this is was something we previously checked)

This PR also ensures that the the graph is validated irrespective of where it is loaded from - `toml`, Rust API, or Python API (Have added test for each API)