### PR TITLE
Removed --universal2 argument from release workflow for arm-darwin

### DIFF
--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           rustup target add aarch64-apple-darwin
           pip install --upgrade maturin
-          maturin build --release -o dist --universal2
+          maturin build --release -o dist --target universal2-apple-darwin
       - name: Pypi Release for macos-latest
         run: |
           pip install twine


### PR DESCRIPTION
Maturin has removed --universal2 cli option in v1.0.0, They now suggest using --target universal2-apple-darwin.
https://github.com/PyO3/maturin/releases/tag/v1.0.0 