### PR TITLE
tree-sitter-java 0.20.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,7 @@ tempdir = "0.3"
 serde_json = "1.0.82"
 
 tree-sitter-kotlin = { git = "https://github.com/fwcd/tree-sitter-kotlin.git" }
-# TODO: Update after next version is released (https://github.com/tree-sitter/tree-sitter-java/issues/146)
-tree-sitter-java = { git = "https://github.com/tree-sitter/tree-sitter-java.git", rev = "c194ee5e6ede5f26cf4799feead4a8f165dcf14d" }
+tree-sitter-java = "0.20.2"
 # TODO: Update after: https://github.com/alex-pinkus/tree-sitter-swift/issues/278 resolves
 tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git", rev = "08a28993599f1968bc81631a89690503e1db7704" }
 tree-sitter-python = "0.20.2"


### PR DESCRIPTION
Bumping `tree-sitter-java` version to `0.20.2`. It solves a TODO in `Cargo.toml`.

As a bonus from the new `tree-sitter-java` version, I'm adding a python test checking that `method_declaration` as top level node works. There are a few formatting changes in _tests/tests.py_ as well.