### PR TITLE
Include `polyglot_piranha.pyi` file in the source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "pyo3"
-include = ["LICENSE", "NOTICE"]
+include = ["LICENSE", "NOTICE", "polyglot_piranha.pyi"]


### PR DESCRIPTION
This would make source distribution fully-typed as well even when users are building from source instead of getting prebuilt wheels.