### PR TITLE
Parse concrete syntax with a proper grammar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,8 @@ pyo3 = "0.20.0"
 pyo3-log = "0.9.0"
 glob = "0.3.1"
 lazy_static = "1.4.0"
+pest = "2.8.1"
+pest_derive = "2.8.1"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/mod.rs
+++ b/mod.rs
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 Uber Technologies, Inc.
+ Copyright (c) 2023 Uber Technologies, Inc.
 
  <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  except in compliance with the License. You may obtain a copy of the License at
@@ -11,23 +11,8 @@ Copyright (c) 2023 Uber Technologies, Inc.
  limitations under the License.
 */
 
-pub(crate) mod capture_group_patterns;
-pub(crate) mod default_configs;
-pub mod edit;
-pub mod filter;
-pub mod language;
-pub(crate) mod matches;
-pub(crate) mod outgoing_edges;
-pub mod piranha_arguments;
-pub mod piranha_output;
-pub(crate) mod rule;
-pub(crate) mod rule_graph;
-pub(crate) mod rule_store;
-pub(crate) mod scopes;
-pub(crate) mod source_code_unit;
-
-pub(crate) mod concrete_syntax;
-
-pub(crate) trait Validator {
-  fn validate(&self) -> Result<(), String>;
-}
+//! Concrete Syntax Module
+//!
+//! This module provides concrete syntax pattern matching capabilities for Piranha.
+//! It includes a parser for concrete syntax patterns and an interpreter that can
+//! match these patterns against tree-sitter ASTs.

--- a/src/df/utils.rs
+++ b/src/df/utils.rs
@@ -34,6 +34,7 @@ pub fn get_capture_groups_from_matcher(node: &Rule) -> Vec<String> {
   match &node.query().pattern_type() {
     PatternType::Tsq => get_capture_groups_from_tsq(node.query().pattern()),
     PatternType::Regex => get_capture_groups_from_regex(node.query().extract_regex().unwrap()),
+    PatternType::Cs => vec![],
     PatternType::Unknown => vec![],
   }
 }
@@ -47,6 +48,7 @@ pub fn get_capture_group_usage_from_matcher(node: &Rule) -> Vec<String> {
   match &node.query().pattern_type() {
     PatternType::Tsq => get_capture_group_usage_from_tsq(node.query().pattern()),
     PatternType::Regex => get_capture_group_usage_from_regex(node.query().pattern()),
+    PatternType::Cs => vec![],
     PatternType::Unknown => vec![],
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ use models::{
 extern crate lazy_static;
 pub mod df;
 pub mod models;
-
 #[cfg(test)]
 mod tests;
 pub mod utilities;

--- a/src/models/capture_group_patterns.rs
+++ b/src/models/capture_group_patterns.rs
@@ -11,7 +11,7 @@ Copyright (c) 2023 Uber Technologies, Inc.
  limitations under the License.
 */
 
-use crate::models::concrete_syntax::get_all_matches_for_concrete_syntax;
+use crate::models::concrete_syntax::interpreter::get_all_matches_for_concrete_syntax;
 use crate::{
   models::Validator,
   utilities::{
@@ -25,9 +25,8 @@ use regex::Regex;
 use serde_derive::Deserialize;
 use std::collections::HashMap;
 use tree_sitter::{Node, Query};
+use crate::models::concrete_syntax::parser::ConcreteSyntax;
 
-#[derive(Debug)]
-pub struct ConcreteSyntax(pub String);
 use super::{
   default_configs::{CONCRETE_SYNTAX_QUERY_PREFIX, REGEX_QUERY_PREFIX},
   matches::Match,
@@ -36,6 +35,7 @@ use super::{
 pub enum PatternType {
   Tsq,
   Regex,
+  Cs,
   Unknown,
 }
 
@@ -59,13 +59,14 @@ impl CGPattern {
 
   pub(crate) fn extract_concrete_syntax(&self) -> ConcreteSyntax {
     let mut _val = &self.pattern()[CONCRETE_SYNTAX_QUERY_PREFIX.len()..];
-    ConcreteSyntax(_val.to_string())
+    ConcreteSyntax::parse(&_val.to_string()).unwrap()
   }
 
   pub(crate) fn pattern_type(&self) -> PatternType {
     match self.0.as_str() {
       pattern if pattern.starts_with("rgx") => PatternType::Regex,
       pattern if pattern.trim().starts_with('(') => PatternType::Tsq,
+      pattern if pattern.trim().starts_with("cs") => PatternType::Cs,
       _ => PatternType::Unknown,
     }
   }

--- a/src/models/capture_group_patterns.rs
+++ b/src/models/capture_group_patterns.rs
@@ -12,6 +12,7 @@ Copyright (c) 2023 Uber Technologies, Inc.
 */
 
 use crate::models::concrete_syntax::interpreter::get_all_matches_for_concrete_syntax;
+use crate::models::concrete_syntax::parser::ConcreteSyntax;
 use crate::{
   models::Validator,
   utilities::{
@@ -25,7 +26,6 @@ use regex::Regex;
 use serde_derive::Deserialize;
 use std::collections::HashMap;
 use tree_sitter::{Node, Query};
-use crate::models::concrete_syntax::parser::ConcreteSyntax;
 
 use super::{
   default_configs::{CONCRETE_SYNTAX_QUERY_PREFIX, REGEX_QUERY_PREFIX},
@@ -59,7 +59,7 @@ impl CGPattern {
 
   pub(crate) fn extract_concrete_syntax(&self) -> ConcreteSyntax {
     let mut _val = &self.pattern()[CONCRETE_SYNTAX_QUERY_PREFIX.len()..];
-    ConcreteSyntax::parse(&_val.to_string()).unwrap()
+    ConcreteSyntax::parse(_val).unwrap()
   }
 
   pub(crate) fn pattern_type(&self) -> PatternType {

--- a/src/models/concrete_syntax/concrete_syntax.pest
+++ b/src/models/concrete_syntax/concrete_syntax.pest
@@ -1,0 +1,17 @@
+// Concrete Syntax Grammar for Piranha
+WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
+
+// Main entry point
+concrete_syntax = { SOI ~ pattern ~ EOI }
+pattern = { element+ }
+
+// An element is either a capture or literal text
+element = _{ capture | literal_text }
+
+// Captures: :[name], :[name+], :[name*]
+capture = { ":[" ~ identifier ~ capture_mode? ~ "]" }
+capture_mode = { "+" | "*" }
+identifier = { (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+
+// Literal text - anything that's not a capture or alternation  
+literal_text = { (!(":[") ~ ANY)+ }

--- a/src/models/concrete_syntax/concrete_syntax.pest
+++ b/src/models/concrete_syntax/concrete_syntax.pest
@@ -1,17 +1,15 @@
 // Concrete Syntax Grammar for Piranha
-WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
-
-// Main entry point
 concrete_syntax = { SOI ~ pattern ~ EOI }
-pattern = { element+ }
+pattern = { (element)+ }
 
 // An element is either a capture or literal text
-element = _{ capture | literal_text }
+element = _{ capture | literal_text | whitespace }
 
-// Captures: :[name], :[name+], :[name*]
-capture = { ":[" ~ identifier ~ capture_mode? ~ "]" }
+// Captures: :[name], :[name+], :[name*], @name
+capture = { (":[" ~ identifier ~ capture_mode? ~ "]") | "@"~identifier } // FIXME: Should remove @ from the grammar, because literals may be parsed incorrectly
 capture_mode = { "+" | "*" }
 identifier = { (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
-// Literal text - anything that's not a capture or alternation  
-literal_text = { (!(":[") ~ ANY)+ }
+// Literal text - single word/token without whitespace
+literal_text = { (!( ":[" | whitespace ) ~ ANY)+ }
+whitespace = _{ (" " | "\t" | "\r" | "\n")+ }

--- a/src/models/concrete_syntax/interpreter.rs
+++ b/src/models/concrete_syntax/interpreter.rs
@@ -236,13 +236,7 @@ pub(crate) fn get_matches_for_subsequence_of_nodes(
       } else {
         // If the current node is an intermediate node
         cursor.goto_first_child();
-        get_matches_for_subsequence_of_nodes(
-          cursor,
-          source_code,
-          cs_elements,
-          true,
-          top_node,
-        )
+        get_matches_for_subsequence_of_nodes(cursor, source_code, cs_elements, true, top_node)
       }
     }
   }
@@ -357,7 +351,7 @@ fn handle_leaf_node_elements(
       );
     } else {
       // If we only consumed part of the literal, create a new literal with the remaining text
-      let remaining_literal = &literal_text[advance_by..].trim_start();
+      let remaining_literal = &literal_text[advance_by..];
       let mut new_elements = vec![CsElement::Literal(remaining_literal.to_string())];
       new_elements.extend_from_slice(remaining_elements);
 

--- a/src/models/concrete_syntax/mod.rs
+++ b/src/models/concrete_syntax/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod parser;
+pub(crate) mod interpreter;

--- a/src/models/concrete_syntax/mod.rs
+++ b/src/models/concrete_syntax/mod.rs
@@ -1,2 +1,15 @@
-pub(crate) mod parser;
+/*
+  Copyright (c) 2023 Uber Technologies, Inc.
+ 
+  <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+  except in compliance with the License. You may obtain a copy of the License at
+  <p>http://www.apache.org/licenses/LICENSE-2.0
+ 
+  <p>Unless required by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
 pub(crate) mod interpreter;
+pub(crate) mod parser;

--- a/src/models/concrete_syntax/mod.rs
+++ b/src/models/concrete_syntax/mod.rs
@@ -1,15 +1,15 @@
 /*
-  Copyright (c) 2023 Uber Technologies, Inc.
- 
-  <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
-  except in compliance with the License. You may obtain a copy of the License at
-  <p>http://www.apache.org/licenses/LICENSE-2.0
- 
-  <p>Unless required by applicable law or agreed to in writing, software distributed under the
-  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  express or implied. See the License for the specific language governing permissions and
-  limitations under the License.
- */
+ Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 pub(crate) mod interpreter;
 pub(crate) mod parser;

--- a/src/models/concrete_syntax/parser.rs
+++ b/src/models/concrete_syntax/parser.rs
@@ -1,0 +1,105 @@
+use pest::Parser;
+use pest_derive::Parser;
+use pest::iterators::Pair;
+
+#[derive(Parser)]
+#[grammar = "models/concrete_syntax/concrete_syntax.pest"]
+pub struct ConcreteSyntaxParser;
+
+/// AST nodes for the concrete syntax language
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConcreteSyntax {
+    pub pattern: CsPattern
+}
+#[derive(Debug, Clone, PartialEq)]
+pub struct CsPattern { 
+    pub sequence: Vec<CsElement>
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CsElement {
+    Capture { name: String, mode: CaptureMode },
+    Literal(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CaptureMode {
+    Single,   // :[var]
+    OnePlus,  // :[var+]
+    ZeroPlus, // :[var*]
+}
+
+
+
+
+
+
+impl ConcreteSyntax {
+    pub fn parse(input: &str) -> Result<Self, String> {
+        use Rule::*;
+
+        let mut pairs = ConcreteSyntaxParser::parse(concrete_syntax, input)
+            .map_err(|e| format!("Parse error: {}", e))?;
+
+        let main_pair = pairs.next().unwrap();
+
+        let mut parsed_pattern = None;
+
+        for pair in main_pair.into_inner() {
+            match pair.as_rule() {
+                pattern => {
+                    parsed_pattern = Some(Self::parse_pattern(pair)?);
+                }
+                EOI => {} // End of input, ignore
+                _ => {}
+            }
+        }
+
+        Ok(ConcreteSyntax {
+            pattern: parsed_pattern.ok_or("No pattern found")?,
+        })
+    }
+
+    fn parse_pattern(pair: Pair<Rule>) -> Result<CsPattern, String> {
+        let elements: Result<Vec<_>, _> = pair.into_inner().map(Self::parse_element).collect();
+        Ok(CsPattern {
+            sequence: elements?,
+        })}
+
+    fn parse_element(pair: Pair<Rule>) -> Result<CsElement, String> {
+        use Rule::*;
+
+        match pair.as_rule() {
+            capture => Self::parse_capture(pair),
+            literal_text => Ok(CsElement::Literal(pair.as_str().trim().to_string())),
+            _ => Err(format!("Unexpected element: {:?}", pair.as_rule())),
+        }
+    }
+
+    fn parse_capture(pair: Pair<Rule>) -> Result<CsElement, String> {
+        let mut inner = pair.into_inner();
+        let identifier = inner.next().unwrap().as_str().to_string();
+
+        let mode = if let Some(mode_pair) = inner.next() {
+            match mode_pair.as_str() {
+                "+" => CaptureMode::OnePlus,
+                "*" => CaptureMode::ZeroPlus,
+                _ => return Err(format!("Unknown capture mode: {}", mode_pair.as_str())),
+            }
+        } else {
+            CaptureMode::Single
+        };
+
+        Ok(CsElement::Capture {
+            name: identifier,
+            mode,
+        })
+    }
+}
+
+
+#[cfg(test)]
+#[path = "unit_tests/test_parser.rs"]
+mod test_parser;
+

--- a/src/models/concrete_syntax/parser.rs
+++ b/src/models/concrete_syntax/parser.rs
@@ -1,15 +1,15 @@
 /*
-  Copyright (c) 2023 Uber Technologies, Inc.
- 
-  <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
-  except in compliance with the License. You may obtain a copy of the License at
-  <p>http://www.apache.org/licenses/LICENSE-2.0
- 
-  <p>Unless required by applicable law or agreed to in writing, software distributed under the
-  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  express or implied. See the License for the specific language governing permissions and
-  limitations under the License.
- */
+ Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 use pest::iterators::Pair;
 use pest::Parser;

--- a/src/models/concrete_syntax/parser.rs
+++ b/src/models/concrete_syntax/parser.rs
@@ -1,6 +1,19 @@
+/*
+  Copyright (c) 2023 Uber Technologies, Inc.
+ 
+  <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+  except in compliance with the License. You may obtain a copy of the License at
+  <p>http://www.apache.org/licenses/LICENSE-2.0
+ 
+  <p>Unless required by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+use pest::iterators::Pair;
 use pest::Parser;
 use pest_derive::Parser;
-use pest::iterators::Pair;
 
 #[derive(Parser)]
 #[grammar = "models/concrete_syntax/concrete_syntax.pest"]
@@ -10,96 +23,90 @@ pub struct ConcreteSyntaxParser;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConcreteSyntax {
-    pub pattern: CsPattern
+  pub pattern: CsPattern,
 }
 #[derive(Debug, Clone, PartialEq)]
-pub struct CsPattern { 
-    pub sequence: Vec<CsElement>
+pub struct CsPattern {
+  pub sequence: Vec<CsElement>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CsElement {
-    Capture { name: String, mode: CaptureMode },
-    Literal(String),
+  Capture { name: String, mode: CaptureMode },
+  Literal(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CaptureMode {
-    Single,   // :[var]
-    OnePlus,  // :[var+]
-    ZeroPlus, // :[var*]
+  Single,   // :[var]
+  OnePlus,  // :[var+]
+  ZeroPlus, // :[var*]
 }
-
-
-
-
-
 
 impl ConcreteSyntax {
-    pub fn parse(input: &str) -> Result<Self, String> {
-        use Rule::*;
+  pub fn parse(input: &str) -> Result<Self, String> {
+    use Rule::*;
 
-        let mut pairs = ConcreteSyntaxParser::parse(concrete_syntax, input)
-            .map_err(|e| format!("Parse error: {}", e))?;
+    let mut pairs = ConcreteSyntaxParser::parse(concrete_syntax, input)
+      .map_err(|e| format!("Parse error: {}", e))?;
 
-        let main_pair = pairs.next().unwrap();
+    let main_pair = pairs.next().unwrap();
 
-        let mut parsed_pattern = None;
+    let mut parsed_pattern = None;
 
-        for pair in main_pair.into_inner() {
-            match pair.as_rule() {
-                pattern => {
-                    parsed_pattern = Some(Self::parse_pattern(pair)?);
-                }
-                EOI => {} // End of input, ignore
-                _ => {}
-            }
+    for pair in main_pair.into_inner() {
+      match pair.as_rule() {
+        pattern => {
+          parsed_pattern = Some(Self::parse_pattern(pair)?);
         }
-
-        Ok(ConcreteSyntax {
-            pattern: parsed_pattern.ok_or("No pattern found")?,
-        })
+        EOI => {} // End of input, ignore
+        _ => {}
+      }
     }
 
-    fn parse_pattern(pair: Pair<Rule>) -> Result<CsPattern, String> {
-        let elements: Result<Vec<_>, _> = pair.into_inner().map(Self::parse_element).collect();
-        Ok(CsPattern {
-            sequence: elements?,
-        })}
+    Ok(ConcreteSyntax {
+      pattern: parsed_pattern.ok_or("No pattern found")?,
+    })
+  }
 
-    fn parse_element(pair: Pair<Rule>) -> Result<CsElement, String> {
-        use Rule::*;
+  fn parse_pattern(pair: Pair<Rule>) -> Result<CsPattern, String> {
+    let elements: Result<Vec<_>, _> = pair.into_inner().map(Self::parse_element).collect();
+    Ok(CsPattern {
+      sequence: elements?,
+    })
+  }
 
-        match pair.as_rule() {
-            capture => Self::parse_capture(pair),
-            literal_text => Ok(CsElement::Literal(pair.as_str().trim().to_string())),
-            _ => Err(format!("Unexpected element: {:?}", pair.as_rule())),
-        }
+  fn parse_element(pair: Pair<Rule>) -> Result<CsElement, String> {
+    use Rule::*;
+
+    match pair.as_rule() {
+      capture => Self::parse_capture(pair),
+      literal_text => Ok(CsElement::Literal(pair.as_str().trim().to_string())),
+      _ => Err(format!("Unexpected element: {:?}", pair.as_rule())),
     }
+  }
 
-    fn parse_capture(pair: Pair<Rule>) -> Result<CsElement, String> {
-        let mut inner = pair.into_inner();
-        let identifier = inner.next().unwrap().as_str().to_string();
+  fn parse_capture(pair: Pair<Rule>) -> Result<CsElement, String> {
+    let mut inner = pair.into_inner();
+    let identifier = inner.next().unwrap().as_str().to_string();
 
-        let mode = if let Some(mode_pair) = inner.next() {
-            match mode_pair.as_str() {
-                "+" => CaptureMode::OnePlus,
-                "*" => CaptureMode::ZeroPlus,
-                _ => return Err(format!("Unknown capture mode: {}", mode_pair.as_str())),
-            }
-        } else {
-            CaptureMode::Single
-        };
+    let mode = if let Some(mode_pair) = inner.next() {
+      match mode_pair.as_str() {
+        "+" => CaptureMode::OnePlus,
+        "*" => CaptureMode::ZeroPlus,
+        _ => return Err(format!("Unknown capture mode: {}", mode_pair.as_str())),
+      }
+    } else {
+      CaptureMode::Single
+    };
 
-        Ok(CsElement::Capture {
-            name: identifier,
-            mode,
-        })
-    }
+    Ok(CsElement::Capture {
+      name: identifier,
+      mode,
+    })
+  }
 }
-
 
 #[cfg(test)]
 #[path = "unit_tests/test_parser.rs"]
 mod test_parser;
-

--- a/src/models/concrete_syntax/unit_tests/interpreter_test.rs
+++ b/src/models/concrete_syntax/unit_tests/interpreter_test.rs
@@ -12,7 +12,7 @@
 */
 
 use crate::models::capture_group_patterns::ConcreteSyntax;
-use crate::models::concrete_syntax::get_all_matches_for_concrete_syntax;
+use crate::models::concrete_syntax::interpreter::get_all_matches_for_concrete_syntax;
 use crate::models::default_configs::GO;
 use crate::models::{
   default_configs::{JAVA, KOTLIN},

--- a/src/models/concrete_syntax/unit_tests/interpreter_test.rs
+++ b/src/models/concrete_syntax/unit_tests/interpreter_test.rs
@@ -11,8 +11,8 @@
  limitations under the License.
 */
 
-use crate::models::capture_group_patterns::ConcreteSyntax;
 use crate::models::concrete_syntax::interpreter::get_all_matches_for_concrete_syntax;
+use crate::models::concrete_syntax::parser::ConcreteSyntax;
 use crate::models::default_configs::GO;
 use crate::models::{
   default_configs::{JAVA, KOTLIN},
@@ -26,7 +26,7 @@ fn run_test(
   let java = PiranhaLanguage::from(language);
   let mut parser = java.parser();
   let tree = parser.parse(code.as_bytes(), None).unwrap();
-  let meta = ConcreteSyntax(String::from(pattern));
+  let meta = ConcreteSyntax::parse(pattern).unwrap();
 
   let (matches, _is_match_found) =
     get_all_matches_for_concrete_syntax(&tree.root_node(), code.as_bytes(), &meta, true, None);

--- a/src/models/concrete_syntax/unit_tests/test_parser.rs
+++ b/src/models/concrete_syntax/unit_tests/test_parser.rs
@@ -1,263 +1,259 @@
+/*
+  Copyright (c) 2023 Uber Technologies, Inc.
+ 
+  <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+  except in compliance with the License. You may obtain a copy of the License at
+  <p>http://www.apache.org/licenses/LICENSE-2.0
+ 
+  <p>Unless required by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 
 use crate::models::concrete_syntax::parser::*;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+  use super::*;
 
-    #[test]
-    fn test_parse_simple_capture() {
-        let input = ":[var]";
-        let result = ConcreteSyntax::parse(input).unwrap();
+  #[test]
+  fn test_parse_simple_capture() {
+    let input = ":[var]";
+    let result = ConcreteSyntax::parse(input).unwrap();
+    let elements = result.pattern.sequence;
 
-        match result.pattern {
-            CsPattern::Sequence(elements) => {
-                assert_eq!(elements.len(), 1);
-                match &elements[0] {
-                    CsElement::Capture { name, mode } => {
-                        assert_eq!(name, "var");
-                        assert_eq!(*mode, CaptureMode::Single);
-                    }
-                    _ => panic!("Expected capture, got: {:?}", elements[0]),
-                }
-            }
+    assert_eq!(elements.len(), 1);
+    match &elements[0] {
+      CsElement::Capture { name, mode } => {
+        assert_eq!(name, "var");
+        assert_eq!(*mode, CaptureMode::Single);
+      }
+      _ => panic!("Expected capture, got: {:?}", elements[0]),
+    }
+  }
+
+  #[test]
+  fn test_parse_literal() {
+    let input = "function";
+    let result = ConcreteSyntax::parse(input).unwrap();
+    let elements = result.pattern.sequence;
+
+    assert_eq!(elements.len(), 1);
+    match &elements[0] {
+      CsElement::Literal(text) => {
+        assert_eq!(text, "function");
+      }
+      _ => panic!("Expected literal, got: {:?}", elements[0]),
+    }
+  }
+
+  #[test]
+  fn test_parse_capture_with_literal() {
+    let input = "function :[name]() {";
+    let result = ConcreteSyntax::parse(input).unwrap();
+    let elements = result.pattern.sequence;
+
+    assert_eq!(elements.len(), 3);
+
+    // Should be: literal "function ", capture "name", literal "() {"
+    match &elements[0] {
+      CsElement::Literal(text) => assert_eq!(text, "function"),
+      _ => panic!("Expected literal, got: {:?}", elements[0]),
+    }
+
+    match &elements[1] {
+      CsElement::Capture { name, mode } => {
+        assert_eq!(name, "name");
+        assert_eq!(*mode, CaptureMode::Single);
+      }
+      _ => panic!("Expected capture, got: {:?}", elements[1]),
+    }
+
+    match &elements[2] {
+      CsElement::Literal(text) => assert_eq!(text, "() {"),
+      _ => panic!("Expected literal, got: {:?}", elements[2]),
+    }
+  }
+
+  #[test]
+  fn test_parse_capture_modes() {
+    let input = ":[single] :[many+] :[optional*]";
+    let result = ConcreteSyntax::parse(input).unwrap();
+    let elements = result.pattern.sequence;
+
+    // Check the captures specifically - the actual number may vary
+    let captures: Vec<&CsElement> = elements
+      .iter()
+      .filter(|e| matches!(e, CsElement::Capture { .. }))
+      .collect();
+
+    assert_eq!(captures.len(), 3);
+
+    match captures[0] {
+      CsElement::Capture { name, mode } => {
+        assert_eq!(name, "single");
+        assert_eq!(*mode, CaptureMode::Single);
+      }
+      _ => panic!("Expected capture"),
+    }
+
+    match captures[1] {
+      CsElement::Capture { name, mode } => {
+        assert_eq!(name, "many");
+        assert_eq!(*mode, CaptureMode::OnePlus);
+      }
+      _ => panic!("Expected capture"),
+    }
+
+    match captures[2] {
+      CsElement::Capture { name, mode } => {
+        assert_eq!(name, "optional");
+        assert_eq!(*mode, CaptureMode::ZeroPlus);
+      }
+      _ => panic!("Expected capture"),
+    }
+  }
+
+  #[test]
+  fn test_parse_complex_pattern() {
+    let input = "if (:[condition+]) { :[body*] }";
+    let result = ConcreteSyntax::parse(input).unwrap();
+    let elements = result.pattern.sequence;
+
+    // Find the captures
+    let captures: Vec<&CsElement> = elements
+      .iter()
+      .filter(|e| matches!(e, CsElement::Capture { .. }))
+      .collect();
+
+    assert_eq!(captures.len(), 2);
+
+    // Check condition capture
+    match captures[0] {
+      CsElement::Capture { name, mode } => {
+        assert_eq!(name, "condition");
+        assert_eq!(*mode, CaptureMode::OnePlus);
+      }
+      _ => panic!("Expected condition capture"),
+    }
+
+    // Check body capture
+    match captures[1] {
+      CsElement::Capture { name, mode } => {
+        assert_eq!(name, "body");
+        assert_eq!(*mode, CaptureMode::ZeroPlus);
+      }
+      _ => panic!("Expected body capture"),
+    }
+  }
+
+  #[test]
+  fn test_parse_identifier_variations() {
+    // Test different valid identifier patterns
+    // Note: identifiers can start with ASCII_ALPHA or "_" per grammar
+    let test_cases = vec![
+      (":[a]", "a"),
+      (":[variable_name]", "variable_name"),
+      (":[var123]", "var123"),
+      (":[CamelCase]", "CamelCase"),
+      (":[_underscore]", "_underscore"),
+      (":[name_with_underscore]", "name_with_underscore"),
+    ];
+
+    for (input, expected_name) in test_cases {
+      let result = ConcreteSyntax::parse(input).unwrap();
+      let elements = result.pattern.sequence;
+
+      assert_eq!(elements.len(), 1);
+      match &elements[0] {
+        CsElement::Capture { name, mode } => {
+          assert_eq!(name, expected_name);
+          assert_eq!(*mode, CaptureMode::Single);
         }
+        _ => panic!("Expected capture for input: {}", input),
+      }
     }
+  }
 
-    #[test]
-    fn test_parse_literal() {
-        let input = "function";
-        let result = ConcreteSyntax::parse(input).unwrap();
+  #[test]
+  fn test_parse_whitespace_handling() {
+    let input = "  function   :[name]   ()  ";
+    let result = ConcreteSyntax::parse(input).unwrap();
+    let elements = result.pattern.sequence;
 
-        match result.pattern {
-            CsPattern::Sequence(elements) => {
-                assert_eq!(elements.len(), 1);
-                match &elements[0] {
-                    CsElement::Literal(text) => {
-                        assert_eq!(text, "function");
-                    }
-                    _ => panic!("Expected literal, got: {:?}", elements[0]),
-                }
-            }
-        }
+    // Whitespace should be preserved in literals but trimmed in the parsing
+    assert!(elements.len() >= 3);
+
+    // Find the capture
+    let capture = elements
+      .iter()
+      .find(|e| matches!(e, CsElement::Capture { .. }))
+      .expect("Should have a capture");
+
+    match capture {
+      CsElement::Capture { name, mode } => {
+        assert_eq!(name, "name");
+        assert_eq!(*mode, CaptureMode::Single);
+      }
+      _ => panic!("Expected capture"),
     }
+  }
 
-    #[test]
-    fn test_parse_capture_with_literal() {
-        let input = "function :[name]() {";
-        let result = ConcreteSyntax::parse(input).unwrap();
+  #[test]
+  fn test_parse_error_cases() {
+    let error_cases = vec![
+      ":[",          // Incomplete capture
+      ":[123]",      // Invalid identifier (starts with number)
+      ":[var++]",    // Invalid capture mode
+      ":[]",         // Empty identifier
+      ":[123var]",   // Invalid identifier (starts with number)
+      ":[var-name]", // Invalid identifier (contains hyphen)
+    ];
 
-        match result.pattern {
-            CsPattern::Sequence(elements) => {
-                assert_eq!(elements.len(), 3);
-
-                // Should be: literal "function ", capture "name", literal "() {"
-                match &elements[0] {
-                    CsElement::Literal(text) => assert_eq!(text, "function"),
-                    _ => panic!("Expected literal, got: {:?}", elements[0]),
-                }
-
-                match &elements[1] {
-                    CsElement::Capture { name, mode } => {
-                        assert_eq!(name, "name");
-                        assert_eq!(*mode, CaptureMode::Single);
-                    }
-                    _ => panic!("Expected capture, got: {:?}", elements[1]),
-                }
-
-                match &elements[2] {
-                    CsElement::Literal(text) => assert_eq!(text, "() {"),
-                    _ => panic!("Expected literal, got: {:?}", elements[2]),
-                }
-            }
-        }
+    for input in error_cases {
+      let result = ConcreteSyntax::parse(input);
+      assert!(result.is_err(), "Expected error for input: {}", input);
     }
+  }
 
-    #[test]
-    fn test_parse_capture_modes() {
-        let input = ":[single] :[many+] :[optional*]";
-        let result = ConcreteSyntax::parse(input).unwrap();
+  #[test]
+  fn test_parse_empty_input() {
+    let result = ConcreteSyntax::parse("");
+    assert!(result.is_err(), "Empty input should produce an error");
+  }
 
-        match result.pattern {
-            CsPattern::Sequence(elements) => {
-                // Check the captures specifically - the actual number may vary
-                let captures: Vec<&CsElement> = elements.iter()
-                    .filter(|e| matches!(e, CsElement::Capture { .. }))
-                    .collect();
+  #[test]
+  fn test_parse_only_whitespace() {
+    let result = ConcreteSyntax::parse("   ");
+    // This might pass depending on grammar - whitespace handling
+    // If it passes, it should create an empty sequence or fail gracefully
+    match result {
+      Ok(cs) => {
+        let elements = cs.pattern.sequence;
 
-                assert_eq!(captures.len(), 3);
-
-                match captures[0] {
-                    CsElement::Capture { name, mode } => {
-                        assert_eq!(name, "single");
-                        assert_eq!(*mode, CaptureMode::Single);
-                    }
-                    _ => panic!("Expected capture"),
-                }
-
-                match captures[1] {
-                    CsElement::Capture { name, mode } => {
-                        assert_eq!(name, "many");
-                        assert_eq!(*mode, CaptureMode::OnePlus);
-                    }
-                    _ => panic!("Expected capture"),
-                }
-
-                match captures[2] {
-                    CsElement::Capture { name, mode } => {
-                        assert_eq!(name, "optional");
-                        assert_eq!(*mode, CaptureMode::ZeroPlus);
-                    }
-                    _ => panic!("Expected capture"),
-                }
-            }
-        }
+        // Should be empty or contain only whitespace literals
+        assert!(
+          elements.is_empty()
+            || elements
+              .iter()
+              .all(|e| matches!(e, CsElement::Literal(s) if s.trim().is_empty()))
+        );
+      }
+      Err(_) => {
+        // Also acceptable - depends on grammar requirements
+      }
     }
+  }
 
-    #[test]
-    fn test_parse_complex_pattern() {
-        let input = "if (:[condition+]) { :[body*] }";
-        let result = ConcreteSyntax::parse(input).unwrap();
+  #[test]
+  fn test_debug_output() {
+    let input = ":[var+]";
+    let result = ConcreteSyntax::parse(input).unwrap();
 
-        match result.pattern {
-            CsPattern::Sequence(elements) => {
-                // Find the captures
-                let captures: Vec<&CsElement> = elements.iter()
-                    .filter(|e| matches!(e, CsElement::Capture { .. }))
-                    .collect();
-
-                assert_eq!(captures.len(), 2);
-
-                // Check condition capture
-                match captures[0] {
-                    CsElement::Capture { name, mode } => {
-                        assert_eq!(name, "condition");
-                        assert_eq!(*mode, CaptureMode::OnePlus);
-                    }
-                    _ => panic!("Expected condition capture"),
-                }
-
-                // Check body capture
-                match captures[1] {
-                    CsElement::Capture { name, mode } => {
-                        assert_eq!(name, "body");
-                        assert_eq!(*mode, CaptureMode::ZeroPlus);
-                    }
-                    _ => panic!("Expected body capture"),
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn test_parse_identifier_variations() {
-        // Test different valid identifier patterns
-        // Note: identifiers can start with ASCII_ALPHA or "_" per grammar
-        let test_cases = vec![
-            (":[a]", "a"),
-            (":[variable_name]", "variable_name"),
-            (":[var123]", "var123"),
-            (":[CamelCase]", "CamelCase"),
-            (":[_underscore]", "_underscore"),
-            (":[name_with_underscore]", "name_with_underscore"),
-        ];
-
-        for (input, expected_name) in test_cases {
-            let result = ConcreteSyntax::parse(input).unwrap();
-            match result.pattern {
-                CsPattern::Sequence(elements) => {
-                    assert_eq!(elements.len(), 1);
-                    match &elements[0] {
-                        CsElement::Capture { name, mode } => {
-                            assert_eq!(name, expected_name);
-                            assert_eq!(*mode, CaptureMode::Single);
-                        }
-                        _ => panic!("Expected capture for input: {}", input),
-                    }
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn test_parse_whitespace_handling() {
-        let input = "  function   :[name]   ()  ";
-        let result = ConcreteSyntax::parse(input).unwrap();
-
-        match result.pattern {
-            CsPattern::Sequence(elements) => {
-                // Whitespace should be preserved in literals but trimmed in the parsing
-                assert!(elements.len() >= 3);
-
-                // Find the capture
-                let capture = elements.iter()
-                    .find(|e| matches!(e, CsElement::Capture { .. }))
-                    .expect("Should have a capture");
-
-                match capture {
-                    CsElement::Capture { name, mode } => {
-                        assert_eq!(name, "name");
-                        assert_eq!(*mode, CaptureMode::Single);
-                    }
-                    _ => panic!("Expected capture"),
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn test_parse_error_cases() {
-        let error_cases = vec![
-            ":[", // Incomplete capture
-            ":[123]", // Invalid identifier (starts with number)
-            ":[var++]", // Invalid capture mode
-            ":[]", // Empty identifier
-            ":[123var]", // Invalid identifier (starts with number)
-            ":[var-name]", // Invalid identifier (contains hyphen)
-        ];
-
-        for input in error_cases {
-            let result = ConcreteSyntax::parse(input);
-            assert!(result.is_err(), "Expected error for input: {}", input);
-        }
-    }
-
-    #[test]
-    fn test_parse_empty_input() {
-        let result = ConcreteSyntax::parse("");
-        assert!(result.is_err(), "Empty input should produce an error");
-    }
-
-    #[test]
-    fn test_parse_only_whitespace() {
-        let result = ConcreteSyntax::parse("   ");
-        // This might pass depending on grammar - whitespace handling
-        // If it passes, it should create an empty sequence or fail gracefully
-        match result {
-            Ok(cs) => {
-                match cs.pattern {
-                    CsPattern::Sequence(elements) => {
-                        // Should be empty or contain only whitespace literals
-                        assert!(elements.is_empty() || elements.iter().all(|e|
-                            matches!(e, CsElement::Literal(s) if s.trim().is_empty())
-                        ));
-                    }
-                }
-            }
-            Err(_) => {
-                // Also acceptable - depends on grammar requirements
-            }
-        }
-    }
-
-    #[test]
-    fn test_debug_output() {
-        let input = ":[var+]";
-        let result = ConcreteSyntax::parse(input).unwrap();
-
-        // Test that Debug trait works (useful for debugging)
-        let debug_str = format!("{:?}", result);
-        assert!(debug_str.contains("var"));
-        assert!(debug_str.contains("OnePlus"));
-    }
+    // Test that Debug trait works (useful for debugging)
+    let debug_str = format!("{:?}", result);
+    assert!(debug_str.contains("var"));
+    assert!(debug_str.contains("OnePlus"));
+  }
 }

--- a/src/models/concrete_syntax/unit_tests/test_parser.rs
+++ b/src/models/concrete_syntax/unit_tests/test_parser.rs
@@ -1,0 +1,263 @@
+
+use crate::models::concrete_syntax::parser::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_capture() {
+        let input = ":[var]";
+        let result = ConcreteSyntax::parse(input).unwrap();
+
+        match result.pattern {
+            CsPattern::Sequence(elements) => {
+                assert_eq!(elements.len(), 1);
+                match &elements[0] {
+                    CsElement::Capture { name, mode } => {
+                        assert_eq!(name, "var");
+                        assert_eq!(*mode, CaptureMode::Single);
+                    }
+                    _ => panic!("Expected capture, got: {:?}", elements[0]),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_literal() {
+        let input = "function";
+        let result = ConcreteSyntax::parse(input).unwrap();
+
+        match result.pattern {
+            CsPattern::Sequence(elements) => {
+                assert_eq!(elements.len(), 1);
+                match &elements[0] {
+                    CsElement::Literal(text) => {
+                        assert_eq!(text, "function");
+                    }
+                    _ => panic!("Expected literal, got: {:?}", elements[0]),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_capture_with_literal() {
+        let input = "function :[name]() {";
+        let result = ConcreteSyntax::parse(input).unwrap();
+
+        match result.pattern {
+            CsPattern::Sequence(elements) => {
+                assert_eq!(elements.len(), 3);
+
+                // Should be: literal "function ", capture "name", literal "() {"
+                match &elements[0] {
+                    CsElement::Literal(text) => assert_eq!(text, "function"),
+                    _ => panic!("Expected literal, got: {:?}", elements[0]),
+                }
+
+                match &elements[1] {
+                    CsElement::Capture { name, mode } => {
+                        assert_eq!(name, "name");
+                        assert_eq!(*mode, CaptureMode::Single);
+                    }
+                    _ => panic!("Expected capture, got: {:?}", elements[1]),
+                }
+
+                match &elements[2] {
+                    CsElement::Literal(text) => assert_eq!(text, "() {"),
+                    _ => panic!("Expected literal, got: {:?}", elements[2]),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_capture_modes() {
+        let input = ":[single] :[many+] :[optional*]";
+        let result = ConcreteSyntax::parse(input).unwrap();
+
+        match result.pattern {
+            CsPattern::Sequence(elements) => {
+                // Check the captures specifically - the actual number may vary
+                let captures: Vec<&CsElement> = elements.iter()
+                    .filter(|e| matches!(e, CsElement::Capture { .. }))
+                    .collect();
+
+                assert_eq!(captures.len(), 3);
+
+                match captures[0] {
+                    CsElement::Capture { name, mode } => {
+                        assert_eq!(name, "single");
+                        assert_eq!(*mode, CaptureMode::Single);
+                    }
+                    _ => panic!("Expected capture"),
+                }
+
+                match captures[1] {
+                    CsElement::Capture { name, mode } => {
+                        assert_eq!(name, "many");
+                        assert_eq!(*mode, CaptureMode::OnePlus);
+                    }
+                    _ => panic!("Expected capture"),
+                }
+
+                match captures[2] {
+                    CsElement::Capture { name, mode } => {
+                        assert_eq!(name, "optional");
+                        assert_eq!(*mode, CaptureMode::ZeroPlus);
+                    }
+                    _ => panic!("Expected capture"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_complex_pattern() {
+        let input = "if (:[condition+]) { :[body*] }";
+        let result = ConcreteSyntax::parse(input).unwrap();
+
+        match result.pattern {
+            CsPattern::Sequence(elements) => {
+                // Find the captures
+                let captures: Vec<&CsElement> = elements.iter()
+                    .filter(|e| matches!(e, CsElement::Capture { .. }))
+                    .collect();
+
+                assert_eq!(captures.len(), 2);
+
+                // Check condition capture
+                match captures[0] {
+                    CsElement::Capture { name, mode } => {
+                        assert_eq!(name, "condition");
+                        assert_eq!(*mode, CaptureMode::OnePlus);
+                    }
+                    _ => panic!("Expected condition capture"),
+                }
+
+                // Check body capture
+                match captures[1] {
+                    CsElement::Capture { name, mode } => {
+                        assert_eq!(name, "body");
+                        assert_eq!(*mode, CaptureMode::ZeroPlus);
+                    }
+                    _ => panic!("Expected body capture"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_identifier_variations() {
+        // Test different valid identifier patterns
+        // Note: identifiers can start with ASCII_ALPHA or "_" per grammar
+        let test_cases = vec![
+            (":[a]", "a"),
+            (":[variable_name]", "variable_name"),
+            (":[var123]", "var123"),
+            (":[CamelCase]", "CamelCase"),
+            (":[_underscore]", "_underscore"),
+            (":[name_with_underscore]", "name_with_underscore"),
+        ];
+
+        for (input, expected_name) in test_cases {
+            let result = ConcreteSyntax::parse(input).unwrap();
+            match result.pattern {
+                CsPattern::Sequence(elements) => {
+                    assert_eq!(elements.len(), 1);
+                    match &elements[0] {
+                        CsElement::Capture { name, mode } => {
+                            assert_eq!(name, expected_name);
+                            assert_eq!(*mode, CaptureMode::Single);
+                        }
+                        _ => panic!("Expected capture for input: {}", input),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_whitespace_handling() {
+        let input = "  function   :[name]   ()  ";
+        let result = ConcreteSyntax::parse(input).unwrap();
+
+        match result.pattern {
+            CsPattern::Sequence(elements) => {
+                // Whitespace should be preserved in literals but trimmed in the parsing
+                assert!(elements.len() >= 3);
+
+                // Find the capture
+                let capture = elements.iter()
+                    .find(|e| matches!(e, CsElement::Capture { .. }))
+                    .expect("Should have a capture");
+
+                match capture {
+                    CsElement::Capture { name, mode } => {
+                        assert_eq!(name, "name");
+                        assert_eq!(*mode, CaptureMode::Single);
+                    }
+                    _ => panic!("Expected capture"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_error_cases() {
+        let error_cases = vec![
+            ":[", // Incomplete capture
+            ":[123]", // Invalid identifier (starts with number)
+            ":[var++]", // Invalid capture mode
+            ":[]", // Empty identifier
+            ":[123var]", // Invalid identifier (starts with number)
+            ":[var-name]", // Invalid identifier (contains hyphen)
+        ];
+
+        for input in error_cases {
+            let result = ConcreteSyntax::parse(input);
+            assert!(result.is_err(), "Expected error for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn test_parse_empty_input() {
+        let result = ConcreteSyntax::parse("");
+        assert!(result.is_err(), "Empty input should produce an error");
+    }
+
+    #[test]
+    fn test_parse_only_whitespace() {
+        let result = ConcreteSyntax::parse("   ");
+        // This might pass depending on grammar - whitespace handling
+        // If it passes, it should create an empty sequence or fail gracefully
+        match result {
+            Ok(cs) => {
+                match cs.pattern {
+                    CsPattern::Sequence(elements) => {
+                        // Should be empty or contain only whitespace literals
+                        assert!(elements.is_empty() || elements.iter().all(|e|
+                            matches!(e, CsElement::Literal(s) if s.trim().is_empty())
+                        ));
+                    }
+                }
+            }
+            Err(_) => {
+                // Also acceptable - depends on grammar requirements
+            }
+        }
+    }
+
+    #[test]
+    fn test_debug_output() {
+        let input = ":[var+]";
+        let result = ConcreteSyntax::parse(input).unwrap();
+
+        // Test that Debug trait works (useful for debugging)
+        let debug_str = format!("{:?}", result);
+        assert!(debug_str.contains("var"));
+        assert!(debug_str.contains("OnePlus"));
+    }
+}

--- a/src/models/concrete_syntax/unit_tests/test_parser.rs
+++ b/src/models/concrete_syntax/unit_tests/test_parser.rs
@@ -1,15 +1,15 @@
 /*
-  Copyright (c) 2023 Uber Technologies, Inc.
- 
-  <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
-  except in compliance with the License. You may obtain a copy of the License at
-  <p>http://www.apache.org/licenses/LICENSE-2.0
- 
-  <p>Unless required by applicable law or agreed to in writing, software distributed under the
-  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  express or implied. See the License for the specific language governing permissions and
-  limitations under the License.
- */
+ Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 use crate::models::concrete_syntax::parser::*;
 
@@ -35,14 +35,20 @@ mod tests {
 
   #[test]
   fn test_parse_literal() {
-    let input = "function";
+    let input = "public int";
     let result = ConcreteSyntax::parse(input).unwrap();
     let elements = result.pattern.sequence;
 
-    assert_eq!(elements.len(), 1);
+    assert_eq!(elements.len(), 2);
     match &elements[0] {
       CsElement::Literal(text) => {
-        assert_eq!(text, "function");
+        assert_eq!(text, "public");
+      }
+      _ => panic!("Expected literal, got: {:?}", elements[0]),
+    }
+    match &elements[1] {
+      CsElement::Literal(text) => {
+        assert_eq!(text, "int");
       }
       _ => panic!("Expected literal, got: {:?}", elements[0]),
     }
@@ -50,11 +56,11 @@ mod tests {
 
   #[test]
   fn test_parse_capture_with_literal() {
-    let input = "function :[name]() {";
+    let input = "function @name() {";
     let result = ConcreteSyntax::parse(input).unwrap();
     let elements = result.pattern.sequence;
 
-    assert_eq!(elements.len(), 3);
+    assert_eq!(elements.len(), 4);
 
     // Should be: literal "function ", capture "name", literal "() {"
     match &elements[0] {
@@ -71,8 +77,13 @@ mod tests {
     }
 
     match &elements[2] {
-      CsElement::Literal(text) => assert_eq!(text, "() {"),
+      CsElement::Literal(text) => assert_eq!(text, "()"),
       _ => panic!("Expected literal, got: {:?}", elements[2]),
+    }
+
+    match &elements[3] {
+      CsElement::Literal(text) => assert_eq!(text, "{"),
+      _ => panic!("Expected literal, got: {:?}", elements[3]),
     }
   }
 


### PR DESCRIPTION
Concrete syntax has a hacky implementation based on string matching. If we want to expand the grammar to support constraints and other constructs, it's worthwhile to build a proper grammar. This will allow us to expand it in the future to use things like:

- `where len(:[name]) > 2` for example to select nodes only with two or more children;
-  `where :[name] matches regex` with regex to add constraints on template variables.

In this PR I essentially wrote the paper, but didn't touch the matching algorithm. In summary:

- Added Pest grammar (concrete_syntax.pest)
- Added parser that converts strings to build an actual AST
- Moved the matching algorithm to [interpreter.rs](https://github.com/danieltrt/piranha/blob/a993eb15fd9f2317f928c6a94c96577ffb73336d/src/models/concrete_syntax/interpreter.rs#L44)