### PR TITLE
API changes for deciding whether or not to keep a comment at the rule level

### DIFF
--- a/polyglot_piranha.pyi
+++ b/polyglot_piranha.pyi
@@ -227,7 +227,7 @@ class Rule:
     "Filters to test before applying a rule"
     is_seed_rule: bool
     "Marks a rule as a seed rule"
-    delete_comments: bool
+    keep_comment_regexes: list[str]
     "Make comment deleting optional"
 
     def __init__(
@@ -240,7 +240,7 @@ class Rule:
         holes: set[str] = set(),
         filters: set[Filter] = set(),
         is_seed_rule: bool = True,
-        delete_comments: bool = True,
+        keep_comment_regexes: Optional[set[str]] = None,
     ):
         """
         Constructs `Rule`

--- a/src/models/default_configs.rs
+++ b/src/models/default_configs.rs
@@ -192,8 +192,8 @@ pub(crate) fn default_is_seed_rule() -> bool {
   true
 }
 
-pub(crate) fn default_delete_comments() -> bool {
-  true
+pub(crate) fn default_keep_comment_regexes() -> HashSet<String> {
+  HashSet::new()
 }
 
 pub(crate) fn default_allow_dirty_ast() -> bool {

--- a/src/models/matches.rs
+++ b/src/models/matches.rs
@@ -20,6 +20,8 @@ use log::trace;
 use pyo3::prelude::{pyclass, pymethods};
 use serde_derive::{Deserialize, Serialize};
 use tree_sitter::Node;
+use regex::Regex;
+use std::collections::HashSet;
 
 use super::{
   piranha_arguments::PiranhaArguments, rule::InstantiatedRule, rule_store::RuleStore,
@@ -120,10 +122,10 @@ impl Match {
   // Populates the leading and trailing comma and comment ranges for the match.
   fn populate_associated_elements(
     &mut self, node: &Node, code: &String, piranha_arguments: &PiranhaArguments,
-    delete_comments: bool,
+    keep_comment_regexes: HashSet<String>,
   ) {
-    self.get_associated_elements(node, code, piranha_arguments, true, delete_comments);
-    self.get_associated_elements(node, code, piranha_arguments, false, delete_comments);
+    self.get_associated_elements(node, code, piranha_arguments, true, &keep_comment_regexes);
+    self.get_associated_elements(node, code, piranha_arguments, false, &keep_comment_regexes);
     self.get_associated_leading_empty_lines(node, code);
   }
 
@@ -183,7 +185,7 @@ impl Match {
   /// We currently capture leading and trailing comments and commas.
   fn get_associated_elements(
     &mut self, node: &Node, code: &String, piranha_arguments: &PiranhaArguments, trailing: bool,
-    delete_comments: bool,
+    keep_comment_regexes: &HashSet<String>,
   ) {
     let mut current_node = *node;
     let mut buf = *piranha_arguments.cleanup_comments_buffer();
@@ -201,13 +203,16 @@ impl Match {
           self.associated_comma = Some(sibling.range().into());
           current_node = sibling;
           continue; // Continue the inner loop (i.e. evaluate next sibling)
-        } else if delete_comments
-          && self._is_comment_safe_to_delete(&sibling, node, piranha_arguments, trailing)
-        {
-          // Add the comment to the associated matches
-          self.associated_comments.push(sibling.range().into());
-          current_node = sibling;
-          continue; // Continue the inner loop (i.e. evaluate next sibling)
+        } else if self._is_comment_safe_to_delete(&sibling, node, piranha_arguments, trailing) {
+          if !keep_comment_regexes.iter().any(|pattern| {
+            Regex::new(pattern)
+              .map(|re| re.is_match(sibling.utf8_text(code.as_bytes()).unwrap()))
+              .unwrap_or(false)
+          }) {
+            self.associated_comments.push(sibling.range().into());
+          }
+            current_node = sibling;
+            continue; // Continue the inner loop (i.e. evaluate next sibling)
         }
         break; // Break the inner loop
       }
@@ -498,7 +503,7 @@ impl SourceCodeUnit {
           &matched_node,
           self.code(),
           self.piranha_arguments(),
-          *rule.rule().delete_comments(),
+          rule.rule().keep_comment_regexes().clone(),
         );
         trace!("Found match {:#?}", p_match);
         output.push(p_match.clone());

--- a/src/models/rule.rs
+++ b/src/models/rule.rs
@@ -25,7 +25,7 @@ use crate::utilities::Instantiate;
 use super::{
   capture_group_patterns::CGPattern,
   default_configs::{
-    default_delete_comments, default_filters, default_groups, default_holes, default_is_seed_rule,
+    default_keep_comment_regexes, default_filters, default_groups, default_holes, default_is_seed_rule,
     default_query, default_replace, default_replace_idx, default_replace_node, default_rule_name,
   },
   filter::Filter,
@@ -97,11 +97,11 @@ pub struct Rule {
   is_seed_rule: bool,
 
   /// Marks comments as deletable
-  #[builder(default = "default_delete_comments()")]
-  #[serde(default = "default_delete_comments")]
+  #[builder(default = "default_keep_comment_regexes()")]
+  #[serde(default = "default_keep_comment_regexes")]
   #[get = "pub"]
   #[pyo3(get)]
-  delete_comments: bool,
+  keep_comment_regexes: HashSet<String>,
 }
 
 impl Rule {
@@ -148,7 +148,7 @@ macro_rules! piranha_rule {
                 $(, is_seed_rule = $is_seed_rule:expr)?
                 $(, groups = [$($group_name: expr)*])?
                 $(, filters = [$($filter:tt)*])?
-                $(, delete_comments = $delete_comments:expr)?
+                $(, keep_comment_regexes = [$($rgex: expr)*])?
               ) => {
     $crate::models::rule::RuleBuilder::default()
     .name($name.to_string())
@@ -160,7 +160,7 @@ macro_rules! piranha_rule {
     $(.holes(std::collections::HashSet::from([$($hole.to_string(),)*])))?
     $(.groups(std::collections::HashSet::from([$($group_name.to_string(),)*])))?
     $(.filters(std::collections::HashSet::from([$($filter)*])))?
-    $(.delete_comments($delete_comments))?
+    $(.keep_comment_regexes(std::collections::HashSet::from([$($rgex.to_string(),)*])))?
     .build().unwrap()
   };
 }
@@ -171,7 +171,7 @@ impl Rule {
   fn py_new(
     name: String, query: Option<String>, replace: Option<String>, replace_idx: Option<u8>,
     replace_node: Option<String>, holes: Option<HashSet<String>>, groups: Option<HashSet<String>>,
-    filters: Option<HashSet<Filter>>, is_seed_rule: Option<bool>, delete_comments: Option<bool>,
+    filters: Option<HashSet<Filter>>, is_seed_rule: Option<bool>, keep_comment_regexes: Option<HashSet<String>>,
   ) -> Self {
     let mut rule_builder = RuleBuilder::default();
 
@@ -208,8 +208,8 @@ impl Rule {
       rule_builder.is_seed_rule(is_seed_rule);
     }
 
-    if let Some(delete_comments) = delete_comments {
-      rule_builder.delete_comments(delete_comments);
+    if let Some(keep_comment_regexes) = keep_comment_regexes {
+      rule_builder.keep_comment_regexes(keep_comment_regexes);
     }
 
     rule_builder.build().unwrap()

--- a/test-resources/java/delete_comments/expected/Test.java
+++ b/test-resources/java/delete_comments/expected/Test.java
@@ -1,6 +1,7 @@
 class Test {
     public void foobar() {
         // Given;
+        more_variables.set_value(false);
         // When
         var result = data.Something();
 

--- a/test-resources/java/delete_comments/input/Test.java
+++ b/test-resources/java/delete_comments/input/Test.java
@@ -1,7 +1,9 @@
 class Test {
     public void foobar() {
         // Given
+        // This is an explanatory comment for variable
         variable.set_value(true);
+        more_variables.set_value(false);
 
         // When
         var result = data.Something();

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -315,7 +315,7 @@ def test_delete_comments_preserved():
         )""",
         replace_node="m",
         replace="",
-        delete_comments=False
+        keep_comment_regexes={"// Given"}
     )
 
     args = PiranhaArguments(


### PR DESCRIPTION
API changes for deciding whether or not to keep a comment at the rule level.
Now instead of booleans, we take a set of regex