### PR TITLE
Introduce Spark3 upgrade plugin

### DIFF
--- a/plugins/pyproject.toml
+++ b/plugins/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.poetry]
+name = "spark_upgrade"
+version = "0.0.1"
+description = "Rules to migrate 'scaletest'"
+# Add any other metadata you need
+
+[tool.poetry.dependencies]
+python = "^3.9"
+polyglot_piranha = "*"
+
+[tool.poetry.dev-dependencies]
+pytest = "7.4.x"
+
+[tool.poetry.scripts."scala_test"]
+main = "spark_upgrade.main:main"
+
+[tool.poetry.scripts."pytest"]
+main = "pytest"

--- a/plugins/spark_upgrade/README.md
+++ b/plugins/spark_upgrade/README.md
@@ -1,0 +1,35 @@
+# `Spark Upgrade` Plugin (WIP)
+
+Upgrades your codebase to Spark 3.3
+
+
+Currently, it updates to [v.3.3](https://spark.apache.org/releases/spark-release-3-3-0.html) only.
+Supported rewrites: 
+* `CalendarInterval` -> `DateTimeConstants`
+
+
+
+## Usage: 
+
+Clone the repository - `git clone https://github.com/uber/piranha.git`
+
+Install the dependencies - `pip3 install -r plugins/spark_upgrade/requirements.txt`
+
+Run the tool - `python3 plugins/spark_upgrade/main.py -h`
+
+CLI: 
+```
+usage: main.py [-h] --path_to_codebase PATH_TO_CODEBASE
+
+Updates the codebase to use a new version of `Spark 3.3`.
+
+options:
+  -h, --help            show this help message and exit
+  --path_to_codebase PATH_TO_CODEBASE
+                        Path to the codebase directory.
+```
+
+## Test
+```
+pytest plugins/
+```

--- a/plugins/spark_upgrade/main.py
+++ b/plugins/spark_upgrade/main.py
@@ -1,0 +1,36 @@
+import argparse
+
+from update_calendar_interval import update_CalendarInterval
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Updates the codebase to use a new version of `spark3`"
+    )
+    parser.add_argument(
+        "--path_to_codebase",
+        required=True,
+        help="Path to the codebase directory.",
+    )
+    parser.add_argument(
+        "--new_version",
+        required=True,
+        default="3.3",
+        help="Version of `Spark` to update to.",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = _parse_args()
+    if args.new_version == "3.3":
+        upgrade_to_spark_3_3(args.path_to_codebase)
+
+
+def upgrade_to_spark_3_3(path_to_codebase):
+    update_CalendarInterval([path_to_codebase])
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/spark_upgrade/main.py
+++ b/plugins/spark_upgrade/main.py
@@ -14,7 +14,6 @@ def _parse_args():
     )
     parser.add_argument(
         "--new_version",
-        required=True,
         default="3.3",
         help="Version of `Spark` to update to.",
     )

--- a/plugins/spark_upgrade/requirements.txt
+++ b/plugins/spark_upgrade/requirements.txt
@@ -1,0 +1,2 @@
+polyglot-piranha
+pytest

--- a/plugins/spark_upgrade/tests/resources/expected/sample.scala
+++ b/plugins/spark_upgrade/tests/resources/expected/sample.scala
@@ -1,0 +1,15 @@
+package org.piranha
+
+import org.apache.spark.sql.catalyst.util.DateTimeConstants
+import org.apache.spark.unsafe.types.CalendarInterval
+
+object CalendarIntervalExample {
+  def main(args: Array[String]): Unit = {
+    // Accessing MICROS_PER_SECOND constant
+    val microsPerSecond = DateTimeConstants.MICROS_PER_SECOND
+    val microsPerHour = DateTimeConstants.MICROS_PER_HOUR
+    val fromYearMonthString = DateTimeConstants.fromYearMonthString("1-2")
+    val fromDayTimeString = DateTimeConstants.fromDayTimeString("1-2")
+    println(s"Microseconds per Second: $microsPerSecond")
+  }
+}

--- a/plugins/spark_upgrade/tests/resources/input/sample.scala
+++ b/plugins/spark_upgrade/tests/resources/input/sample.scala
@@ -1,0 +1,14 @@
+package org.piranha
+
+import org.apache.spark.unsafe.types.CalendarInterval
+
+object CalendarIntervalExample {
+  def main(args: Array[String]): Unit = {
+    // Accessing MICROS_PER_SECOND constant
+    val microsPerSecond = CalendarInterval.MICROS_PER_SECOND
+    val microsPerHour = CalendarInterval.MICROS_PER_HOUR
+    val fromYearMonthString = CalendarInterval.fromYearMonthString("1-2")
+    val fromDayTimeString = CalendarInterval.fromDayTimeString("1-2")
+    println(s"Microseconds per Second: $microsPerSecond")
+  }
+}

--- a/plugins/spark_upgrade/tests/test_spark_upgrade.py
+++ b/plugins/spark_upgrade/tests/test_spark_upgrade.py
@@ -1,0 +1,83 @@
+import logging
+from pathlib import Path
+from os import walk
+from tempfile import TemporaryDirectory
+
+from update_calendar_interval import update_CalendarInterval
+
+FORMAT = "%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s"
+logging.basicConfig(format=FORMAT)
+logging.getLogger().setLevel(logging.DEBUG)
+
+
+def test_update_CalendarInterval():
+    logging.error("Here")
+    input_codebase = "plugins/spark_upgrade/tests/resources/input/"
+    expected_codebase = "plugins/spark_upgrade/tests/resources/expected/"
+    logging.info("Here")
+    with TemporaryDirectory() as temp_dir:
+        tp = temp_dir
+        logging.info("Here")
+        copy_dir(input_codebase, tp)
+        logging.info("Here")
+        summary = update_CalendarInterval([tp])
+        assert summary is not None
+        assert is_as_expected_files(expected_codebase, tp)
+
+
+def remove_whitespace(input_str):
+    """Removes all the whitespace from the string.
+    Args:
+        input_str (str): input string
+    Returns:
+        str: transformed input strings with no whitespace
+    """
+    return "".join(input_str.split()).strip()
+
+
+def copy_dir(source_dir, dest_dir):
+    """Copy files in {source_dir} to {dest_dir}
+    Properties to note:
+    * Assumes {dest_dir} is present.
+    * Overwrites the similarly named files.
+    Args:
+        source_dir (str):
+        dir_name (str):
+    """
+    for root, _, files in walk(source_dir):
+        src_root = Path(root)
+        dest_root = Path(dest_dir, src_root.relative_to(source_dir))
+        Path(dest_root).mkdir(parents=True, exist_ok=True)
+        for f in files:
+            src_file = Path(src_root, f)
+            dest_file = Path(
+                dest_root, f.replace(".testjava", ".java").replace(".testkt", ".kt")
+            )
+            dest_file.write_text(src_file.read_text())
+
+
+def is_as_expected_files(path_to_expected, path_to_actual):
+    for root, _, files in walk(path_to_actual):
+        actual_root = Path(root)
+        expected_root = Path(path_to_expected, actual_root.relative_to(path_to_actual))
+        for file_name in files:
+            actual_file = Path(actual_root, file_name)
+            expected_file = Path(expected_root, file_name)
+            if not expected_file.exists():
+                expected_file = Path(
+                    expected_root,
+                    file_name.replace(".java", ".testjava")
+                    .replace(".kt", ".testkt")
+                    .replace(".swift", ".testswift")
+                    .replace(".go", ".testgo"),
+                )
+            _actual_content = actual_file.read_text()
+            actual_content = remove_whitespace(_actual_content).strip()
+            expected_content = remove_whitespace(expected_file.read_text())
+            if not actual_content and expected_file.exists():
+                logging.error(f"Actual content of the file was empty !!!")
+                return False
+            if expected_content != actual_content:
+                logging.error(f"Actual content of the file :\n{_actual_content}")
+                return False
+    return True

--- a/plugins/spark_upgrade/update_calendar_interval.py
+++ b/plugins/spark_upgrade/update_calendar_interval.py
@@ -51,5 +51,4 @@ def update_CalendarInterval(paths_to_codebase: List[str]):
         allow_dirty_ast=True,
     )
 
-    print("Hey")
     return execute_piranha(args)

--- a/plugins/spark_upgrade/update_calendar_interval.py
+++ b/plugins/spark_upgrade/update_calendar_interval.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from polyglot_piranha import (
+    Filter,
+    OutgoingEdges,
+    PiranhaArguments,
+    Rule,
+    RuleGraph,
+    execute_piranha,
+)
+
+
+def update_CalendarInterval(paths_to_codebase: List[str]):
+    update_CalendarInterval = Rule(
+        name="update_CalendarInterval",
+        query="cs CalendarInterval.:[x]",
+        replace_node="*",
+        replace="DateTimeConstants.@x",
+        holes={"calendarInterval"},
+    )
+    add_import_DateTimeConstants = Rule(
+        name="add_import_DateTimeConstants",
+        query="(package_clause) @package_clause",
+        replace_node="package_clause",
+        replace="@package_clause\nimport org.apache.spark.sql.catalyst.util.DateTimeConstants",
+        filters={
+            Filter(
+                enclosing_node="(compilation_unit) @cu",
+                not_contains=[
+                    "cs import org.apache.spark.sql.catalyst.util.DateTimeConstants"
+                ],
+            )
+        },
+        is_seed_rule=False,
+    )
+
+    args = PiranhaArguments(
+        language="scala",
+        paths_to_codebase=paths_to_codebase,
+        substitutions={"calendarInterval": "CalendarInterval"},
+        rule_graph=RuleGraph(
+            rules=[update_CalendarInterval, add_import_DateTimeConstants],
+            edges=[
+                OutgoingEdges(
+                    "update_CalendarInterval",
+                    to=["add_import_DateTimeConstants"],
+                    scope="File",
+                )
+            ],
+        ),
+        allow_dirty_ast=True,
+    )
+
+    print("Hey")
+    return execute_piranha(args)


### PR DESCRIPTION
Introduces plugin for spark3 upgrade. At this moment it only migrates `CalendarInterval`  to `DateTimeConstants`