### PR TITLE
Swift: Fix cleaning of statements after return

### DIFF
--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -75,7 +75,6 @@ scope = "Parent"
 from = "boolean_literal_cleanup"
 to = [
   "variable_inline_cleanup",
-  "delete_all_statements_after_return",
   "boolean_expression_simplify",
   "statement_cleanup",
 ]
@@ -88,7 +87,7 @@ to = ["boolean_literal_cleanup"]
 [[edges]]
 scope = "File"
 from = "statement_cleanup"
-to = ["if_cleanup"]
+to = ["post_processing_cleanup", "if_cleanup"]
 
 [[edges]]
 scope = "Parent"

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -1175,12 +1175,13 @@ query = """(
         (_)+ @extras
     )
 )"""
-groups = ["if_cleanup"]
+groups = ["post_processing_cleanup"]
 replace_node = "extras"
 replace = ""
 is_seed_rule = false
 [[rules.filters]]
 not_contains = ["(directive) @d"]
+enclosing_node = "(function_declaration) @crfd"
 
 # Dummy rule that acts as a junction for all boolean based cleanups
 # Let's say you want to define rules from A -> B, A -> C, D -> B, D -> C, ... 

--- a/test-resources/swift/delete_statements_after_return/expected/SampleClass.swift
+++ b/test-resources/swift/delete_statements_after_return/expected/SampleClass.swift
@@ -1,13 +1,48 @@
 class C1 {
     func f1(){
         // some function call
-        doSomething()
+        doSomething() 
         return some_return_value_1
     }
 
 
     func f2(){
         return some_return_value_2
+    }
+
+    func f3(someParam: String, someOtherParam: SomeType) -> Set<String> {
+        guard let abc, case let .caseItem(itemData) = abc else { return [] }
+        return []
+    }
+
+    func f4(from someVar: SomeType, someOtherVar: String?) -> Set<String> {
+        guard let dcx, case let .caseItem(dcx) = dcx else { return [] }
+        return []
+    }
+    
+    func f5(vara: String, varb: Int) -> Bool? {
+        return nil
+    }
+
+    func f6(someVar: SomeType, someOtherVar: SomeOtherType) -> Bool? {
+        return nil
+    }
+
+    func f7(error: Error?) -> Bool {
+        let verifyExceptionCode = "error_verify_someEvent"
+        return false
+    }
+
+    func f8(forContext someContext: SomeContextType) -> Int? {
+        return 5
+    }
+
+    func f9()->String?{
+        return nil
+    }
+
+    func f10()->String?{
+        return nil
     }
 }
 

--- a/test-resources/swift/delete_statements_after_return/input/SampleClass.swift
+++ b/test-resources/swift/delete_statements_after_return/input/SampleClass.swift
@@ -40,6 +40,96 @@ class C1 {
         // some comment
         var d = c ? 1 : 0
     }
+
+    func f3(someParam: String, someOtherParam: SomeType) -> Set<String> {
+        guard let abc, case let .caseItem(itemData) = abc else { return [] }
+        
+        if placeholder_true {
+            return []
+        }
+        return Set(
+            SomeOperations()
+        )
+    }
+
+    func f4(from someVar: SomeType, someOtherVar: String?) -> Set<String> {
+        guard let dcx, case let .caseItem(dcx) = dcx else { return [] }
+        let x = placeholder_true
+        if x {
+            return []
+        } else {
+            someFunctionCall()
+        }
+        return Set(
+            SomeOperations()
+        )
+    }
+    
+    func f5(vara: String, varb: Int) -> Bool? {
+        if placeholder_true {
+            return nil
+        }
+        let someVar = TestEnum.some_parameter.cachedValue
+        let someOtherVar = TestEnum.someOtherParameter.cachedValue
+        return someVar == someOtherParameter ? nil : (someVar < someOtherParameter)
+    }
+
+    func f6(someVar: SomeType, someOtherVar: SomeOtherType) -> Bool? {
+        let t = placeholder_false
+        if !t{
+            return nil
+        }
+        let someVar = TestEnum.some_parameter.cachedValue
+        let someOtherVar = TestEnum.someOtherParameter.cachedValue
+        return someVar == someOtherParameter ? nil : (someVar < someOtherParameter)
+    }
+
+    func f7(error: Error?) -> Bool {
+        let verifyExceptionCode = "error_verify_someEvent"
+
+        guard placeholder_false else { return false }
+
+        guard let error else { return false }
+
+        switch error {
+        case ABCService.StatusErrorCodes.SomeRequestType.failedRequestError(let failedRequestException):
+            return true
+        case BookingService.StatusErrorCodes.SomeRequestType.failedRequestError(let failedRequestException):
+            return false
+        default:
+            return false
+        }
+    }
+
+    func f8(forContext someContext: SomeContextType) -> Int? {
+        guard !placeholder_false else {
+            return nil
+        }
+        guard !placeholder_false else {
+            return nil
+        }
+        return 5
+    }
+
+    func f9()->String?{
+        var b1 = placeholder_false
+        if !b1 {
+            guard !placeholder_true else {
+                return nil
+            }
+        }
+        return "someString"
+    }
+
+    func f10()->String?{
+        guard !placeholder_false else {
+            var c = placeholder_true
+            if c {
+                return "working"
+            }
+        }
+        return nil
+    }
 }
 
 enum E1 {


### PR DESCRIPTION
This PR fixes the issues where we were seeing improper cleanup of statements after a return statement was brought in the function scope post an if/guard cleanup. Please refer to tests to understand the cases in more details. 