### PR TITLE
Enhance Spark2 migration

### DIFF
--- a/plugins/spark_upgrade/spark_config/__init__.py
+++ b/plugins/spark_upgrade/spark_config/__init__.py
@@ -46,6 +46,7 @@ class SparkConfigChange(ExecutePiranha):
                 "spark_conf_change_java_scala", ["dummy"], scope="ParentIterative"
             ),
             OutgoingEdges("BuilderPattern", ["dummy"], scope="ParentIterative"),
+            #StandAloneCall
             OutgoingEdges(
                 "dummy",
                 [
@@ -56,7 +57,7 @@ class SparkConfigChange(ExecutePiranha):
             ),
             OutgoingEdges(
                 "update_enclosing_var_declaration",
-                ["update_spark_context"],
+                ["update_spark_context", "StandAloneCall"],
                 scope="File",
             ),
         ] + ([] if self.language == "scala" else java_rules.EDGES)

--- a/plugins/spark_upgrade/spark_config/java_rules.py
+++ b/plugins/spark_upgrade/spark_config/java_rules.py
@@ -2,7 +2,7 @@ from polyglot_piranha import Filter, OutgoingEdges, Rule
 
 update_enclosing_var_declaration_java = Rule(
     name="update_enclosing_var_declaration_java",
-    query="cs SparkConf :[conf_var] = :[rhs];",
+    query="cs :[type] :[conf_var] = :[rhs];",
     replace_node="*",
     replace="SparkSession @conf_var = @rhs.getOrCreate();",
     is_seed_rule=False,

--- a/plugins/spark_upgrade/spark_config/java_scala_rules.py
+++ b/plugins/spark_upgrade/spark_config/java_scala_rules.py
@@ -13,6 +13,8 @@ from polyglot_piranha import (
     Rule,
 )
 
+
+# Rules for transforming builder patterns
 # Rule to transform EntropyCalculator() arguments
 spark_conf_change_java_scala = Rule(
     name="spark_conf_change_java_scala",
@@ -103,12 +105,106 @@ set_spark_home_change_java_scala = Rule(
     is_seed_rule=False,
 )
 
+app_name_change_java_scala_stand_alone_call = Rule(
+    name="app_name_change_java_scala_stand_alone_call",
+    query="cs @conf_var.setAppName(:[app_name])",
+    replace_node="*",
+    replace="@conf_var.appName(@app_name)",
+    groups={"StandAloneCall"},
+    holes= {"conf_var"},
+    is_seed_rule=False,
+)
+
+master_name_change_java_scala_stand_alone_call = Rule(
+    name="master_name_change_java_scala_stand_alone_call",
+    query="cs @conf_var.setMaster(:[master])",
+    replace_node="*",
+    replace="@conf_var.master(@master)",
+    groups={"StandAloneCall"},
+    holes= {"conf_var"},
+    is_seed_rule=False,
+)
+
+setter_name_change_java_scala_stand_alone_call = Rule(
+    name="setter_name_change_java_scala_stand_alone_call",
+    query="cs @conf_var.set(:[a1],:[a2])",
+    replace_node="*",
+    replace="@conf_var.config(@a1, @a2)",
+    groups={"StandAloneCall"},
+    holes= {"conf_var"},
+    is_seed_rule=False,
+)
+
+set_all_change_java_scala_stand_alone_call = Rule(
+    name="set_all_change_java_scala_stand_alone_call",
+    query="cs @conf_var.setAll(:[a1])",
+    replace_node="*",
+    replace="@conf_var.all(@a1)",
+    groups={"StandAloneCall"},
+    holes= {"conf_var"},
+    is_seed_rule=False,
+)
+
+set_if_missing_java_scala_stand_alone_call = Rule(
+    name="set_if_missing_java_scala_stand_alone_call",
+    query="cs @conf_var.setIfMissing(:[a1], :[a2])",
+    replace_node="*",
+    replace="@conf_var.ifMissing(@a1)",
+    groups={"StandAloneCall"},
+    holes= {"conf_var"},
+    is_seed_rule=False,
+)
+
+set_jars_change_java_scala_stand_alone_call = Rule(
+    name="set_jars_change_java_scala_stand_alone_call",
+    query="cs @conf_var.setJars(:[a1])",
+    replace_node="*",
+    replace="@conf_var.jars(@a1)",
+    groups={"StandAloneCall"},
+    holes= {"conf_var"},
+    is_seed_rule=False,
+)
+
+set_executor_env_change_1_java_scala_stand_alone_call = Rule(
+    name="set_executor_env_change_1_java_scala_stand_alone_call",
+    query="cs @conf_var.setExecutorEnv(:[a1])",
+    replace_node="*",
+    replace="@conf_var.executorEnv(@a1)",
+    groups={"StandAloneCall"},
+    holes= {"conf_var"},
+    is_seed_rule=False,
+)
+
+set_executor_env_change_2_java_scala_stand_alone_call = Rule(
+    name="set_executor_env_change_2_java_scala_stand_alone_call",
+    query="cs @conf_var.setExecutorEnv(:[a1], :[a2])",
+    replace_node="*",
+    replace="@conf_var.executorEnv(@a1, @a2)",
+    groups={"StandAloneCall"},
+    holes= {"conf_var"},
+    is_seed_rule=False,
+)
+
+set_spark_home_change_java_scala_stand_alone_call = Rule(
+    name="set_spark_home_change_java_scala_stand_alone_call",
+    query="cs @conf_var.setSparkHome(:[a1])",
+    replace_node="*",
+    replace="@conf_var.sparkHome(@a1)",
+    groups={"StandAloneCall"},
+    holes= {"conf_var"},
+    is_seed_rule=False,
+)
+
+
 
 
 dummy = Rule(name="dummy", is_seed_rule=False)
 
 RULES = [
+    # Transforms the initializer
     spark_conf_change_java_scala,
+    
+    # Transforms the builder pattern
     app_name_change_java_scala,
     master_name_change_java_scala,
     setter_name_change_java_scala,
@@ -118,6 +214,20 @@ RULES = [
     set_executor_env_change_1_java_scala,
     set_executor_env_change_2_java_scala,
     set_spark_home_change_java_scala,
+    
+    # Transforms the stand alone calls
+    app_name_change_java_scala_stand_alone_call,
+    master_name_change_java_scala_stand_alone_call,
+    setter_name_change_java_scala_stand_alone_call,
+    set_all_change_java_scala_stand_alone_call,
+    set_if_missing_java_scala_stand_alone_call,
+    set_jars_change_java_scala_stand_alone_call,
+    set_executor_env_change_1_java_scala_stand_alone_call,
+    set_executor_env_change_2_java_scala_stand_alone_call,
+    set_spark_home_change_java_scala_stand_alone_call,
+    
+    
+    
     dummy,
 ]
 

--- a/plugins/spark_upgrade/tests/resources/spark_conf/expected/sample.java
+++ b/plugins/spark_upgrade/tests/resources/spark_conf/expected/sample.java
@@ -25,6 +25,13 @@ public class Sample {
           .getOrCreate();
         
         sc = conf1.sparkContext();
+        
+        SparkSession conf2 = new SparkSession.builder().config("spark.sql.legacy.allowUntypedScalaUDF", "true").getOrCreate();
+        conf2.config("spark.driver.instances:", "100");
+        conf2.appName(appName);
+        conf2.sparkHome(sparkHome);
+
+        sc2 = conf2.sparkContext();
 
     }
 }

--- a/plugins/spark_upgrade/tests/resources/spark_conf/expected/sample.scala
+++ b/plugins/spark_upgrade/tests/resources/spark_conf/expected/sample.scala
@@ -24,6 +24,14 @@ class Sample {
         .config("spark.driver.allowMultipleContexts", "true")
         .getOrCreate()
     sc1 = conf1.sparkContext
+    
+    val conf2 = new SparkSession.builder()
+        .config("spark.sql.legacy.allowUntypedScalaUDF", "true")
+        .master(master)
+        .getOrCreate()
+    conf2.sparkHome(sparkHome)
+
+    conf2.executorEnv("spark.executor.extraClassPath", "test")
 
   }
 }

--- a/plugins/spark_upgrade/tests/resources/spark_conf/input/sample.java
+++ b/plugins/spark_upgrade/tests/resources/spark_conf/input/sample.java
@@ -19,6 +19,15 @@ public class Sample {
         
         sc = new JavaSparkContext(conf1);
 
+
+
+        var conf2 = new SparkConf();
+        conf2.set("spark.driver.instances:", "100");
+        conf2.setAppName(appName);
+        conf2.setSparkHome(sparkHome);
+
+        sc2 = new JavaSparkContext(conf2);
+
        
     }
 }

--- a/plugins/spark_upgrade/tests/resources/spark_conf/input/sample.scala
+++ b/plugins/spark_upgrade/tests/resources/spark_conf/input/sample.scala
@@ -20,6 +20,16 @@ class Sample {
       .set("spark.driver.allowMultipleContexts", "true")
     sc1 = new SparkContext(conf1)
     
+
+    val conf2 = new SparkConf()
+      .setMaster(master)
+    
+    conf2.setSparkHome(sparkHome)
+
+    conf2.setExecutorEnv("spark.executor.extraClassPath", "test")
+
+
+
   }
 
 }


### PR DESCRIPTION
Fixes the bug related to not being able to rewrite java expressions using var. Added a feature to match non builder pattern occurences of the SparkConf setters.