### PR TITLE
Bug Fix: Avoid over-deletion when looking for associated comma

### DIFF
--- a/test-resources/go/feature_flag/system_1/const_same_file/expected/sample.go
+++ b/test-resources/go/feature_flag/system_1/const_same_file/expected/sample.go
@@ -68,6 +68,18 @@ func callerFunc() {
 
 // should not replace the function name
 func isFlagEnabledFunc() bool {
+
+    // Should not delete this comment and the func below
+    t.Run("message", func(t *Foobar.T) {
+        fmt.Println("some logging statement")
+    })
+
+    // Should not delete this comment and the func below
+    t.Run1(func(t *Foobar.T) {
+        fmt.Println("some other logging statement")
+    }, "other_message" )
+
+
     fmt.Println("not enabled")
     return false
 }

--- a/test-resources/go/feature_flag/system_1/const_same_file/expected/sample.go
+++ b/test-resources/go/feature_flag/system_1/const_same_file/expected/sample.go
@@ -69,12 +69,12 @@ func callerFunc() {
 // should not replace the function name
 func isFlagEnabledFunc() bool {
 
-    // Should not delete this comment and the func below
+    // After deleting the assignment, this comment and the leading `func {...` is not deleted
     t.Run("message", func(t *Foobar.T) {
         fmt.Println("some logging statement")
     })
 
-    // Should not delete this comment and the func below
+    // After deleting the assignment, this comment and the trailing `},` is not deleted
     t.Run1(func(t *Foobar.T) {
         fmt.Println("some other logging statement")
     }, "other_message" )

--- a/test-resources/go/feature_flag/system_1/const_same_file/input/sample.go
+++ b/test-resources/go/feature_flag/system_1/const_same_file/input/sample.go
@@ -87,6 +87,19 @@ func callerFunc() {
 
 // should not replace the function name
 func isFlagEnabledFunc() bool {
+    // Should not delete this comment and the func below
+    t.Run("message", func(t *Foobar.T) {
+        isFlgEnabled := exp.BoolValue(staleFlagConst)
+        fmt.Println("some logging statement")
+    })
+    
+    // Should not delete this comment and the func below
+    t.Run1(func(t *Foobar.T) {
+        isFlgEnabled1 := exp.BoolValue(staleFlagConst)
+        fmt.Println("some other logging statement")
+    }, "other_message" )
+
+
     isFlagEnabledFunc := exp.BoolValue(staleFlagConst)
 
     if !isFlagEnabledFunc {

--- a/test-resources/go/feature_flag/system_1/const_same_file/input/sample.go
+++ b/test-resources/go/feature_flag/system_1/const_same_file/input/sample.go
@@ -92,11 +92,11 @@ func isFlagEnabledFunc() bool {
         isFlgEnabled := exp.BoolValue(staleFlagConst)
         fmt.Println("some logging statement")
     })
-    
+
     // Should not delete this comment and the func below
     t.Run1(func(t *Foobar.T) {
-        isFlgEnabled1 := exp.BoolValue(staleFlagConst)
         fmt.Println("some other logging statement")
+        isFlgEnabled1 := exp.BoolValue(staleFlagConst)
     }, "other_message" )
 
 

--- a/test-resources/go/feature_flag/system_1/const_same_file/input/sample.go
+++ b/test-resources/go/feature_flag/system_1/const_same_file/input/sample.go
@@ -87,13 +87,13 @@ func callerFunc() {
 
 // should not replace the function name
 func isFlagEnabledFunc() bool {
-    // Should not delete this comment and the func below
+    // After deleting the assignment, this comment and the leading `func {...` is not deleted
     t.Run("message", func(t *Foobar.T) {
         isFlgEnabled := exp.BoolValue(staleFlagConst)
         fmt.Println("some logging statement")
     })
 
-    // Should not delete this comment and the func below
+    // After deleting the assignment, this comment and the trailing `},` is not deleted
     t.Run1(func(t *Foobar.T) {
         fmt.Println("some other logging statement")
         isFlgEnabled1 := exp.BoolValue(staleFlagConst)


### PR DESCRIPTION
Previously, we were walking up the parent to find the associated trailing/leading comma. 
But we did not have any safety checks guarding this comma deletions (like we have for comments).

Lets say in the below scenario we delete ` isFlgEnabled := exp.BoolValue(staleFlagConst)` :
```
 t.Run("message", func(t *Foobar.T) {
         isFlgEnabled := exp.BoolValue(staleFlagConst)
         fmt.Println("some logging statement")
     })
```

Our comment/comma cleanup logic would kick in and cleanup stuff like below:
```
 t.Run("message"
         fmt.Println("some logging statement")
     })
```
Note we deleted the extra `, func(t *Foobar.T) {`


I introduced a simple safety check that ensures that there is no node between the comma and the node intended to be deleted.



