### PR TITLE
Bug Fix - Create dummy rule from py api

### DIFF
--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -210,6 +210,8 @@ class Rule:
     "Holes that need to be filled, in order to instantiate a rule"
     filters: set[Filter]
     "Filters to test before applying a rule"
+    is_seed_rule: bool
+    "Marks a rule as a seed rule"
 
     def __init__(
         self,
@@ -241,6 +243,8 @@ class Rule:
                 Holes that need to be filled, in order to instantiate a rule
             filters: set[Filter]
                 Filters to test before applying a rule
+            is_seed_rule: bool
+                Marks a rule as a seed rule
         """
         ...
 

--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -214,7 +214,7 @@ class Rule:
     def __init__(
         self,
         name: str,
-        query: str,
+        query: Optional[str] = None,
         replace_node: Optional[str] = None,
         replace: Optional[str] = None,
         groups: set[str] = set(),

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -149,12 +149,17 @@ macro_rules! piranha_rule {
 impl Rule {
   #[new]
   fn py_new(
-    name: String, query: String, replace: Option<String>, replace_node: Option<String>,
+    name: String, query: Option<String>, replace: Option<String>, replace_node: Option<String>,
     holes: Option<HashSet<String>>, groups: Option<HashSet<String>>,
     filters: Option<HashSet<Filter>>, is_seed_rule: Option<bool>,
   ) -> Self {
     let mut rule_builder = RuleBuilder::default();
-    rule_builder.name(name).query(TSQuery::new(query));
+
+    rule_builder.name(name);
+    if let Some(q) = query {
+      rule_builder.query(TSQuery::new(q));
+    }
+
     if let Some(replace) = replace {
       rule_builder.replace(replace);
     }


### PR DESCRIPTION
Currently, because of slight misconfuguration Piranha python API does not allow the user to create a dummy rule. This PR fixes this bug.