### PR TITLE
Fix kotlin grammar dependency after upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ ctrlc = "3.4"
 # TODO: Update if we upgrade tree-sitter to >=0.21
 # Kotlin's grammar needs to fix the way it parses unary expressions (currently -a + b gets parsed as - (a +b)).
 # Once we upstream the fix, we can point to the official version.
-tree-sitter-kotlin = { git = "https://github.com/danieltrt/tree-sitter-kotlin", rev = "8eb82b294900b66965ecfe39cdcbb8b16c99ff71" }
+tree-sitter-kotlin = { git = "https://github.com/danieltrt/tree-sitter-kotlin", rev = "5e0b07cb2ba628842028313b60b97699cc5e0fee" }
 tree-sitter-java = "0.20.2"
 # TODO: Update after: https://github.com/alex-pinkus/tree-sitter-swift/issues/278 resolves
 tree-sitter-swift = { git = "https://github.com/satyam1749/tree-sitter-swift.git", rev = "08a28993599f1968bc81631a89690503e1db7704" }

--- a/src/models/unit_tests/concrete_syntax_test.rs
+++ b/src/models/unit_tests/concrete_syntax_test.rs
@@ -14,7 +14,10 @@
 use crate::models::capture_group_patterns::ConcreteSyntax;
 use crate::models::concrete_syntax::get_all_matches_for_concrete_syntax;
 use crate::models::default_configs::GO;
-use crate::models::{default_configs::{JAVA, KOTLIN}, language::PiranhaLanguage};
+use crate::models::{
+  default_configs::{JAVA, KOTLIN},
+  language::PiranhaLanguage,
+};
 
 fn run_test(
   code: &str, pattern: &str, expected_matches: usize, expected_vars: Vec<Vec<(&str, &str)>>,
@@ -38,7 +41,6 @@ fn run_test(
     }
   }
 }
-
 
 #[test]
 fn test_single_match_kotlin() {

--- a/src/models/unit_tests/concrete_syntax_test.rs
+++ b/src/models/unit_tests/concrete_syntax_test.rs
@@ -14,7 +14,7 @@
 use crate::models::capture_group_patterns::ConcreteSyntax;
 use crate::models::concrete_syntax::get_all_matches_for_concrete_syntax;
 use crate::models::default_configs::GO;
-use crate::models::{default_configs::JAVA, language::PiranhaLanguage};
+use crate::models::{default_configs::{JAVA, KOTLIN}, language::PiranhaLanguage};
 
 fn run_test(
   code: &str, pattern: &str, expected_matches: usize, expected_vars: Vec<Vec<(&str, &str)>>,
@@ -37,6 +37,20 @@ fn run_test(
       assert_eq!(val, expected_val);
     }
   }
+}
+
+
+#[test]
+fn test_single_match_kotlin() {
+  run_test(
+    "class Something : BaseParameters(namespace = \"data\") {
+              val something_else: Boolean by parameter(\"something_else\")
+          }",
+    "val :[stale_property_name] : Boolean by parameter(\"something_else\")",
+    1,
+    vec![vec![("stale_property_name", "something_else")]],
+    KOTLIN,
+  );
 }
 
 #[test]


### PR DESCRIPTION
The latest update to the kotlin grammar made string literal non anonymous, which causes concrete syntax matches to fail.
This update fixes that