### PR TITLE
Raise structure visibility to enable running Piranha from a different Rust project

### DIFF
--- a/src/models/edit.rs
+++ b/src/models/edit.rs
@@ -31,7 +31,7 @@ use pyo3::{prelude::pyclass, pymethods};
 
 #[derive(Serialize, Debug, Clone, Getters, MutGetters, Deserialize)]
 #[pyclass]
-pub(crate) struct Edit {
+pub struct Edit {
   // The match representing the target site of the edit
   #[pyo3(get)]
   #[get = "pub"]

--- a/src/models/matches.rs
+++ b/src/models/matches.rs
@@ -29,7 +29,7 @@ use super::{
 
 #[derive(Serialize, Debug, Clone, Getters, MutGetters, Deserialize)]
 #[pyclass]
-pub(crate) struct Match {
+pub struct Match {
   // Code snippet that matched
   #[get = "pub"]
   #[pyo3(get)]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod capture_group_patterns;
 pub(crate) mod default_configs;
 pub(crate) mod edit;
 pub(crate) mod filter;
-pub(crate) mod language;
+pub mod language;
 pub(crate) mod matches;
 pub(crate) mod outgoing_edges;
 pub mod piranha_arguments;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -13,8 +13,8 @@ Copyright (c) 2023 Uber Technologies, Inc.
 
 pub(crate) mod capture_group_patterns;
 pub(crate) mod default_configs;
-pub(crate) mod edit;
-pub(crate) mod filter;
+pub mod edit;
+pub mod filter;
 pub mod language;
 pub(crate) mod matches;
 pub(crate) mod outgoing_edges;

--- a/src/models/piranha_output.rs
+++ b/src/models/piranha_output.rs
@@ -26,24 +26,24 @@ use pyo3::{prelude::pyclass, pymethods};
 pub struct PiranhaOutputSummary {
   /// Path to the file
   #[pyo3(get)]
-  #[get = "pub(crate)"]
+  #[get = "pub"]
   path: String,
   /// Original content of the file after all the rewrites
   #[pyo3(get)]
-  #[get = "pub(crate)"]
+  #[get = "pub"]
   #[serde(skip)]
   original_content: String,
   /// Final content of the file after all the rewrites
   #[pyo3(get)]
-  #[get = "pub(crate)"]
+  #[get = "pub"]
   content: String,
   /// All the occurrences of "match-only" rules
   #[pyo3(get)]
-  #[get = "pub(crate)"]
+  #[get = "pub"]
   matches: Vec<(String, Match)>,
   /// All the applied edits
   #[pyo3(get)]
-  #[get = "pub(crate)"]
+  #[get = "pub"]
   rewrites: Vec<Edit>,
 }
 


### PR DESCRIPTION
Hello,

this PR raises structural visibility for the `Edit`, `Match` and `PiranhaOutputSummary` structs and allows the structures from the `language` module (e.g. `PiranhaLanguage`) to be used into a different Rust project that consumes Piranha.

The exemplary usage is presented here:
https://github.com/intuita-inc/codemod-engine-rust/blob/main/src/main.rs#L12
https://github.com/intuita-inc/codemod-engine-rust/blob/main/src/main.rs#L65
https://github.com/intuita-inc/codemod-engine-rust/blob/main/src/main.rs#L89
