### PR TITLE
Use CIBuildWheel to release polyglot-piranha to avoid linking to new glibc/glibcxx

### DIFF
--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -20,7 +20,7 @@ jobs:
       CIBW_BUILD_VERBOSITY: 1
       CIBW_ARCHS: ${{ fromJSON('{"linux-x86":"x86_64","linux-arm":"aarch64","macos-arm":"universal2"}')[matrix.target] }}
       CIBW_SKIP: "pp* *-musllinux*"
-      MACOSX_DEPLOYMENT_TARGET: "10.12"
+      MACOSX_DEPLOYMENT_TARGET: "10.13"
 
     steps:
       - uses: actions/checkout@v4
@@ -46,5 +46,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.os }}
+          name: dist-${{ matrix.target }}
           path: dist/

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -16,34 +16,35 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
-      CIBW_BUILD: |
-        cp39-manylinux_x86_64
-        cp310-manylinux_x86_64
-        cp311-manylinux_x86_64
-        cp312-manylinux_x86_64
-        cp39-manylinux_aarch64
-        cp310-manylinux_aarch64
-        cp311-manylinux_aarch64
-        cp312-manylinux_aarch64
-        cp39-macosx_universal2
-        cp310-macosx_universal2
-        cp311-macosx_universal2
-        cp312-macosx_universal2
-      CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
-      CIBW_BUILD_FRONTEND: build
+      CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_ARCHS_LINUX: "x86_64 aarch64"
+      CIBW_ARCHS_MACOS: "universal2"
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
-      - name: Install cibuildwheel
+      - name: Set up QEMU for cross-compilation
+        if: runner.os == 'ubuntu-latest'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Install maturin and cibuildwheel
         run: |
-          python -m pip install --upgrade pip
-          pip install cibuildwheel
+          python -m pip install maturin cibuildwheel
+
+      - name: Build source distribution (sdist)
+        run: maturin sdist --out dist
 
       - name: Build wheels with cibuildwheel
-        run: cibuildwheel --output-dir dist
+        run: python -m cibuildwheel --output-dir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: dist/

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -2,25 +2,15 @@ name: Release Polyglot Piranha
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
   workflow_dispatch:
-    inputs:
-      repository:
-        description: 'PyPI repository (pypi or testpypi)'
-        required: false
-        default: 'pypi'
+
 jobs:
-  release:
+  build:
     strategy:
       matrix:
         target: [linux-x86, linux-arm, macos-arm]
     runs-on: ${{ fromJSON('{"linux-x86":"ubuntu-latest","linux-arm":"ubuntu-24.04-arm","macos-arm":"macos-latest"}')[matrix.target] }}
-    env:
-      CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
-      CIBW_BUILD_VERBOSITY: 1
-      CIBW_ARCHS: ${{ fromJSON('{"linux-x86":"x86_64","linux-arm":"aarch64","macos-arm":"universal2"}')[matrix.target] }}
-      CIBW_SKIP: "pp* *-musllinux*"
-      MACOSX_DEPLOYMENT_TARGET: "10.13"
 
     steps:
       - uses: actions/checkout@v4
@@ -30,21 +20,62 @@ jobs:
           python-version: '3.x'
 
       - name: Install Rust targets for macOS for cross-compilation
-        run: |
-          rustup target add x86_64-apple-darwin aarch64-apple-darwin
         if: runner.os == 'macOS'
-
-      - name: Install maturin and cibuildwheel
-        run: |
-          python -m pip install maturin cibuildwheel
-
-      - name: Build source distribution (sdist)
-        run: maturin sdist --out dist
-
-      - name: Build wheels with cibuildwheel
-        run: python -m cibuildwheel --output-dir dist
+        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin
+        
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          # For macOS, we directly build a universal binary.
+          CIBW_ARCHS: ${{ fromJSON('{"linux-x86":"x86_64","linux-arm":"aarch64","macos-arm":"universal2"}')[matrix.target] }}
+          # We do not need pypy and musllinux wheels.
+          CIBW_SKIP: "pp* *-musllinux*"
+          # This is the minimum macOS version the rust toolchain supports.
+          MACOSX_DEPLOYMENT_TARGET: "10.13"
+          # Also run python tests with the built wheels for extra validation.
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: "pytest {project}/tests"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.target }}
-          path: dist/
+          name: cibw-wheels-${{ matrix.target }}
+          path: ./wheelhouse/*.whl
+
+      - name: Build source distribution once only on linux-x86
+        if: ${{ matrix.target == "linux-x86" }} 
+        run: pipx run build --sdist --outdir ./wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ matrix.target == "linux-x86" }} 
+        with:
+          name: cibw-sdist
+          path: ./wheelhouse/*.tar.gz
+
+  upload:
+    needs: build
+    environment: pypi
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: cibw-*
+        path: dist
+        merge-multiple: true
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Pypi Release (only on tag push)
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      run: |
+        pip install twine
+        twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
+
+    - name: TestPyPI Release
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        pip install twine
+        twine upload --repository testpypi --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_TOKEN }} dist/*

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -45,7 +45,7 @@ jobs:
         rustup target add aarch64-apple-darwin
     - name: Build wheel with Maturin ${{ matrix.target }}
       run: |
-        maturin build --release -o dist --target ${{ contains(matrix.target, 'macos') && '--target universal2-apple-darwin' || '' }} -i ${{ matrix.python-version }}
+        maturin build --release -o dist ${{ contains(matrix.target, 'macos') && '--target universal2-apple-darwin' || '' }} -i ${{ matrix.python-version }}
     - name: Build source distribution (only once for linux-x86)
       if: ${{ matrix.target == 'linux-x86' }}
       run: |

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -22,9 +22,13 @@ jobs:
       - name: Install Rust targets for macOS for cross-compilation
         if: runner.os == 'macOS'
         run: rustup target add x86_64-apple-darwin aarch64-apple-darwin
-        
+
+      - name: Install maturin and cibuildwheel
+        run: |
+          python -m pip install maturin cibuildwheel
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2
+        run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -38,9 +38,6 @@ jobs:
           CIBW_SKIP: "pp* *-musllinux*"
           # This is the minimum macOS version the rust toolchain supports.
           MACOSX_DEPLOYMENT_TARGET: "10.13"
-          # Also run python tests with the built wheels for extra validation.
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: "pytest ./tests"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.x'
 
       - name: Set up QEMU for cross-compilation
-        if: runner.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -16,9 +16,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
-      CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+      CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
       CIBW_BUILD_VERBOSITY: 1
       CIBW_ARCHS_LINUX: "x86_64 aarch64"
+      CIBW_SKIP: "pp* *-musllinux*"
       CIBW_ARCHS_MACOS: "universal2"
       MACOSX_DEPLOYMENT_TARGET: "10.12"
 

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -13,40 +13,37 @@ jobs:
   release:
     strategy:
       matrix:
-        target: [linux-x86, linux-arm, macos-arm]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-    runs-on: ${{ fromJSON('{"linux-x86":"ubuntu-latest","linux-arm":"ubuntu-latest","macos-arm":"macos-latest"}')[matrix.target] }}
-    # TODO: We need to pin a debian version for linux for consistency with internal CI and Devpod versions. This avoids version mismatches of critical libs like glibc.
-    container: ${{ contains(matrix.target, 'linux') && fromJSON('{"linux-x86":"quay.io/pypa/manylinux2014_x86_64", "linux-arm":"quay.io/pypa/manylinux2014_aarch64"}')[matrix.target] || null }}
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      CIBW_BUILD: |
+        cp39-manylinux_x86_64
+        cp310-manylinux_x86_64
+        cp311-manylinux_x86_64
+        cp312-manylinux_x86_64
+        cp39-manylinux_aarch64
+        cp310-manylinux_aarch64
+        cp311-manylinux_aarch64
+        cp312-manylinux_aarch64
+        cp39-macosx_universal2
+        cp310-macosx_universal2
+        cp311-macosx_universal2
+        cp312-macosx_universal2
+      CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
+      CIBW_BUILD_FRONTEND: build
+
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: pip install --upgrade maturin
-      run: |
-        pip install --upgrade maturin
-    - name: Setup rustup target linux-arm
-      if: ${{ matrix.target == 'linux-arm' }}
-      # g++ is needed for tree-sitter YAML dependency
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-aarch64-linux-gnu
-        sudo apt-get install g++-aarch64-linux-gnu
-        rustup target add aarch64-unknown-linux-gnu
-        mkdir -p .cargo
-        touch .cargo/config.toml
-        echo "[target.aarch64-unknown-linux-gnu]" >> .cargo/config.toml
-        echo "linker = \"aarch64-linux-gnu-gcc\"" >> .cargo/config.toml
-    - name: Setup rustup target macOS-arm
-      if: ${{ matrix.target == 'macos-arm' }}
-      run: |
-        rustup target add x86_64-apple-darwin
-        rustup target add aarch64-apple-darwin
-    - name: Build wheel with Maturin ${{ matrix.target }}
-      run: |
-        maturin build --release -o dist ${{ contains(matrix.target, 'macos') && '--target universal2-apple-darwin' || '' }} -i ${{ matrix.python-version }}
-    - name: Build source distribution (only once for linux-x86)
-      if: ${{ matrix.target == 'linux-x86' }}
-      run: |
-        maturin build --sdist -o dist
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade pip
+          pip install cibuildwheel
+
+      - name: Build wheels with cibuildwheel
+        run: cibuildwheel --output-dir dist

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -13,13 +13,11 @@ jobs:
   release:
     strategy:
       matrix:
-        target: [linux-x86, linux-arm]
+        target: [linux-x86, linux-arm, macos-arm]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ fromJSON('{"linux-x86":"ubuntu-latest","linux-arm":"ubuntu-latest","macos-arm":"macos-latest"}')[matrix.target] }}
     # TODO: We need to pin a debian version for linux for consistency with internal CI and Devpod versions. This avoids version mismatches of critical libs like glibc.
-    container: ${{ 
-      contains(matrix.target, 'linux') && fromJSON('{"linux-x86":"quay.io/pypa/manylinux2014_x86_64", "linux-arm":"quay.io/pypa/manylinux2014_aarch64"}')[matrix.target] || null 
-    }}
+    container: ${{ contains(matrix.target, 'linux') && fromJSON('{"linux-x86":"quay.io/pypa/manylinux2014_x86_64", "linux-arm":"quay.io/pypa/manylinux2014_aarch64"}')[matrix.target] || null }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -17,8 +17,9 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ fromJSON('{"linux-x86":"ubuntu-latest","linux-arm":"ubuntu-latest","macos-arm":"macos-latest"}')[matrix.target] }}
     # TODO: We need to pin a debian version for linux for consistency with internal CI and Devpod versions. This avoids version mismatches of critical libs like glibc.
-    container:
-      image: debian:11
+    container: ${{ 
+      contains(matrix.target, 'linux') && fromJSON('{"linux-x86":"quay.io/pypa/manylinux2014_x86_64", "linux-arm":"quay.io/pypa/manylinux2014_aarch64"}')[matrix.target] || null 
+    }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -46,7 +47,7 @@ jobs:
         rustup target add aarch64-apple-darwin
     - name: Build wheel with Maturin ${{ matrix.target }}
       run: |
-        maturin build --release -o dist --target ${{ fromJSON('{"linux-x86":"x86_64-unknown-linux-gnu","linux-arm":"aarch64-unknown-linux-gnu","macos-arm":"universal2-apple-darwin"}')[matrix.target] }} -i ${{ matrix.python-version }}
+        maturin build --release -o dist --target ${{ contains(matrix.target, 'macos') && '--target universal2-apple-darwin' || '' }} -i ${{ matrix.python-version }}
     - name: Build source distribution (only once for linux-x86)
       if: ${{ matrix.target == 'linux-x86' }}
       run: |

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -20,6 +20,7 @@ jobs:
       CIBW_BUILD_VERBOSITY: 1
       CIBW_ARCHS_LINUX: "x86_64 aarch64"
       CIBW_ARCHS_MACOS: "universal2"
+      MACOSX_DEPLOYMENT_TARGET: "10.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     strategy:
       matrix:
-        target: [linux-x86, linux-arm, macos-arm]
+        target: [linux-x86, linux-arm]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ fromJSON('{"linux-x86":"ubuntu-latest","linux-arm":"ubuntu-latest","macos-arm":"macos-latest"}')[matrix.target] }}
     # TODO: We need to pin a debian version for linux for consistency with internal CI and Devpod versions. This avoids version mismatches of critical libs like glibc.

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           platforms: all
 
+      - name: Install Rust targets for macOS
+        run: |
+          rustup target add x86_64-apple-darwin aarch64-apple-darwin
+        if: runner.os == 'macOS'
+
       - name: Install maturin and cibuildwheel
         run: |
           python -m pip install maturin cibuildwheel

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -14,9 +14,11 @@ jobs:
     strategy:
       matrix:
         target: [linux-x86, linux-arm, macos-arm]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-    runs-on: ${{ fromJSON('{"linux-x86":"ubuntu-22.04","linux-arm":"ubuntu-latest","macos-arm":"macos-latest"}')[matrix.target] }}Add commentMore actions
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+    runs-on: ${{ fromJSON('{"linux-x86":"ubuntu-latest","linux-arm":"ubuntu-latest","macos-arm":"macos-latest"}')[matrix.target] }}
     # TODO: We need to pin a debian version for linux for consistency with internal CI and Devpod versions. This avoids version mismatches of critical libs like glibc.
+    container:
+      image: debian:11
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -49,13 +51,3 @@ jobs:
       if: ${{ matrix.target == 'linux-x86' }}
       run: |
         maturin build --sdist -o dist
-    - name: Pypi Release
-      if: ${{ github.event.inputs.repository == '' || github.event.inputs.repository == 'pypi' }}
-      run: |
-        pip install twine
-        twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
-    - name: TestPyPI Release
-      if: ${{ github.event.inputs.repository == 'testpypi' }}
-      run: |
-        pip install twine
-        twine upload --repository testpypi --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_TOKEN }} dist/*

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -44,11 +44,11 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Build source distribution once only on linux-x86
-        if: ${{ matrix.target == "linux-x86" }} 
+        if: ${{ matrix.target == 'linux-x86' }} 
         run: pipx run build --sdist --outdir ./wheelhouse
 
       - uses: actions/upload-artifact@v4
-        if: ${{ matrix.target == "linux-x86" }} 
+        if: ${{ matrix.target == 'linux-x86' }} 
         with:
           name: cibw-sdist
           path: ./wheelhouse/*.tar.gz

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -13,14 +13,13 @@ jobs:
   release:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+        target: [linux-x86, linux-arm, macos-arm]
+    runs-on: ${{ fromJSON('{"linux-x86":"ubuntu-latest","linux-arm":"ubuntu-24.04-arm","macos-arm":"macos-latest"}')[matrix.target] }}
     env:
       CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
       CIBW_BUILD_VERBOSITY: 1
-      CIBW_ARCHS_LINUX: "x86_64 aarch64"
+      CIBW_ARCHS: ${{ fromJSON('{"linux-x86":"x86_64","linux-arm":"aarch64","macos-arm":"universal2"}')[matrix.target] }}
       CIBW_SKIP: "pp* *-musllinux*"
-      CIBW_ARCHS_MACOS: "universal2"
       MACOSX_DEPLOYMENT_TARGET: "10.12"
 
     steps:
@@ -30,13 +29,7 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Set up QEMU for cross-compilation
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
-      - name: Install Rust targets for macOS
+      - name: Install Rust targets for macOS for cross-compilation
         run: |
           rustup target add x86_64-apple-darwin aarch64-apple-darwin
         if: runner.os == 'macOS'

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -40,7 +40,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
           # Also run python tests with the built wheels for extra validation.
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: "pytest {project}/tests"
+          CIBW_TEST_COMMAND: "pytest tests"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/polyglot_release.yml
+++ b/.github/workflows/polyglot_release.yml
@@ -40,7 +40,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
           # Also run python tests with the built wheels for extra validation.
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: "pytest tests"
+          CIBW_TEST_COMMAND: "pytest ./tests"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Our release workflow is heavily dependent on the OS we are running our release job in. Specifically, we need to build rust core using pyo3, which link against glibc the current OS provides.

Due to the deprecation of ubuntu 20.04 in github actions, we have recently bumped our OS version in the release job, which also bumped the glibc version we linked against in the built wheels.

This generally poses problems for older OSes (especially for the older OSes we still use internally). 

This PR uses [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/) to build instead, which uses [manylinux](https://github.com/pypa/manylinux) container under the hood for building that use a relatively old version of glibc to ensure the built wheels have best compatibility.

I tried this in my private fork and it works (only failing at the upload step due to lack of API token): https://github.com/yuxincs/piranha/actions/runs/15383618174