### PR TITLE
Recent maturin version and standardizing Python across GH workflows

### DIFF
--- a/.github/workflows/polyglot_build.yml
+++ b/.github/workflows/polyglot_build.yml
@@ -1,7 +1,7 @@
 name: Polyglot Piranha
 on:
   pull_request:
-  push: 
+  push:
     branches:
       - master
 env:
@@ -24,7 +24,11 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt
-      - name: Run pre-commit 
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Run pre-commit
         run : |
           python -m venv .env
           source .env/bin/activate
@@ -33,10 +37,6 @@ jobs:
           pre-commit run --all-files
       - name: Run unit and integration tests
         run: cargo build && cargo test -- --include-ignored
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
       - name: Create virtualenv and install dependencies
         run: |
           python -m venv .env
@@ -45,7 +45,7 @@ jobs:
       - name: Run Python tests
         run: |
           source .env/bin/activate
-          pip3 install -r experimental/requirements.txt
+          pip install -r experimental/requirements.txt
           maturin develop
           pytest tests/tests.py
           pytest -s -rx .

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Build wheel with Maturin
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Build wheel with Maturin
@@ -46,7 +46,7 @@ jobs:
       CXXFLAGS: -stdlib=libc++ -mmacosx-version-min=10.16
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Build wheel with Maturin
@@ -68,7 +68,7 @@ jobs:
       CXXFLAGS: -stdlib=libc++
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Build wheel with Maturin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Version 0.3.23
 -------------
+This version may fail to `pip install polyglot-piranha` in some Linux versions.
+
 * Python wheel with no duplicate entries in generated METADATA
 * RELEASING.md: updated instructions
 * Starter kit for Zap Transformation plugin

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,13 +7,13 @@ Releasing
  4. Update the `README.md` with the new version.
  5. `git commit -am "[PolyglotPiranha] Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
  6. `git tag -a vX.Y.Z-polyglot -m "PolyglotPiranha Version X.Y.Z"` (where X.Y.Z is the new version)
- 7. `git push --set-upstream release-X.Y.Z && git push --tags`
+ 7. `git push --set-upstream origin release-X.Y.Z && git push --tags`
  8. Create a PR, request for review and merge it into `master` after it is approved.
  9. From your terminal run : `gh workflow run "Release Polyglot Piranha" --ref master` or do this from the Github UI
  10. Wait till this action is completed.
  11. Manually release MacOS M1 wheel (Currently GitHub Actions do not provide M1 VM)
-    1. Clone the piranha repo and pull the latest `master` branch 
-    2. `cargo build --no-default-features`
-    3. `maturin build --release`
-    4. `twine upload --skip-existing target/wheels/*`
+      1. Clone the piranha repo and pull the latest `master` branch
+      2. `cargo build --no-default-features`
+      3. `maturin build --release`
+      4. `twine upload --skip-existing target/wheels/*`
  13. Visit [polyglot-piranha](https://pypi.org/project/polyglot-piranha/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ documentation = "https://github.com/uber/piranha"
 repository = "https://github.com/uber/piranha"
 
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1.4.0,<2.0"]
 build-backend = "maturin"
 
 [tool.maturin]


### PR DESCRIPTION
## Changes

- `pyproject.toml`: Bump maturin to latest version ([taken from their documentation](https://github.com/PyO3/maturin/blob/91feb4bf756893d111bf3a1ac6137fa82147ee48/README.md#source-distribution))
- build workflow:
    - python setup _before_ any python command
    - py version 3.8 (from #417)
- release workflow: setup-python v4 (same as build)
- `RELEASING.md`:
    - fix in push step
    - markdown fixes
- `CHANGELOG.md`: pointing out that version `0.3.23` may not install some Linux versions (see below for more details)

## Tests

- GitHub build workflow
- Following `RELEASING.md` steps in local environment:
    - ubuntu
    - macOS

## Context

#643's `pyproject.toml` is only supported by more recent versions of `maturin`. 
Currently, by running `pip install maturin`, we use the latest `1.4.0` version in local development, most of GitHub workflows, and in `RELEASING.md`.
However, `pyproject.toml` was specifying version `0.13.0` for `maturin`, which raised a warning (e.g., [build for #643](https://github.com/uber/piranha/actions/runs/7350250110/job/20011576923#logs) , [build for #632)](https://github.com/uber/piranha/actions/runs/6857939798/job/18647926336#logs):

> Warning: You specified maturin >=0.13, <0.14 in pyproject.toml under `build-system.requires`, but the current maturin version is 1.4.0

So after #634, we had a build problem for specific ubuntu version when `maturin` version was indeed `0.13.0`. The build problem seems to be flaky, as #634's build passed, but following ones did not. Moreover, I successfully locally built releases from macOS and another ubuntu version.

The changes in `polyglot_build.yml` and `polyglot_release.yml` aim to remove this python and python-dependencies inconsistencies.



