### PR TITLE
Kotlin cleanup rules to support `!true &&` and `!false ||` expressions

### DIFF
--- a/src/cleanup_rules/kt/rules.toml
+++ b/src/cleanup_rules/kt/rules.toml
@@ -204,6 +204,25 @@ replace = "true"
 replace_node = "prefix_expression"
 is_seed_rule = false
 
+# Before :
+#  !false ||
+# After :
+#  true
+#
+[[rules]]
+groups = ["boolean_expression_simplify"]
+name = "simplify_not_false_disjunction"
+query = """
+(
+(prefix_expression (disjunction_expression (_) @nested_expression)) @prefix_expression
+(#match? @nested_expression "^false$")
+(#match? @prefix_expression "!.*")
+)
+"""
+replace = "true"
+replace_node = "prefix_expression"
+is_seed_rule = false
+
 # Before : 
 #  !true
 # After :
@@ -217,6 +236,25 @@ query = """
 (prefix_expression (boolean_literal) @exp) @prefix_expression
 (#eq? @exp "true")
 (#match? @prefix_expression "!.*")  
+)
+"""
+replace = "false"
+replace_node = "prefix_expression"
+is_seed_rule = false
+
+# Before :
+#  !true &&
+# After :
+#  false
+#
+[[rules]]
+groups = ["boolean_expression_simplify"]
+name = "simplify_not_true_conjunction"
+query = """
+(
+(prefix_expression (conjunction_expression (_) @nested_expression)) @prefix_expression
+(#match? @nested_expression "^true$")
+(#match? @prefix_expression "!.*")
 )
 """
 replace = "false"

--- a/test-resources/kt/feature_flag_system_1/control/expected/XPFlagCleanerCases.kt
+++ b/test-resources/kt/feature_flag_system_1/control/expected/XPFlagCleanerCases.kt
@@ -55,6 +55,12 @@ internal class XPFlagCleanerPositiveCases {
 
     }
 
+    fun test_conjunction_expression(flag1: Boolean, flag2: Boolean, condition: String) =
+        println("Hi world")
+
+    fun test_disjunction_expression(flag1: Boolean, flag2: Boolean, condition: String) =
+        println("Hello World")
+
     fun other_api_stale_flag() {
         println("Hi world")
     }

--- a/test-resources/kt/feature_flag_system_1/control/input/XPFlagCleanerCases.kt
+++ b/test-resources/kt/feature_flag_system_1/control/input/XPFlagCleanerCases.kt
@@ -86,6 +86,26 @@ internal class XPFlagCleanerPositiveCases {
         }
     }
 
+    fun test_conjunction_expression(flag1: Boolean, flag2: Boolean, condition: String) =
+        if ((flag1 || flag2) &&
+            !experimentation!!.isToggleDisabled(TestExperimentName.STALE_FLAG) &&
+            condition != "ENABLED"
+        ) {
+            println("Hello World")
+        } else {
+            println("Hi world")
+        }
+
+    fun test_disjunction_expression(flag1: Boolean, flag2: Boolean, condition: String) =
+        if ((flag1 && flag2) ||
+            !experimentation!!.isToggleEnabled(TestExperimentName.STALE_FLAG) ||
+            condition != "ENABLED"
+        ) {
+            println("Hello World")
+        } else {
+            println("Hi world")
+        }
+
     fun other_api_stale_flag() {
         if (experimentation!!.isFlagTreated(TestExperimentName.STALE_FLAG)) {
             println("Hello World")

--- a/test-resources/kt/feature_flag_system_2/control/expected/XPFlagCleanerInterfaceMethod.kt
+++ b/test-resources/kt/feature_flag_system_2/control/expected/XPFlagCleanerInterfaceMethod.kt
@@ -38,7 +38,7 @@ internal class XPFlagCleanerPositiveCases {
     }
 
     fun conditional_with_else_contains_stale_flag_tbool(a: Int, abc: Boolean) {
-        println("Hello World")
+        println("Hi world")
     }
 
     fun conditional_with_else_contains_stale_flag_tbool_reassigned(a: Int, z: Int) {
@@ -72,12 +72,12 @@ internal class XPFlagCleanerPositiveCases {
 
     fun conditional_with_else_contains_stale_flag_tbool_reassigned_ftbool(a: Int, z: Int) {
    
-        println("Hello World")
+        println("Hi world")
     }
 
     fun conditional_with_else_contains_stale_flag_tbool_reassigned_ftbool_1(a: Int, z: Int) {
      
-        println("Hello World")
+        println("Hi world")
     }
 
     fun conditional_with_else_contains_stale_flag_tbool_reassigned_ftbool_2(a: Int, z: Int) {


### PR DESCRIPTION
I noticed an issue when processing boolean expressions:
`if (!feature.isEnabled(FEATURE_A) && condition != "constant")`

Piranha refactors it like this:
`if (!condition != "constant")` which is syntactically and logically incorrect

I implemented two additional rules to fix it:

1) simplify not true in conjunction expression

`!true && ...` => the whole boolean expression will be refactored to `false`

2) simplify not false in disjunction expression

`!false || ... ` => the whole boolean expression will be refactored to `true`

Looking forward to a feedback / review. Thanks!