### PR TITLE
Adding the option to use :[x] instead of @x

### DIFF
--- a/src/df/utils.rs
+++ b/src/df/utils.rs
@@ -100,7 +100,7 @@ pub fn get_capture_groups_from_tsq(pattern: String) -> Vec<String> {
 
   // maps matched strings to a vec of strings
   let capture_groups = output_summaries
-    .get(0)
+    .first()
     .map(|summary| {
       summary
         .matches()
@@ -147,7 +147,7 @@ pub fn get_capture_group_usage_from_tsq(pattern: String) -> Vec<String> {
 
   // maps matched strings to a vec of strings
   let matched_strings = output_summaries
-    .get(0)
+    .first()
     .map(|summary| {
       summary
         .matches()

--- a/src/models/unit_tests/rule_test.rs
+++ b/src/models/unit_tests/rule_test.rs
@@ -55,6 +55,25 @@ fn test_rule_try_instantiate_positive() {
   ))
 }
 
+#[test]
+fn test_rule_try_instantiate_positive_cs() {
+  let rule = piranha_rule! {
+      name= "test",
+      query= "cs :[variable_name] = :[value]",
+      replace_node = "*",
+      replace = "",
+      holes = ["variable_name"]
+  };
+
+  let substitutions: HashMap<String, String> =
+    HashMap::from([(String::from("variable_name"), String::from("foobar"))]);
+  let instantiated_rule = InstantiatedRule::new(&rule, &substitutions);
+  assert!(eq_without_whitespace(
+    instantiated_rule.query().pattern().as_str(),
+    "cs foobar = :[value]"
+  ))
+}
+
 /// Tests whether a valid rule is *not* instantiated given invalid substitutions.
 #[test]
 #[should_panic]

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -47,7 +47,7 @@ where
         T::default()
       } else {
         #[rustfmt::skip]
-      panic!("Could not read file: {file_path:?} \n Error : \n {err:?}");
+        panic!("Could not read file: {file_path:?} \n Error : \n {err:?}");
       }
     }
   }
@@ -138,6 +138,9 @@ impl Instantiate for String {
     for (tag, substitute) in substitutions {
       // Before replacing the key, it is transformed to a tree-sitter tag by adding `@` as prefix
       let key = format!("@{tag}");
+      output = output.replace(&key, substitute);
+
+      let key = format!(":[{tag}]");
       output = output.replace(&key, substitute);
     }
     output

--- a/src/utilities/unit_tests/tree_sitter_utilities_test.rs
+++ b/src/utilities/unit_tests/tree_sitter_utilities_test.rs
@@ -138,3 +138,17 @@ fn test_instantiate() {
     "isFlagTreated foo bar true"
   )
 }
+
+#[test]
+fn test_instantiate_cs() {
+  let substitutions = HashMap::from([
+    ("variable_name".to_string(), "isFlagTreated".to_string()),
+    ("init".to_string(), "true".to_string()),
+  ]);
+  assert_eq!(
+    CGPattern(":[variable_name] foo bar :[init]".to_string())
+      .instantiate(&substitutions)
+      .0,
+    "isFlagTreated foo bar true"
+  )
+}


### PR DESCRIPTION
This changes the instantiation method to make it more intuitive when using concrete syntax

It is now possible to

```
match = if (true) :[consq] else :[alt]
replace_node = "*"
replace = :[consq]
```