### PR TITLE
cli: capture allow_dirty_ast

### DIFF
--- a/src/models/piranha_arguments.rs
+++ b/src/models/piranha_arguments.rs
@@ -280,6 +280,7 @@ impl PiranhaArguments {
       .cleanup_comments(*p.cleanup_comments())
       .dry_run(*p.dry_run())
       .experiment_dyn(default_experiment_dyn())
+      .allow_dirty_ast(*p.allow_dirty_ast())
       .build()
   }
 


### PR DESCRIPTION
Fixes the CLI to allow passing the dirty ast option. 