### PR TITLE
Release Workflow: multiple py versions and arm

### DIFF
--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -3,10 +3,11 @@ on:
   workflow_dispatch:
 jobs:
   build_ubuntu:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, ubuntu-20.04]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -16,71 +17,23 @@ jobs:
       run: |
         pip install --upgrade maturin
         maturin build --release -o dist
-        maturin build --sdist -o dist
-    - name: Pypi Release
-      run: |
-        pip install twine
-        twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
-  build_ubuntu_20:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Build wheel with Maturin
-      run: |
-        pip install --upgrade maturin
-        maturin build --release -o dist
-        maturin build --sdist -o dist
-    - name: Pypi Release
-      run: |
-        pip install twine
-        twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
-  build_ubuntu_20_arm:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name : Install rustup targets
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-aarch64-linux-gnu
-        rustup target add aarch64-unknown-linux-gnu
-    - name: Setup cargo target and linker
-      run: |
-        mkdir -p .cargo
-        touch .cargo/config.toml
-        echo "[target.aarch64-unknown-linux-gnu]" >> .cargo/config.toml
-        echo "linker = \"aarch64-linux-gnu-gcc\"" >> .cargo/config.toml
-    - name: Build wheel with Maturin
-      run: |
-        pip install --upgrade maturin
-        maturin build --release -o dist --target aarch64-unknown-linux-gnu -i ${{ matrix.python-version }}
         maturin build --sdist -o dist
     - name: Pypi Release
       run: |
         pip install twine
         twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
   build_ubuntu_arm:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, ubuntu-20.04]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name : Install rustup target
+    - name : Install rustup targets
       run: |
         sudo apt-get update
         sudo apt-get install gcc-aarch64-linux-gnu

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -4,33 +4,99 @@ on:
 jobs:
   build_ubuntu:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
     - name: Build wheel with Maturin
       run: |
         pip install --upgrade maturin
         maturin build --release -o dist
         maturin build --sdist -o dist
-    - name: Pypi Release for ubuntu-latest
+    - name: Pypi Release
       run: |
         pip install twine
         twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
   build_ubuntu_20:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
     - name: Build wheel with Maturin
       run: |
         pip install --upgrade maturin
         maturin build --release -o dist
         maturin build --sdist -o dist
-    - name: Pypi Release for ubuntu-latest
+    - name: Pypi Release
+      run: |
+        pip install twine
+        twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
+  build_ubuntu_20_arm:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name : Install rustup targets
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-aarch64-linux-gnu
+        rustup target add aarch64-unknown-linux-gnu
+    - name: Setup cargo target and linker
+      run: |
+        mkdir -p .cargo
+        touch .cargo/config.toml
+        echo "[target.aarch64-unknown-linux-gnu]" >> .cargo/config.toml
+        echo "linker = \"aarch64-linux-gnu-gcc\"" >> .cargo/config.toml
+    - name: Build wheel with Maturin
+      run: |
+        pip install --upgrade maturin
+        maturin build --release -o dist --target aarch64-unknown-linux-gnu -i ${{ matrix.python-version }}
+        maturin build --sdist -o dist
+    - name: Pypi Release
+      run: |
+        pip install twine
+        twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
+  build_ubuntu_arm:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name : Install rustup target
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-aarch64-linux-gnu
+        rustup target add aarch64-unknown-linux-gnu
+    - name: Setup cargo target and linker
+      run: |
+        mkdir -p .cargo
+        touch .cargo/config.toml
+        echo "[target.aarch64-unknown-linux-gnu]" >> .cargo/config.toml
+        echo "linker = \"aarch64-linux-gnu-gcc\"" >> .cargo/config.toml
+    - name: Build wheel with Maturin
+      run: |
+        pip install --upgrade maturin
+        maturin build --release -o dist --target aarch64-unknown-linux-gnu -i ${{ matrix.python-version }}
+        maturin build --sdist -o dist
+    - name: Pypi Release
       run: |
         pip install twine
         twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
@@ -39,21 +105,17 @@ jobs:
     runs-on: [macos-12]
     strategy:
       matrix:
-        arch: ['x86_64']
-    env:
-      # Polyglot depends on tree-sitter-python which tries to compile c++ files stdlibc++ which is depreciated in newer version of mac.
-      MACOSX_DEPLOYMENT_TARGET: 10.16
-      CXXFLAGS: -stdlib=libc++ -mmacosx-version-min=10.16
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
       - name: Build wheel with Maturin
         run: |
           pip install --upgrade maturin
           maturin build --release -o dist
-      - name: Pypi Release for macos-latest
+      - name: Pypi Release
         run: |
           pip install twine
           twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
@@ -62,21 +124,21 @@ jobs:
     runs-on: [macos-latest]
     strategy:
       matrix:
-        arch: ['arm64']
-    env:
-      # Polyglot depends on tree-sitter-python which tries to compile c++ files stdlibc++ which is depreciated in newer version of mac.
-      CXXFLAGS: -stdlib=libc++
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
+      - name: Install rustup targets
+        run: |
+          rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
       - name: Build wheel with Maturin
         run: |
-          rustup target add aarch64-apple-darwin
           pip install --upgrade maturin
-          maturin build --release -o dist --target universal2-apple-darwin
-      - name: Pypi Release for macos-latest
+          maturin build --release -o dist --target universal2-apple-darwin -i ${{ matrix.python-version }}
+      - name: Pypi Release
         run: |
           pip install twine
           twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -1,13 +1,13 @@
 name: Release Polyglot Piranha
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 jobs:
   release:
     strategy:
       matrix:
         target: [linux-x86, linux-arm, macos-arm]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-    # We suspect we need 20.04 due to glibc not being new enough on Debian/devpod.
+    # We need 20.04 due to glibc not being new enough on Debian/devpod
+    # It has glibc 2.28+ (manylinux_2_28), which is compatible with Debian 10: https://github.com/pypa/manylinux/tree/8e297ac3813be400a9a244a2828c18d3dd7e6969?tab=readme-ov-file#manylinux_2_28-almalinux-8-based
     runs-on: ${{ fromJSON('{"linux-x86":"ubuntu-20.04","linux-arm":"ubuntu-latest","macos-arm":"macos-latest"}')[matrix.target] }}
     steps:
     - uses: actions/checkout@v4
@@ -17,7 +17,7 @@ jobs:
     - name: pip install --upgrade maturin
       run: |
         pip install --upgrade maturin
-    - name: Setup rustup target linux aarch64
+    - name: Setup rustup target linux-arm
       if: ${{ matrix.target == 'linux-arm' }}
       run: |
         sudo apt-get update
@@ -27,23 +27,14 @@ jobs:
         touch .cargo/config.toml
         echo "[target.aarch64-unknown-linux-gnu]" >> .cargo/config.toml
         echo "linker = \"aarch64-linux-gnu-gcc\"" >> .cargo/config.toml
-    - name: Setup rustup target macOS
+    - name: Setup rustup target macOS-arm
       if: ${{ matrix.target == 'macos-arm' }}
       run: |
         rustup target add x86_64-apple-darwin
         rustup target add aarch64-apple-darwin
-    - name: Build wheel with Maturin linux x86
-      if: ${{ matrix.target == 'linux-x86' }}
+    - name: Build wheel with Maturin ${{ matrix.target }}
       run: |
-        maturin build --release -o dist -i ${{ matrix.python-version }}
-    - name: Build wheel with Maturin linux arm
-      if: ${{ matrix.target == 'linux-arm' }}
-      run: |
-        maturin build --release -o dist --target aarch64-unknown-linux-gnu -i ${{ matrix.python-version }}
-    - name: Build wheel with Maturin macOS
-      if: ${{ matrix.target == 'macos-arm' }}
-      run: |
-        maturin build --release -o dist --target universal2-apple-darwin -i ${{ matrix.python-version }}
+        maturin build --release -o dist --target ${{ fromJSON('{"linux-x86":"x86_64-unknown-linux-gnu","linux-arm":"aarch64-unknown-linux-gnu","macos-arm":"universal2-apple-darwin"}')[matrix.target] }} -i ${{ matrix.python-version }}
     - name: Build source distribution
       if: ${{ matrix.target == 'linux-x86' }}
       run: |

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -2,10 +2,10 @@ name: Release Polyglot Piranha
 on:
   workflow_dispatch:
 jobs:
-  build_ubuntu:
+  release:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04]
+        os: [ubuntu-latest, ubuntu-20.04, macos-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
@@ -13,85 +13,38 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Build wheel with Maturin
-      run: |
-        pip install --upgrade maturin
-        maturin build --release -o dist
-        maturin build --sdist -o dist
-    - name: Pypi Release
-      run: |
-        pip install twine
-        twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
-  build_ubuntu_arm:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, ubuntu-20.04]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name : Install rustup targets
+    - name: Setup rustup target linux aarch64
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         sudo apt-get update
         sudo apt-get install gcc-aarch64-linux-gnu
         rustup target add aarch64-unknown-linux-gnu
-    - name: Setup cargo target and linker
-      run: |
         mkdir -p .cargo
         touch .cargo/config.toml
         echo "[target.aarch64-unknown-linux-gnu]" >> .cargo/config.toml
         echo "linker = \"aarch64-linux-gnu-gcc\"" >> .cargo/config.toml
-    - name: Build wheel with Maturin
+    - name: Setup rustup target macOS
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        rustup target add x86_64-apple-darwin
+        rustup target add aarch64-apple-darwin
+    - name: pip install --upgrade maturin
       run: |
         pip install --upgrade maturin
-        maturin build --release -o dist --target aarch64-unknown-linux-gnu -i ${{ matrix.python-version }}
+    - name: Build wheel with Maturin linux x86
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
+      run: |
+        maturin build --release -o dist
         maturin build --sdist -o dist
+    - name: Build wheel with Maturin linux arm
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        maturin build --release -o dist --target aarch64-unknown-linux-gnu -i ${{ matrix.python-version }}
+    - name: Build wheel with Maturin macOS
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        maturin build --release -o dist --target universal2-apple-darwin -i ${{ matrix.python-version }}
     - name: Pypi Release
       run: |
         pip install twine
         twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
-  macos_build_x86:
-    name: 'macos-x86'
-    runs-on: [macos-12]
-    strategy:
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Build wheel with Maturin
-        run: |
-          pip install --upgrade maturin
-          maturin build --release -o dist
-      - name: Pypi Release
-        run: |
-          pip install twine
-          twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
-  macos_build_arm:
-    name: 'macos-arm64'
-    runs-on: [macos-latest]
-    strategy:
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install rustup targets
-        run: |
-          rustup target add x86_64-apple-darwin
-          rustup target add aarch64-apple-darwin
-      - name: Build wheel with Maturin
-        run: |
-          pip install --upgrade maturin
-          maturin build --release -o dist --target universal2-apple-darwin -i ${{ matrix.python-version }}
-      - name: Pypi Release
-        run: |
-          pip install twine
-          twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -5,16 +5,20 @@ jobs:
   release:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, macos-latest]
+        target: [linux-x86, linux-arm, macos-arm]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-    runs-on: ${{ matrix.os }}
+    # We suspect we need 20.04 due to glibc not being new enough on Debian/devpod.
+    runs-on: ${{ fromJSON('{"linux-x86":"ubuntu-20.04","linux-arm":"ubuntu-latest","macos-arm":"macos-latest"}')[matrix.target] }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: pip install --upgrade maturin
+      run: |
+        pip install --upgrade maturin
     - name: Setup rustup target linux aarch64
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.target == 'linux-arm' }}
       run: |
         sudo apt-get update
         sudo apt-get install gcc-aarch64-linux-gnu
@@ -24,26 +28,26 @@ jobs:
         echo "[target.aarch64-unknown-linux-gnu]" >> .cargo/config.toml
         echo "linker = \"aarch64-linux-gnu-gcc\"" >> .cargo/config.toml
     - name: Setup rustup target macOS
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.target == 'macos-arm' }}
       run: |
         rustup target add x86_64-apple-darwin
         rustup target add aarch64-apple-darwin
-    - name: pip install --upgrade maturin
-      run: |
-        pip install --upgrade maturin
     - name: Build wheel with Maturin linux x86
-      if: ${{ matrix.os == 'ubuntu-20.04' }}
+      if: ${{ matrix.target == 'linux-x86' }}
       run: |
-        maturin build --release -o dist
-        maturin build --sdist -o dist
+        maturin build --release -o dist -i ${{ matrix.python-version }}
     - name: Build wheel with Maturin linux arm
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.target == 'linux-arm' }}
       run: |
         maturin build --release -o dist --target aarch64-unknown-linux-gnu -i ${{ matrix.python-version }}
     - name: Build wheel with Maturin macOS
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.target == 'macos-arm' }}
       run: |
         maturin build --release -o dist --target universal2-apple-darwin -i ${{ matrix.python-version }}
+    - name: Build source distribution
+      if: ${{ matrix.target == 'linux-x86' }}
+      run: |
+        maturin build --sdist -o dist
     - name: Pypi Release
       run: |
         pip install twine

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Build wheel with Maturin ${{ matrix.target }}
       run: |
         maturin build --release -o dist --target ${{ fromJSON('{"linux-x86":"x86_64-unknown-linux-gnu","linux-arm":"aarch64-unknown-linux-gnu","macos-arm":"universal2-apple-darwin"}')[matrix.target] }} -i ${{ matrix.python-version }}
-    - name: Build source distribution
+    - name: Build source distribution (only once for linux-x86)
       if: ${{ matrix.target == 'linux-x86' }}
       run: |
         maturin build --sdist -o dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@ repos:
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-yaml
+        # excluding as inline json fails check-yaml
+        exclude: ^.github/workflows/polyglot_release.yml$
       - id: check-toml
         files: src/|test-resources/|demo/
       - id: end-of-file-fixer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "polyglot_piranha"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 description = "Polyglot Piranha is a library for performing structural find and replace with deep cleanup."
 authors = [
   { name = "Ameya Ketkar", email = "ketkara@uber.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,7 @@
 name = "polyglot_piranha"
 requires-python = ">=3.8"
 description = "Polyglot Piranha is a library for performing structural find and replace with deep cleanup."
-authors = [
-  { name = "Ameya Ketkar", email = "ketkara@uber.com" },
-  { name = "Lazaro Clapp", email = "lazaro@uber.com" },
-  { name = "Uber Technologies Inc." },
-]
+authors = [{ name = "Uber Technologies Inc." }]
 license = "Apache-2.0"
 readme = "README.md"
 keywords = [


### PR DESCRIPTION
Using a matrix strategy in the "Release Polyglot Piranha" workflows jobs to change python versions within [3.8; 3.12].
Moreover, adding more jobs to release for linux and macos ARM.

Successful execution of the workflow: https://github.com/uber/piranha/actions/runs/9909648923
Successful release of wheels in TestPyPi: https://test.pypi.org/project/polyglot-piranha-test/0.3.253a0/#files