### PR TITLE
Fixing a small typo in the readme with a repeated parameter

### DIFF
--- a/POLYGLOT_README.md
+++ b/POLYGLOT_README.md
@@ -145,7 +145,6 @@ An object of PiranhaArguments can be instantiated with the following arguments:
 - (*optional*) `number_of_ancestors_in_parent_scope` (`usize`): The number of ancestors considered when `PARENT` rules
 - (*optional*) `delete_file_if_empty` (`bool`): User option that determines whether an empty file will be deleted
 - (*optional*) `delete_consecutive_new_lines` (`bool`) : Replaces consecutive `\n`s  with a single `\n`
-- (*optional*) `dry_run` (`bool`) : Disables in-place rewriting of code
 
 <h5> Returns </h5>
 


### PR DESCRIPTION
The dry_run parameter and it's associated description are repeated. This removes that duplication.