### PR TITLE
Fix SparkMigration plugin

### DIFF
--- a/plugins/spark_upgrade/spark_config/java_scala_rules.py
+++ b/plugins/spark_upgrade/spark_config/java_scala_rules.py
@@ -20,7 +20,7 @@ spark_conf_change_java_scala = Rule(
     name="spark_conf_change_java_scala",
     query="cs new SparkConf()",
     replace_node="*",
-    replace='new SparkSession.builder().config("spark.sql.legacy.allowUntypedScalaUDF", "true")',
+    replace='SparkSession.builder().config("spark.sql.legacy.allowUntypedScalaUDF", "true")',
     holes={"spark_conf"},
 )
 

--- a/plugins/spark_upgrade/tests/resources/spark_conf/expected/sample.java
+++ b/plugins/spark_upgrade/tests/resources/spark_conf/expected/sample.java
@@ -7,7 +7,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 
 public class Sample {
     public static void main(String[] args) {
-        SparkSession conf = new SparkSession.builder()
+        SparkSession conf = SparkSession.builder()
                 .config("spark.sql.legacy.allowUntypedScalaUDF", "true")
                 .appName("Sample App")
                 .getOrCreate();
@@ -15,7 +15,7 @@ public class Sample {
         SparkContext sc = conf.sparkContext();
 
 
-        SparkSession conf1 = new SparkSession.builder()
+        SparkSession conf1 = SparkSession.builder()
           .config("spark.sql.legacy.allowUntypedScalaUDF", "true")
           .sparkHome(sparkHome)
           .executorEnv("spark.executor.extraClassPath", "test")
@@ -26,12 +26,14 @@ public class Sample {
         
         sc = conf1.sparkContext();
         
-        SparkSession conf2 = new SparkSession.builder().config("spark.sql.legacy.allowUntypedScalaUDF", "true").getOrCreate();
+        SparkSession conf2 = SparkSession.builder().config("spark.sql.legacy.allowUntypedScalaUDF", "true").getOrCreate();
         conf2.config("spark.driver.instances:", "100");
         conf2.appName(appName);
         conf2.sparkHome(sparkHome);
 
         sc2 = conf2.sparkContext();
+
+        SparkSession conf3 = SparkSession.builder().config("spark.sql.legacy.allowUntypedScalaUDF", "true").getOrCreate();
 
     }
 }

--- a/plugins/spark_upgrade/tests/resources/spark_conf/expected/sample.scala
+++ b/plugins/spark_upgrade/tests/resources/spark_conf/expected/sample.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.SparkSession
 class Sample {
   def main(args: Array[String]): Unit = {
     
-    val conf= new SparkSession.builder()
+    val conf= SparkSession.builder()
         .config("spark.sql.legacy.allowUntypedScalaUDF", "true")
         .appName("Sample App")
         .getOrCreate()
@@ -14,7 +14,7 @@ class Sample {
     val sc = conf.sparkContext
 
 
-    val conf1 = new SparkSession.builder()
+    val conf1 = SparkSession.builder()
         .config("spark.sql.legacy.allowUntypedScalaUDF", "true")
         .master(master)
         .all(Seq(("k2", "v2"), ("k3", "v3")))
@@ -25,7 +25,7 @@ class Sample {
         .getOrCreate()
     sc1 = conf1.sparkContext
     
-    val conf2 = new SparkSession.builder()
+    val conf2 = SparkSession.builder()
         .config("spark.sql.legacy.allowUntypedScalaUDF", "true")
         .master(master)
         .getOrCreate()

--- a/plugins/spark_upgrade/tests/resources/spark_conf/input/sample.java
+++ b/plugins/spark_upgrade/tests/resources/spark_conf/input/sample.java
@@ -28,6 +28,9 @@ public class Sample {
 
         sc2 = new JavaSparkContext(conf2);
 
+
+        var conf3 = new SparkConf();
+
        
     }
 }


### PR DESCRIPTION
The builder method is static and not instance. So remove the new keyword