### PR TITLE
Update commit hash to include value argument label

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tree-sitter-kotlin = { git = "https://github.com/fwcd/tree-sitter-kotlin.git" }
 # TODO: Update after next version is released (https://github.com/tree-sitter/tree-sitter-java/issues/146)
 tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java.git", rev = "c194ee5e6ede5f26cf4799feead4a8f165dcf14d" }
 # TODO: Update after: https://github.com/alex-pinkus/tree-sitter-swift/issues/278 resolves
-tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git", rev = "cfc890d84bc4f561694b8b29e32abd8f2212cb20" }
+tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git", rev = "08a28993599f1968bc81631a89690503e1db7704" }
 tree-sitter-python = "0.20.2"
 tree-sitter-typescript = "0.20.1"
 # TODO: Update after https://github.com/tree-sitter/tree-sitter-go/pull/103 lands


### PR DESCRIPTION
This diff updates base commit that points to tree-sitter-swift for Satyam's repo to include the value_argument_label node generated after running tree-sitter generate command. 

Pls refer to this for the changes: https://github.com/Satyam1749/tree-sitter-swift/commit/08a28993599f1968bc81631a89690503e1db7704