### PR TITLE
Pin tree-sitter-kotlin to 0.3.5 to fix broken build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,8 @@ env_logger = "0.10.0"
 tempdir = "0.3"
 serde_json = "1.0.82"
 
-tree-sitter-kotlin = "0.3.1"
+# TODO: Update if we upgrade tree-sitter to >=0.21
+tree-sitter-kotlin = "=0.3.5"
 tree-sitter-java = "0.20.2"
 # TODO: Update after: https://github.com/alex-pinkus/tree-sitter-swift/issues/278 resolves
 tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git", rev = "08a28993599f1968bc81631a89690503e1db7704" }


### PR DESCRIPTION
PR #649 introduced support for Kotlin, but used a version of `tree-sitter-kotlin` which requires a newer version of `tree-sitter` than what is currently used. This PR pins `tree-sitter-kotlin` to one version older in order to fix the build.