### PR TITLE
Add support for Palm, Claude-2, Cohere Llama2, CodeLlama (100+LLMs)

### DIFF
--- a/experimental/piranha_playground/main.py
+++ b/experimental/piranha_playground/main.py
@@ -14,6 +14,7 @@ import os
 import sys
 
 import openai
+import litellm
 from flask import Flask, Response, jsonify, render_template, request, session
 
 from piranha_playground.data_validation import (ImproveData, InferData,
@@ -136,8 +137,8 @@ def test_rule():
 
 
 def main():
-    openai.api_key = os.getenv("OPENAI_API_KEY")
-    if not openai.api_key:
+    litellm.api_key = os.getenv("OPENAI_API_KEY")
+    if not litellm.api_key:
         sys.exit(
             "Please set the OPENAI_API_KEY environment variable to your OpenAI API key."
         )

--- a/experimental/piranha_playground/rule_inference/piranha_chat.py
+++ b/experimental/piranha_playground/rule_inference/piranha_chat.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Tuple
 
 import attr
 import openai
+from litellm import completion
 
 from piranha_playground.rule_inference.utils.logger_formatter import \
     CustomFormatter
@@ -407,7 +408,7 @@ enclosing_node = """((identifier) @name) (#eq? @name "x"))"""
         for _ in range(3):
             try:
                 logger.debug("Attempting to get completion from GPT.")
-                response = openai.ChatCompletion.create(
+                response = completion(
                     model=self.model,
                     messages=self.messages,
                     temperature=self.temperature,  # this is the degree of randomness of the model's output

--- a/experimental/requirements.txt
+++ b/experimental/requirements.txt
@@ -2,6 +2,7 @@ tree-sitter==0.20.2
 tree-sitter-languages
 attrs
 openai
+litellm
 polyglot-piranha
 toml
 pytest


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```