### PR TITLE
linux-arm release: install g++

### DIFF
--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -19,9 +19,11 @@ jobs:
         pip install --upgrade maturin
     - name: Setup rustup target linux-arm
       if: ${{ matrix.target == 'linux-arm' }}
+      # g++ is needed for tree-sitter YAML dependency
       run: |
         sudo apt-get update
         sudo apt-get install gcc-aarch64-linux-gnu
+        sudo apt-get install g++-aarch64-linux-gnu
         rustup target add aarch64-unknown-linux-gnu
         mkdir -p .cargo
         touch .cargo/config.toml


### PR DESCRIPTION
Fix for [error](https://github.com/uber/piranha/actions/runs/10113433225/job/27969800161#step:7:298) in the release workflow after we added the YAML dependency.
Successfully reproduced and fixed when running `maturin build --release` on a local Debian machine.