### PR TITLE
Build Tree-sitter playground on PRs as well

### DIFF
--- a/.github/workflows/deploy_tree_sitter_playground.yml
+++ b/.github/workflows/deploy_tree_sitter_playground.yml
@@ -4,50 +4,77 @@ on:
   push:
     branches: [ master ]
     paths:
-      - 'playground/tree-sitter/**'
-      - '**/Cargo.toml'
       - '.github/workflows/deploy_tree_sitter_playground.yml'
+      - 'playground/tree-sitter/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  pull_request:
+    paths:
+      - '.github/workflows/deploy_tree_sitter_playground.yml'
+      - 'playground/tree-sitter/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install tree-sitter CLI
+        # We have to lock tree-sitter CLI to 0.24 since newer CLI does not support building
+        # the old grammars we use in Piranha.
+        run: cargo install tree-sitter-cli --version "=0.24"
+
+      - name: Build playground
+        run: python build.py --dist-dir ./dist/tree-sitter-playground
+        working-directory:
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        working-directory: playground/tree-sitter
+        with:
+          name: site-build
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'  # Only deploy from master
     permissions:
       contents: read
       pages: write
       id-token: write
-
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: site-build
+          path: ./dist
 
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
 
-    - name: Setup Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
 
-    - name: Install tree-sitter CLI
-      # We have to lock tree-sitter CLI to 0.24 since newer CLI does not support building
-      # the old grammars we use in Piranha.
-      run: cargo install tree-sitter-cli --version "=0.24"
-
-    - name: Build playground
-      run: python build.py --dist-dir ./dist/tree-sitter-playground
-      working-directory: playground/tree-sitter
-
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: playground/tree-sitter/dist
-
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR changes the tree-sitter playground github actions to also build on PRs to catch breakages, but only deploy on master branch.