### PR TITLE
Fix replace_identifier_with_nil rule

### DIFF
--- a/src/cleanup_rules/go/rules.toml
+++ b/src/cleanup_rules/go/rules.toml
@@ -556,7 +556,7 @@ replace_node = "identifier"
 holes = ["err"]
 is_seed_rule = false
 [[rules.filters]]
-enclosing_node = "(block) @block"
+enclosing_node = "[(function_declaration) (method_declaration)] @block"
 not_contains = ["""
 (
     [


### PR DESCRIPTION
Fix the enclosing node from block to function_declaration for 
`replace_identifier_with_nil` rule
