### PR TITLE
Add delete_comments Flag to Rules

### DIFF
--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -227,6 +227,8 @@ class Rule:
     "Filters to test before applying a rule"
     is_seed_rule: bool
     "Marks a rule as a seed rule"
+    delete_comments: bool
+    "Marks a rule as a seed rule"
 
     def __init__(
         self,
@@ -238,6 +240,7 @@ class Rule:
         holes: set[str] = set(),
         filters: set[Filter] = set(),
         is_seed_rule: bool = True,
+        delete_comments: bool = True,
     ):
         """
         Constructs `Rule`

--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -228,7 +228,7 @@ class Rule:
     is_seed_rule: bool
     "Marks a rule as a seed rule"
     delete_comments: bool
-    "Marks a rule as a seed rule"
+    "Make comment deleting optional"
 
     def __init__(
         self,

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -192,6 +192,10 @@ pub(crate) fn default_is_seed_rule() -> bool {
   true
 }
 
+pub(crate) fn default_delete_comments() -> bool {
+  true
+}
+
 pub(crate) fn default_allow_dirty_ast() -> bool {
   false
 }

--- a/src/models/matches.rs
+++ b/src/models/matches.rs
@@ -119,7 +119,8 @@ impl Match {
 
   // Populates the leading and trailing comma and comment ranges for the match.
   fn populate_associated_elements(
-    &mut self, node: &Node, code: &String, piranha_arguments: &PiranhaArguments, delete_comments: bool,
+    &mut self, node: &Node, code: &String, piranha_arguments: &PiranhaArguments,
+    delete_comments: bool,
   ) {
     self.get_associated_elements(node, code, piranha_arguments, true, delete_comments);
     self.get_associated_elements(node, code, piranha_arguments, false, delete_comments);
@@ -181,7 +182,8 @@ impl Match {
   /// Get the associated elements for the match.
   /// We currently capture leading and trailing comments and commas.
   fn get_associated_elements(
-    &mut self, node: &Node, code: &String, piranha_arguments: &PiranhaArguments, trailing: bool, delete_comments: bool,
+    &mut self, node: &Node, code: &String, piranha_arguments: &PiranhaArguments, trailing: bool,
+    delete_comments: bool,
   ) {
     let mut current_node = *node;
     let mut buf = *piranha_arguments.cleanup_comments_buffer();
@@ -199,7 +201,9 @@ impl Match {
           self.associated_comma = Some(sibling.range().into());
           current_node = sibling;
           continue; // Continue the inner loop (i.e. evaluate next sibling)
-        } else if delete_comments && self._is_comment_safe_to_delete(&sibling, node, piranha_arguments, trailing) {
+        } else if delete_comments
+          && self._is_comment_safe_to_delete(&sibling, node, piranha_arguments, trailing)
+        {
           // Add the comment to the associated matches
           self.associated_comments.push(sibling.range().into());
           current_node = sibling;
@@ -490,7 +494,12 @@ impl SourceCodeUnit {
         p_match.range().end_byte,
       );
       if self.is_satisfied(matched_node, rule, p_match.matches(), rule_store) {
-        p_match.populate_associated_elements(&matched_node, self.code(), self.piranha_arguments(), *rule.rule().delete_comments());
+        p_match.populate_associated_elements(
+          &matched_node,
+          self.code(),
+          self.piranha_arguments(),
+          *rule.rule().delete_comments(),
+        );
         trace!("Found match {:#?}", p_match);
         output.push(p_match.clone());
       }

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -160,6 +160,7 @@ macro_rules! piranha_rule {
     $(.holes(std::collections::HashSet::from([$($hole.to_string(),)*])))?
     $(.groups(std::collections::HashSet::from([$($group_name.to_string(),)*])))?
     $(.filters(std::collections::HashSet::from([$($filter)*])))?
+    $(.delete_comments($delete_comments))?
     .build().unwrap()
   };
 }

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -25,8 +25,8 @@ use crate::utilities::Instantiate;
 use super::{
   capture_group_patterns::CGPattern,
   default_configs::{
-    default_filters, default_groups, default_holes, default_is_seed_rule, default_delete_comments, default_query,
-    default_replace, default_replace_idx, default_replace_node, default_rule_name,
+    default_delete_comments, default_filters, default_groups, default_holes, default_is_seed_rule,
+    default_query, default_replace, default_replace_idx, default_replace_node, default_rule_name,
   },
   filter::Filter,
   Validator,
@@ -96,7 +96,7 @@ pub struct Rule {
   #[pyo3(get)]
   is_seed_rule: bool,
 
-  /// Marks a rule as a seed rule
+  /// Marks comments as deletable
   #[builder(default = "default_delete_comments()")]
   #[serde(default = "default_delete_comments")]
   #[get = "pub"]
@@ -170,7 +170,7 @@ impl Rule {
   fn py_new(
     name: String, query: Option<String>, replace: Option<String>, replace_idx: Option<u8>,
     replace_node: Option<String>, holes: Option<HashSet<String>>, groups: Option<HashSet<String>>,
-    filters: Option<HashSet<Filter>>, is_seed_rule: Option<bool>,
+    filters: Option<HashSet<Filter>>, is_seed_rule: Option<bool>, delete_comments: Option<bool>,
   ) -> Self {
     let mut rule_builder = RuleBuilder::default();
 
@@ -205,6 +205,10 @@ impl Rule {
 
     if let Some(is_seed_rule) = is_seed_rule {
       rule_builder.is_seed_rule(is_seed_rule);
+    }
+
+    if let Some(delete_comments) = delete_comments {
+      rule_builder.delete_comments(delete_comments);
     }
 
     rule_builder.build().unwrap()

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -148,6 +148,7 @@ macro_rules! piranha_rule {
                 $(, is_seed_rule = $is_seed_rule:expr)?
                 $(, groups = [$($group_name: expr)*])?
                 $(, filters = [$($filter:tt)*])?
+                $(, delete_comments = $delete_comments:expr)?
               ) => {
     $crate::models::rule::RuleBuilder::default()
     .name($name.to_string())

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -25,7 +25,7 @@ use crate::utilities::Instantiate;
 use super::{
   capture_group_patterns::CGPattern,
   default_configs::{
-    default_filters, default_groups, default_holes, default_is_seed_rule, default_query,
+    default_filters, default_groups, default_holes, default_is_seed_rule, default_delete_comments, default_query,
     default_replace, default_replace_idx, default_replace_node, default_rule_name,
   },
   filter::Filter,
@@ -95,6 +95,13 @@ pub struct Rule {
   #[get = "pub"]
   #[pyo3(get)]
   is_seed_rule: bool,
+
+  /// Marks a rule as a seed rule
+  #[builder(default = "default_delete_comments()")]
+  #[serde(default = "default_delete_comments")]
+  #[get = "pub"]
+  #[pyo3(get)]
+  delete_comments: bool,
 }
 
 impl Rule {

--- a/src/models/unit_tests/rule_test.rs
+++ b/src/models/unit_tests/rule_test.rs
@@ -415,6 +415,7 @@ fn test_rule_delete_comments() {
   let args = PiranhaArgumentsBuilder::default()
     .paths_to_codebase(vec![UNUSED_CODE_PATH.to_string()])
     .language(PiranhaLanguage::from(JAVA))
+    .cleanup_comments(true)
     .build();
   let mut parser = args.language().parser();
 

--- a/src/models/unit_tests/rule_test.rs
+++ b/src/models/unit_tests/rule_test.rs
@@ -235,6 +235,7 @@ fn test_get_edit_for_context_positive() {
   let mut rule_store = RuleStore::default();
   let args = PiranhaArgumentsBuilder::default()
     .paths_to_codebase(vec![UNUSED_CODE_PATH.to_string()])
+    .language(PiranhaLanguage::from(JAVA))
     .build();
   let mut parser = args.language().parser();
 
@@ -284,6 +285,7 @@ fn test_get_edit_for_context_negative() {
 
   let args = PiranhaArgumentsBuilder::default()
     .paths_to_codebase(vec![UNUSED_CODE_PATH.to_string()])
+    .language(PiranhaLanguage::from(JAVA))
     .build();
   let mut parser = args.language().parser();
 
@@ -395,7 +397,6 @@ fn test_rule_delete_comments() {
   };
 
   let rule = InstantiatedRule::new(&_rule, &HashMap::new());
-
   let source_code = "class Test {
           public void foobar(){
             // Given

--- a/src/models/unit_tests/rule_test.rs
+++ b/src/models/unit_tests/rule_test.rs
@@ -381,3 +381,66 @@ fn test_satisfies_filter_not_enclosing_node_negative() {
     |result| result,
   );
 }
+
+/// Tests whether comments are preserved when delete_comments is set to false
+#[test]
+fn test_rule_delete_comments() {
+  println!("Starting test...");
+  let _rule = piranha_rule! {
+    name= "delete_invoc",
+    query= "((method_invocation) @m (#eq? @m \"variable.set_value(true)\"))",
+    replace_node = "m",
+    replace = "",
+    delete_comments = false
+  };
+
+  let rule = InstantiatedRule::new(&_rule, &HashMap::new());
+
+  let source_code = "class Test {
+          public void foobar(){
+            // Given
+            variable.set_value(true);
+
+            // When
+            var result = data.Something();
+
+            // Then
+            assertTrue(\"This is a test\", result);
+          }
+        }";
+
+  let mut rule_store = RuleStore::default();
+
+  let args = PiranhaArgumentsBuilder::default()
+    .paths_to_codebase(vec![UNUSED_CODE_PATH.to_string()])
+    .language(PiranhaLanguage::from(JAVA))
+    .build();
+  let mut parser = args.language().parser();
+
+  let mut source_code_unit = SourceCodeUnit::new(
+    &mut parser,
+    source_code.to_string(),
+    &HashMap::new(),
+    PathBuf::new().as_path(),
+    &args,
+  );
+  let node = source_code_unit.root_node();
+  let matches = source_code_unit.get_matches(&rule, &mut rule_store, node, true);
+  assert!(!matches.is_empty());
+
+  let edit = source_code_unit.get_edit(&rule, &mut rule_store, node, true);
+  assert!(edit.is_some());
+  let edit = edit.unwrap();
+
+  // Apply the edit to the source code unit
+  source_code_unit.apply_edit(&edit, &mut parser);
+
+  // Inspect the resulting code
+  let edited_code = source_code_unit.code();
+
+  // Now assert on the full edited code
+  assert!(edited_code.contains("// Given"));
+  assert!(edited_code.contains("// When"));
+  assert!(edited_code.contains("// Then"));
+  assert!(!edited_code.contains("variable.set_value(true);"));
+}

--- a/test-resources/java/delete_comments/expected/Test.java
+++ b/test-resources/java/delete_comments/expected/Test.java
@@ -7,4 +7,4 @@ class Test {
         // Then
         assertTrue("This is a test", result);
     }
-} 
+}

--- a/test-resources/java/delete_comments/expected/Test.java
+++ b/test-resources/java/delete_comments/expected/Test.java
@@ -1,0 +1,10 @@
+class Test {
+    public void foobar() {
+        // Given;
+        // When
+        var result = data.Something();
+
+        // Then
+        assertTrue("This is a test", result);
+    }
+} 

--- a/test-resources/java/delete_comments/input/Test.java
+++ b/test-resources/java/delete_comments/input/Test.java
@@ -1,0 +1,12 @@
+class Test {
+    public void foobar() {
+        // Given
+        variable.set_value(true);
+
+        // When
+        var result = data.Something();
+
+        // Then
+        assertTrue("This is a test", result);
+    }
+} 

--- a/test-resources/java/delete_comments/input/Test.java
+++ b/test-resources/java/delete_comments/input/Test.java
@@ -9,4 +9,4 @@ class Test {
         // Then
         assertTrue("This is a test", result);
     }
-} 
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -305,3 +305,27 @@ def _java_toplevel_mdecl_matches_anything(code_snippet: str) -> bool:
             return len(summaries) > 0
         except:
             assert False, f"Java method_declaration as top level node should not raise an error:\n{code_snippet}"
+
+def test_delete_comments_preserved():
+    delete_invocation = Rule(
+        name="delete_invocation",
+        query="""(
+            (method_invocation) @m
+            (#eq? @m "variable.set_value(true)")
+        )""",
+        replace_node="m",
+        replace="",
+        delete_comments=False
+    )
+
+    args = PiranhaArguments(
+        language="java",
+        paths_to_codebase=["test-resources/java/delete_comments/input"],
+        rule_graph=RuleGraph(rules=[delete_invocation], edges=[]),
+        dry_run=True,
+    )
+
+    output_summaries = execute_piranha(args)
+    assert len(output_summaries) == 1
+
+    assert is_as_expected("test-resources/java/delete_comments/", output_summaries)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -323,6 +323,7 @@ def test_delete_comments_preserved():
         paths_to_codebase=["test-resources/java/delete_comments/input"],
         rule_graph=RuleGraph(rules=[delete_invocation], edges=[]),
         dry_run=True,
+        cleanup_comments=True
     )
 
     output_summaries = execute_piranha(args)


### PR DESCRIPTION
Allows rules to optionally preserve comments during code transformations. Defaults to current behavior (deletion), but can be disabled per rule