### PR TITLE
Improve ternary simplification

### DIFF
--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -598,14 +598,14 @@ is_seed_rule = false
 # var v = nil
 #
 [[rules]]
-name = "ternary_false_alternative_nil"
+name = "ternary_true_consequent_nil"
 query = """(
 (ternary_expression
     condition:[(boolean_literal) @true  
             (tuple_expression 
                 value: (boolean_literal) @true)]
     ) @ternary_block
-(#eq? @false "true")
+(#eq? @true "true")
 (#match? @ternary_block "\\\\?[\\\\n\\\\r\\\\s]*nil[\\\\n\\\\r\\\\s]*:")
 )"""
 groups = ["if_cleanup"]

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -565,6 +565,54 @@ replace_node = "ternary_block"
 replace = "@block_false"
 is_seed_rule = false
 
+
+# A hack to handle the scenario when `nil` is used in the ternary expression
+# TODO: Track https://github.com/alex-pinkus/tree-sitter-swift/issues/303 to remove this hack
+# var v = false ? x : nil
+#
+# After
+# var v = nil
+#
+[[rules]]
+name = "ternary_false_alternative_nil"
+query = """(
+(ternary_expression
+    condition:[(boolean_literal) @false  
+            (tuple_expression 
+                value: (boolean_literal) @false)]
+    ) @ternary_block
+(#eq? @false "false")
+(#match? @ternary_block ":[\\\\n\\\\r\\\\s]*nil\\\\b")
+)"""
+groups = ["if_cleanup"]
+replace_node = "ternary_block"
+replace = "nil"
+is_seed_rule = false
+
+
+## A hack to handle the scenario when `nil` is used in the ternary expression
+# TODO: Track https://github.com/alex-pinkus/tree-sitter-swift/issues/303 to remove this hack
+# var v = true ? nil : x
+#
+# After
+# var v = nil
+#
+[[rules]]
+name = "ternary_false_alternative_nil"
+query = """(
+(ternary_expression
+    condition:[(boolean_literal) @true  
+            (tuple_expression 
+                value: (boolean_literal) @true)]
+    ) @ternary_block
+(#eq? @false "true")
+(#match? @ternary_block "\\\\?[\\\\n\\\\r\\\\s]*nil[\\\\n\\\\r\\\\s]*:")
+)"""
+groups = ["if_cleanup"]
+replace_node = "ternary_block"
+replace = "nil"
+is_seed_rule = false
+
 # delete variables declared in a function scope
 [[rules]]
 name = "delete_variable_declaration"

--- a/test-resources/swift/cleanup_rules/expected/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/expected/SampleClass.swift
@@ -162,6 +162,8 @@ class SampleClass {
     func checkTernary() {
         var value = 2
         var value2 = 3
+        var value3 =  nil
+        var value4 =  nil
     }
 
     func checkIfBooleanWithComments(){

--- a/test-resources/swift/cleanup_rules/input/SampleClass.swift
+++ b/test-resources/swift/cleanup_rules/input/SampleClass.swift
@@ -212,6 +212,11 @@ class SampleClass {
     func checkTernary() {
         var value = TestEnum.stale_flag_one.isEnabled || v2 ? 2 : 3
         var value2 =  placeholder_false ? 2 : 3
+        var value3 =  placeholder_false ? 2 : nil
+        var value4 =  !placeholder_false 
+                        ?
+                                 nil 
+                                 : 2
     }
 
     func checkIfBooleanWithComments(){


### PR DESCRIPTION
Adds a hacky way to simplify ternary expressions when nil is used. This hack can be removed when https://github.com/alex-pinkus/tree-sitter-swift/issues/303 is resolved