### PR TITLE
Fix Variable Inline issues related to parameter cleanup in adhoc cases

### DIFF
--- a/src/cleanup_rules/swift/edges.toml
+++ b/src/cleanup_rules/swift/edges.toml
@@ -36,8 +36,8 @@ to = ["replace_identifier_with_value", "delete_parent_assignment"]
 scope = "Class"
 from = "delete_field_initialisation_init"
 to = [
-  "replace_self_identifier_with_value",
   "replace_identifier_with_value",
+  "replace_self_identifier_with_value",
   "delete_field_declaration",
 ]
 
@@ -45,8 +45,8 @@ to = [
 scope = "Class"
 from = "delete_field_initialisation"
 to = [
-  "replace_self_identifier_with_value",
   "replace_identifier_with_value",
+  "replace_self_identifier_with_value",
   "delete_parent_assignment",
 ]
 

--- a/src/cleanup_rules/swift/rules.toml
+++ b/src/cleanup_rules/swift/rules.toml
@@ -769,6 +769,9 @@ not_contains = [
     )""",
 ]
 
+[[rules.filters]]
+not_enclosing_node = "(value_argument_label) @va"
+
 # rule to delete declaration of variable in class scope
 [[rules]]
 name = "delete_field_declaration"

--- a/test-resources/swift/variable_inline/adhoc_variable_inline/expected/AdhocVariableInlining.swift
+++ b/test-resources/swift/variable_inline/adhoc_variable_inline/expected/AdhocVariableInlining.swift
@@ -30,3 +30,89 @@ class C2{
         }
     }
 }
+
+class C3 {
+    private lazy var someVar: SomeType = {
+        
+        let b: VectorDrawable = .caseB
+        let c = vectorImageComboViewBuilder.buildComboView(for: b, anotherFor: someOtherVar)
+        c.someAttribute = true
+        return c
+    }()
+
+    private var someComputedVar: SomeVarType {
+        
+        return shared {
+            SomeFunctionCall(a: "b", c: c)
+        }
+    }
+
+    
+
+    private func f3() -> String{
+        abc.subscribe(onNext: {(someVar: SomeVarType) in
+        switch someVar {
+            case .caseA:
+            return "someString"
+            case .caseB: 
+            return "someOtherString"
+            case .caseC:
+             return "to_be_retained"
+            case .caseD:
+             return "to_be_retained"
+
+            default: "another_test_case"
+        }})
+    }
+
+    private func f4() -> String{
+        abc.subscribe(onNext: {(someVar: SomeVarType) in
+            if someCondition {
+                doSomeCalls()
+            } else {
+                let someInternalVar = "some_internal_var"
+                if someOtherCondition {
+                    someFunctionCall()
+                    
+                }
+            }
+        })
+    }
+}
+
+class C4 {
+     
+    var varA: A 
+    var varB: B
+
+    private lazy var someComputedProperty: SomePropertyType {
+        let a = SomeFunctionCall(
+            firstVar: .a,
+            localVar: false,
+            secondVar: .b,
+            thirdVar: thirdVar
+        )
+    }
+
+    init(varA: A, varB: B){
+        
+        self.varA = varA
+        self.varB = varB
+
+        someFunctionCall(varB, varA, false)
+        
+    }
+
+    func ifInSwitch() -> String?{
+        switch varA {
+            case .a:
+                return "a"
+            case .b:
+                let someNestedVar = "some_nested_var"
+                doSOmethingElse()
+                
+            default:
+                return nil
+        }
+    }
+}

--- a/test-resources/swift/variable_inline/adhoc_variable_inline/input/AdhocVariableInlining.swift
+++ b/test-resources/swift/variable_inline/adhoc_variable_inline/input/AdhocVariableInlining.swift
@@ -38,3 +38,103 @@ class C2{
         }
     }
 }
+
+class C3 {
+    private lazy var someVar: SomeType = {
+        let a = placeholder_false
+        let b: VectorDrawable = a ? .caseA : .caseB
+        let c = vectorImageComboViewBuilder.buildComboView(for: b, anotherFor: someOtherVar)
+        c.someAttribute = true
+        return c
+    }()
+
+    private var someComputedVar: SomeVarType {
+        let localVar = placeholder_false
+        return shared {
+            SomeFunctionCall(a: localVar ? "a" : "b", c: c)
+        }
+    }
+
+    private var x = !placeholder_false
+
+    private func f3() -> String{
+        abc.subscribe(onNext: {(someVar: SomeVarType) in
+        switch someVar {
+            case .caseA:
+            return "someString"
+            case .caseB: 
+            return "someOtherString"
+            case .caseC:
+             if self.x{
+                return "to_be_retained"
+             }
+             return "to_be_deleted"
+            case .caseD:
+                if x{
+                    return "to_be_retained"
+                }
+            return "to_be_deleted"
+            default: "another_test_case"
+        }})
+    }
+
+    private func f4() -> String{
+        abc.subscribe(onNext: {(someVar: SomeVarType) in
+            if someCondition {
+                doSomeCalls()
+            } else {
+                let someInternalVar = "some_internal_var"
+                if someOtherCondition {
+                    if self.x {
+                        someFunctionCall()
+                    } else {
+                        someOtherFunctionCall()
+                    }
+                }
+            }
+        })
+    }
+}
+
+class C4 {
+    private let localVar: Bool 
+    var varA: A 
+    var varB: B
+
+    private lazy var someComputedProperty: SomePropertyType {
+        let a = SomeFunctionCall(
+            firstVar: .a,
+            localVar: localVar,
+            secondVar: .b,
+            thirdVar: thirdVar
+        )
+    }
+
+    init(varA: A, varB: B){
+        self.localVar = placeholder_false
+        self.varA = varA
+        self.varB = varB
+
+        if localVar {
+            someFunctionCall(varA, varB, localVar)
+        } else {
+            someFunctionCall(varB, varA, localVar)
+        }
+    }
+
+    func ifInSwitch() -> String?{
+        switch varA {
+            case .a:
+                return "a"
+            case .b:
+                let someNestedVar = "some_nested_var"
+                if localVar {
+                    doSomething()
+                } else {
+                    doSOmethingElse()
+                }
+            default:
+                return nil
+        }
+    }
+}

--- a/test-resources/swift/variable_inline/field_variable_inline/expected/FieldVariableInline.swift
+++ b/test-resources/swift/variable_inline/field_variable_inline/expected/FieldVariableInline.swift
@@ -311,3 +311,9 @@ class C24 {
     super.init(someParameter: someVar)
   }
 }
+
+class C25 {
+  init() {
+    super.init(someParameter: someFunctionCall(a: true))
+  }
+}

--- a/test-resources/swift/variable_inline/field_variable_inline/input/FieldVariableInline.swift
+++ b/test-resources/swift/variable_inline/field_variable_inline/input/FieldVariableInline.swift
@@ -437,3 +437,10 @@ class C24 {
     super.init(someParameter: a ? someVar : someOtherVar)
   }
 }
+
+class C25 {
+  init() {
+    let a = !placeholder_false
+    super.init(someParameter: someFunctionCall(a: a))
+  }
+}


### PR DESCRIPTION
This diff fixes the issues caught when Piranha was run in our swift code. The issues broadly revolved around adhoc cases of variable cleanup like being passed in a function as an argument. Please refer to the new tests added to understand more about these adhoc cases. 

In case CI tests fail, pls rerun after landing #612