### PR TITLE
[PolyglotPiranha] Prepare for release 0.3.32.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.3.32
+-------------
+
+* Changes the Kotlin grammar dependency to a custom branch due to problems with parsing expressions
+* API changes for deciding whether or not to keep a comment at the rule level
+
 Version 0.3.31
 -------------
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Uber Technologies Inc."]
 name = "piranha"
 description = "Polyglot Piranha is a library for performing structural find and replace with deep cleanup."
-version = "0.3.31"
+version = "0.3.32"
 edition = "2021"
 include = ["pyproject.toml", "src/"]
 exclude = ["legacy"]


### PR DESCRIPTION
* Changes the Kotlin grammar dependency to a custom branch due to problems with parsing expressions
* API changes for deciding whether or not to keep a comment at the rule level
