### PR TITLE
Aggressively simplify something or true

### DIFF
--- a/src/cleanup_rules/go/rules.toml
+++ b/src/cleanup_rules/go/rules.toml
@@ -151,16 +151,7 @@ name = "simplify_something_or_true"
 query = """
 (
     (binary_expression
-        left : ([
-                (identifier)
-                (parenthesized_expression (identifier))
-                (true)
-                (parenthesized_expression (true))
-                (false)
-                (parenthesized_expression (false))
-                (selector_expression)
-                (parenthesized_expression (selector_expression))
-            ]) @lhs
+        left : (_) @lhs
         operator:"||"
         right: [(true) (parenthesized_expression (true))]
     ) @binary_expression

--- a/src/cleanup_rules/java/rules.toml
+++ b/src/cleanup_rules/java/rules.toml
@@ -239,11 +239,7 @@ name = "simplify_something_or_true"
 query = """
 (
     (binary_expression
-        left : [
-            (identifier)
-            (true)
-            (false)
-        ] @lhs
+        left : (_) @lhs
         operator:"||"
         right: (true)
     )

--- a/src/cleanup_rules/kt/rules.toml
+++ b/src/cleanup_rules/kt/rules.toml
@@ -307,9 +307,7 @@ groups = ["boolean_expression_simplify"]
 name = "simplify_something_or_true"
 query = """
 (
-(disjunction_expression [(simple_identifier)
-                          (boolean_literal)
-                        ] @lhs 
+(disjunction_expression (_) @lhs 
                         ((boolean_literal) @rhs)  ) @disjunction_expression
 (#eq? @rhs "true")  
 )"""

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -103,10 +103,10 @@ is_seed_rule = false
 #   true
 #
 [[rules]]
-name = "some_identifier_or_true"
+name = "something_or_true"
 query = """(
 (disjunction_expression
-        lhs: (simple_identifier)
+        lhs: (_)
         rhs: [(boolean_literal) @true  
             (tuple_expression 
                 value: (boolean_literal) @true)]

--- a/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/expected/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/expected/sample.go
@@ -61,9 +61,9 @@ func simplify_false_and_something(something bool) {
     
 
     // function call || true
-    if f1() || true {
-        fmt.Println("keep as it is")
-    }
+    
+    fmt.Println("simplify and keep the statement")
+    
 }
 
 // simplify `!true` and `!false` and also:
@@ -76,10 +76,9 @@ func simplify_true_or_something(something bool) {
     fmt.Println("only true 4")
     // selector_expression: simplify
     fmt.Println("only true 5")
-    // does not simplify binary_expression; left call may contain side-effects
-    if exp.BoolValue("random") || true {
-        fmt.Println("keep")
-    }
+    // Simplify the below  if
+    fmt.Println("keep")
+   
 }
 
 // simplify `!true` and `!false` and also:

--- a/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/input/sample.go
+++ b/test-resources/go/feature_flag/builtin_rules/boolean_expression_simplify/input/sample.go
@@ -104,7 +104,7 @@ func simplify_false_and_something(something bool) {
 
     // function call || true
     if f1() || exp.BoolValue("true") {
-        fmt.Println("keep as it is")
+        fmt.Println("simplify and keep the statement")
     }
 }
 
@@ -130,7 +130,7 @@ func simplify_true_or_something(something bool) {
         fmt.Println("only true 5")
     }
 
-    // does not simplify binary_expression; left call may contain side-effects
+    // Simplify the below  if
     if exp.BoolValue("random") || exp.BoolValue("true") {
         fmt.Println("keep")
     }

--- a/test-resources/java/feature_flag_system_2/treated/expected/XPMethodChainCases.java
+++ b/test-resources/java/feature_flag_system_2/treated/expected/XPMethodChainCases.java
@@ -35,9 +35,7 @@ class XPMethodChainCases {
     if (sp.otherFlag().getCachedValue()) {
       System.out.println("!!!");
     }
-    if (sp.otherFlag().getCachedValue() || true) {
-      System.out.println("!!!");
-    }
+    System.out.println("simplify and keep the statement");
     // test for identifier || true
     System.out.println("!!!");
     

--- a/test-resources/java/feature_flag_system_2/treated/input/XPMethodChainCases.java
+++ b/test-resources/java/feature_flag_system_2/treated/input/XPMethodChainCases.java
@@ -41,7 +41,7 @@ class XPMethodChainCases {
       System.out.println("!!!");
     }
     if (sp.otherFlag().getCachedValue() || sp.isStaleFeature().getCachedValue()) {
-      System.out.println("!!!");
+      System.out.println("simplify and keep the statement");
     }
     // test for identifier || true
     if (a || sp.isStaleFeature().getCachedValue()){

--- a/test-resources/kt/feature_flag_system_2/treated/expected/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/expected/XPMethodChainCases.kt
@@ -39,9 +39,9 @@ internal class XPMethodChainCases {
             if (sp.isOtherFlag().cachedValue) {
                 println("!!!")
             }
-            if (sp.isOtherFlag().cachedValue || true) {
-                println("LHS is not a simple identifier!!!")
-            }
+            
+            println("simplify if and keep statement")
+            
             // simple_identifier || true
             println("Test for identifier || true!!!")
             

--- a/test-resources/kt/feature_flag_system_2/treated/input/XPMethodChainCases.kt
+++ b/test-resources/kt/feature_flag_system_2/treated/input/XPMethodChainCases.kt
@@ -45,7 +45,7 @@ internal class XPMethodChainCases {
                 println("!!!")
             }
             if (sp.isOtherFlag().cachedValue || sp.isStaleFeature().cachedValue) {
-                println("LHS is not a simple identifier!!!")
+                println("simplify if and keep statement")
             }
             // simple_identifier && false, should be deleted
             if (a && !sp.isStaleFeature().cachedValue){


### PR DESCRIPTION
Aggressively simplifies boolean disjunction expressions when RHS is  and LHS is any AST node. Earlier we were conservatively only simplifying when LHS was an identifier or literal. But now(after feedback from folks) we have decided to make this simplification more aggressive. This PR is similar to https://github.com/uber/piranha/pull/532/. 