### PR TITLE
Fix maturin package configuration to resolve LICENSE file installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "pyo3"
-include = ["LICENSE", "NOTICE", "polyglot_piranha.pyi"]
+include = ["polyglot_piranha.pyi"]


### PR DESCRIPTION
pyproject.toml already has the LICENSE, but I'm unsure if that's enough 