### PR TITLE
explicit license in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
   { name = "Lazaro Clapp", email = "lazaro@uber.com" },
   { name = "Uber Technologies Inc." },
 ]
-license = { file = "LICENSE" }
+license = "Apache-2.0"
 readme = "README.md"
 keywords = [
   "refactoring",


### PR DESCRIPTION
This PR ultimately removes a duplicate `License-File: LICENSE` entry in the `METADATA` file of the python wheel generated by maturin. For instance, from our latest release:

```
Metadata-Version: 2.1
Name: polyglot_piranha
Version: 0.3.22
License-File: LICENSE
License-File: LICENSE
License-File: NOTICE 
...
```

Right now, we have a _license file_ entry in both `Cargo.toml` and `pyproject.toml`. It seems that maturin adds both entries. 
This PR removes the file entry from `pyproject.toml` while still keeping the license explicit (`Apache-2.0`).

The duplicate entry leads to weird behavior:

1) when unzipping the `.whl`:

```
replace polyglot_piranha-0.3.22.dist-info/license_files/LICENSE? [y]es, [n]o, [A]ll, [N]one, [r]ename: y
```

2) raises an error in:

https://github.com/pypa/installer/blob/777a499d5a351c07a631147c96e41db8cdfdbcfc/src/installer/destinations.py#L165-L167