### PR TITLE
Release workflow: ubuntu-20.04

### DIFF
--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -18,8 +18,8 @@ jobs:
       run: |
         pip install twine
         twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
-  build_ubuntu_18:
-    runs-on: ubuntu-18.04
+  build_ubuntu_20:
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v4


### PR DESCRIPTION
Changing ubuntu from 18.04 to 20.04 as it's the "oldest" supported.

Ubuntu 18.04 image was discontinued by GitHub: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Currently, our "Release Polyglot Piranha" workflow is failing after a day:
> This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.