### PR TITLE
Bug Fix: Cleanup sub-optimal ternary operator cleanup

### DIFF
--- a/src/cleanup_rules/java/rules.toml
+++ b/src/cleanup_rules/java/rules.toml
@@ -443,6 +443,27 @@ replace = ""
 replace_node = "post"
 is_seed_rule = false
 
+
+# Before :
+#  condition ? abc() : abc();
+# After :
+#  abc()
+#
+[[rules]]
+groups = ["if_cleanup"]
+name = "simplify_ternary_similar_consequent_alternative"
+query = """
+(
+    (ternary_expression condition: (_)
+        consequence: (_)* @consequence
+        alternative: (_)* @alternative)
+@ternary_expression
+(#eq? @consequence @alternative)
+)"""
+replace = "@consequence"
+replace_node = "ternary_expression"
+is_seed_rule = false
+
 # Before :
 #  true ? abc() : def();
 # After :

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -471,6 +471,29 @@ replace_node = "guard_block"
 replace = ""
 is_seed_rule = false
 
+
+#
+# Before
+# var v = true ? x : y
+#
+# After
+# var v = x
+#
+[[rules]]
+name = "ternary_similar_consequent_alternative"
+query = """(
+(ternary_expression
+    if_true:(_) @block_true
+    if_false:(_) @block_false
+    ) @ternary_block
+(#eq? @block_true @block_false)
+)"""
+groups = ["if_cleanup"]
+replace_node = "ternary_block"
+replace = "@block_true"
+is_seed_rule = false
+
+
 #
 # Before
 # var v = true ? x : y

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -474,7 +474,7 @@ is_seed_rule = false
 
 #
 # Before
-# var v = true ? x : y
+# var v = true ? x : x
 #
 # After
 # var v = x

--- a/test-resources/java/feature_flag_system_2/treated/expected/XPFlagCleanerInterfaceMethod.java
+++ b/test-resources/java/feature_flag_system_2/treated/expected/XPFlagCleanerInterfaceMethod.java
@@ -85,4 +85,8 @@ class XPFlagCleanerPositiveCases {
       System.out.println("Hi world");
     }
   }
+
+    public boolean isEnabledFlag(X x){
+      return true;
+  }
 }

--- a/test-resources/java/feature_flag_system_2/treated/input/XPFlagCleanerInterfaceMethod.java
+++ b/test-resources/java/feature_flag_system_2/treated/input/XPFlagCleanerInterfaceMethod.java
@@ -129,4 +129,8 @@ class XPFlagCleanerPositiveCases {
       System.out.println("Hi world");
     }
   }
+
+  public boolean isEnabledFlag(X x){
+    return x.cond ? true : exp.isStaleFeature().getCachedValue();
+  }
 }

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -328,6 +328,6 @@ class SampleClass {
         toBePreservedInequality11() 
 
         toBePreservedInequality12() 
+        x = true
     }
-    x = true
 }

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -329,4 +329,5 @@ class SampleClass {
 
         toBePreservedInequality12() 
     }
+    x = true
 }

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -492,5 +492,7 @@ class SampleClass {
          } else {
             toBeDeletedInequality12b()
          }
+
+         x = condition() ? TestEnum.stale_flag_one.isEnabled : true
     }
 }


### PR DESCRIPTION
We were not simplifying the code when the alternative and consequence of the ternary opertors are the same. This PR fixes that, and adds tests for it