### PR TITLE
tree-sitter-go pointing to a new branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git
 tree-sitter-python = "0.20.2"
 tree-sitter-typescript = "0.20.1"
 # TODO: Update after https://github.com/tree-sitter/tree-sitter-go/pull/103 lands
-tree-sitter-go = { git = "https://github.com/uber/tree-sitter-go.git", rev = "8f807196afab4a1a1256dbf62a011020c6fe7745" }
+tree-sitter-go = { git = "https://github.com/uber/tree-sitter-go.git", rev = "f8cffd0af7baaf7bf6062e403efe7c0d06319c41" }
 tree-sitter-thrift = "0.5.0"
 tree-sitter-strings = { git = "https://github.com/uber/tree-sitter-strings.git" }
 tree-sitter-query = "0.1.0"


### PR DESCRIPTION
- branch is now up to date with upstream
- `statement_list` still exposed
- `interpreted_string_literal_basic_content` newly exposed
- https://github.com/uber/tree-sitter-go/commit/f8cffd0af7baaf7bf6062e403efe7c0d06319c41