### PR TITLE
 Adding TypeScript to Piranha Playground (redo)

### DIFF
--- a/experimental/piranha_playground/data_validation.py
+++ b/experimental/piranha_playground/data_validation.py
@@ -15,7 +15,7 @@ import toml
 from piranha_playground.rule_inference.utils.pretty_toml import PrettyTOML
 from piranha_playground.rule_inference.utils.rule_utils import RawRuleGraph
 
-LANGUAGES = ["kt", "java", "go", "swift"]
+LANGUAGES = ["kt", "java", "go", "swift", "tsx"]
 
 
 @attr.s

--- a/experimental/piranha_playground/rule_inference/template_parser.py
+++ b/experimental/piranha_playground/rule_inference/template_parser.py
@@ -26,6 +26,7 @@ class TemplateParser:
         "go": "comment",
         "kt": "comment",
         "swift": "comment",
+        "tsx": "comment"
     }
     template_holes = attr.ib(default=attr.Factory(dict))
 

--- a/experimental/piranha_playground/templates/index.html
+++ b/experimental/piranha_playground/templates/index.html
@@ -28,6 +28,7 @@
             <option value="java" selected="selected">Java</option>
             <option value="kt">Kotlin</option>
             <option value="go">Go</option>
+            <option value="tsx">TypeScript</option>
           </select>
         </div>
         <div class="col-lg-10 d-flex justify-content-end">


### PR DESCRIPTION
This PR adds Typescript support to the playground. PR #577 was closed due to a CLA agreement error. 