### PR TITLE
Update go grammar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git
 tree-sitter-python = "0.20.2"
 tree-sitter-typescript = "0.20.1"
 # TODO: Update after https://github.com/tree-sitter/tree-sitter-go/pull/103 lands
-tree-sitter-go = { git = "https://github.com/uber/tree-sitter-go.git", rev = "8f807196afab4a1a1256dbf62a011020c6fe7745" }
+tree-sitter-go = { git = "https://github.com/uber/tree-sitter-go.git", rev = "f8cffd0af7baaf7bf6062e403efe7c0d06319c41" }
 tree-sitter-thrift = "0.5.0"
 tree-sitter-strings = { git = "https://github.com/uber/tree-sitter-strings.git" }
 tree-sitter-query = "0.1.0"

--- a/src/tests/test_piranha_go.rs
+++ b/src/tests/test_piranha_go.rs
@@ -21,6 +21,7 @@ create_match_tests! {
   GO,
   test_match_only_for_loop: "structural_find/go_stmt_for_loop", HashMap::from([("find_go_stmt_for_loop", 1)]);
   test_match_only_go_stmt_for_loop:"structural_find/for_loop", HashMap::from([("find_for", 4)]);
+  test_match_expression_with_string_literal:"structural_find/expression_with_string_literal", HashMap::from([("match_bool_value", 1)]);
 }
 
 create_rewrite_tests! {

--- a/test-resources/go/structural_find/expression_with_string_literal/configurations/rules.toml
+++ b/test-resources/go/structural_find/expression_with_string_literal/configurations/rules.toml
@@ -1,0 +1,3 @@
+[[rules]]
+name = "match_bool_value"
+query = "cs :[x].BoolValue(\":[y]\")"

--- a/test-resources/go/structural_find/expression_with_string_literal/input/sample.go
+++ b/test-resources/go/structural_find/expression_with_string_literal/input/sample.go
@@ -1,0 +1,20 @@
+package flag
+
+import "fmt"
+
+
+func a() {
+    if exp.BoolValue("staleFlagConst") {
+        fmt.Println("true")
+    } else {
+        fmt.Println("false")
+    }
+}
+
+func a1() {
+    if exp.BoolValue(staleFlagConst) {
+        fmt.Println("true")
+    } else {
+        fmt.Println("false")
+    }
+}


### PR DESCRIPTION
Updated the go grammar to account for string literals (https://github.com/uber/piranha/pull/580).
 Also checked if the fix solves the piranha bug around parsing string literals when using concrete syntax