### PR TITLE
Adding support for a where clause for alternations

### DIFF
--- a/src/models/capture_group_patterns.rs
+++ b/src/models/capture_group_patterns.rs
@@ -147,10 +147,11 @@ impl CompiledCGPattern {
         get_all_matches_for_regex(node, source_code, regex, recursive, replace_node)
       }
       CompiledCGPattern::M(concrete_syntax) => {
+        let resolved_syntax = concrete_syntax.clone().resolve().unwrap();
         let matches = get_all_matches_for_concrete_syntax(
           node,
           code_str,
-          concrete_syntax,
+          &resolved_syntax,
           recursive,
           replace_node,
         );

--- a/src/models/concrete_syntax/concrete_syntax.pest
+++ b/src/models/concrete_syntax/concrete_syntax.pest
@@ -1,6 +1,6 @@
 // Concrete Syntax Grammar for Piranha
 concrete_syntax = { SOI ~ pattern ~ EOI }
-pattern = { (element)+ ~ (", where" ~ constraints)? }
+pattern = { (element)+ ~ ("|>" ~ constraints)? }
 
 // An element is either a capture or literal text
 element = _{ capture | literal_text }
@@ -11,7 +11,7 @@ capture_mode = { "+" | "*" }
 identifier = { (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Literal text - single word/token without whitespace
-literal_text = { (!( ":[" | ", where" | "@" ) ~ ANY)+ }
+literal_text = { (!( ":[" | "|>" | "@" ) ~ ANY)+ }
 WHITESPACE = _{ (" " | "\t" | "\r" | "\n")+ }
 
 // Where constraints (extensible for future constraint types)
@@ -19,4 +19,4 @@ constraints = { constraint ~ ("," ~ constraint)* }
 constraint = { in_constraint }
 in_constraint = { capture ~ "in" ~ "[" ~ list_items? ~ "]" }
 list_items = { quoted_string ~ ("," ~ quoted_string)* }
-quoted_string = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
+quoted_string = { "\"" ~ ( "\\\\" | "\\\"" | (!"\"" ~ ANY) )* ~ "\"" }

--- a/src/models/concrete_syntax/concrete_syntax.pest
+++ b/src/models/concrete_syntax/concrete_syntax.pest
@@ -1,6 +1,6 @@
 // Concrete Syntax Grammar for Piranha
 concrete_syntax = { SOI ~ pattern ~ EOI }
-pattern = { (element)+ ~ ("," ~ "where" ~ constraints)? }
+pattern = { (element)+ ~ (", where" ~ constraints)? }
 
 // An element is either a capture or literal text
 element = _{ capture | literal_text | whitespace }
@@ -11,7 +11,7 @@ capture_mode = { "+" | "*" }
 identifier = { (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Literal text - single word/token without whitespace
-literal_text = { (!( ":[" | whitespace ) ~ ANY)+ }
+literal_text = { (!( ":[" | whitespace | ", where" ) ~ ANY)+ }
 whitespace = _{ (" " | "\t" | "\r" | "\n")+ }
 
 // Where constraints (extensible for future constraint types)

--- a/src/models/concrete_syntax/concrete_syntax.pest
+++ b/src/models/concrete_syntax/concrete_syntax.pest
@@ -1,6 +1,6 @@
 // Concrete Syntax Grammar for Piranha
 concrete_syntax = { SOI ~ pattern ~ EOI }
-pattern = { (element)+ }
+pattern = { (element)+ ~ ("," ~ "where" ~ constraints)? }
 
 // An element is either a capture or literal text
 element = _{ capture | literal_text | whitespace }
@@ -13,3 +13,10 @@ identifier = { (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 // Literal text - single word/token without whitespace
 literal_text = { (!( ":[" | whitespace ) ~ ANY)+ }
 whitespace = _{ (" " | "\t" | "\r" | "\n")+ }
+
+// Where constraints (extensible for future constraint types)
+constraints = { constraint ~ ("," ~ constraint)* }
+constraint = { in_constraint }
+in_constraint = { capture ~ "in" ~ "[" ~ list_items? ~ "]" }
+list_items = { quoted_string ~ ("," ~ quoted_string)* }
+quoted_string = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }

--- a/src/models/concrete_syntax/concrete_syntax.pest
+++ b/src/models/concrete_syntax/concrete_syntax.pest
@@ -3,7 +3,7 @@ concrete_syntax = { SOI ~ pattern ~ EOI }
 pattern = { (element)+ ~ (", where" ~ constraints)? }
 
 // An element is either a capture or literal text
-element = _{ capture | literal_text | whitespace }
+element = _{ capture | literal_text }
 
 // Captures: :[name], :[name+], :[name*], @name
 capture = { (":[" ~ identifier ~ capture_mode? ~ "]") | "@"~identifier } // FIXME: Should remove @ from the grammar, because literals may be parsed incorrectly
@@ -11,8 +11,8 @@ capture_mode = { "+" | "*" }
 identifier = { (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Literal text - single word/token without whitespace
-literal_text = { (!( ":[" | whitespace | ", where" ) ~ ANY)+ }
-whitespace = _{ (" " | "\t" | "\r" | "\n")+ }
+literal_text = { (!( ":[" | ", where" | "@" ) ~ ANY)+ }
+WHITESPACE = _{ (" " | "\t" | "\r" | "\n")+ }
 
 // Where constraints (extensible for future constraint types)
 constraints = { constraint ~ ("," ~ constraint)* }

--- a/src/models/concrete_syntax/mod.rs
+++ b/src/models/concrete_syntax/mod.rs
@@ -13,3 +13,4 @@
 
 pub(crate) mod interpreter;
 pub(crate) mod parser;
+pub(crate) mod resolver;

--- a/src/models/concrete_syntax/parser.rs
+++ b/src/models/concrete_syntax/parser.rs
@@ -204,12 +204,7 @@ impl ConcreteSyntax {
         let text = pair.as_str().trim();
         let tokens: Vec<String> = text.split_whitespace().map(|s| s.to_string()).collect();
 
-        Ok(
-          tokens
-            .into_iter()
-            .map(CsElement::Literal)
-            .collect(),
-        )
+        Ok(tokens.into_iter().map(CsElement::Literal).collect())
       }
       _ => Err(format!("Unexpected element: {:?}", pair.as_rule())),
     }

--- a/src/models/concrete_syntax/resolver.rs
+++ b/src/models/concrete_syntax/resolver.rs
@@ -75,8 +75,7 @@ impl ConcreteSyntax {
     if !constraint_map.is_empty() {
       let unresolved: Vec<String> = constraint_map.keys().cloned().collect();
       return Err(format!(
-        "Unresolved constraints for captures: {:?}",
-        unresolved
+        "Unresolved constraints for captures: {unresolved:?}"
       ));
     }
 

--- a/src/models/concrete_syntax/resolver.rs
+++ b/src/models/concrete_syntax/resolver.rs
@@ -1,0 +1,93 @@
+/*
+ Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+use super::parser::{CaptureMode, ConcreteSyntax, CsConstraint, CsElement};
+use std::collections::HashMap;
+
+/// Resolved structure where constraints are attached to captures
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedConcreteSyntax {
+  pub pattern: ResolvedCsPattern,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedCsPattern {
+  pub sequence: Vec<ResolvedCsElement>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedCsElement {
+  Capture {
+    name: String,
+    mode: CaptureMode,
+    constraints: Vec<CsConstraint>,
+  },
+  Literal(String),
+}
+
+impl ConcreteSyntax {
+  /// Resolve constraints by attaching them to their corresponding captures
+  pub fn resolve(self) -> Result<ResolvedConcreteSyntax, String> {
+    // Build a map of capture names to their constraints
+    let mut constraint_map: HashMap<String, Vec<CsConstraint>> = HashMap::new();
+
+    for constraint in self.pattern.constraints {
+      match &constraint {
+        CsConstraint::In { capture, .. } => {
+          constraint_map
+            .entry(capture.clone())
+            .or_default()
+            .push(constraint);
+        }
+      }
+    }
+
+    // Transform elements, attaching constraints to captures
+    let mut resolved_sequence = Vec::new();
+
+    for element in self.pattern.sequence {
+      match element {
+        CsElement::Capture { name, mode } => {
+          let constraints = constraint_map.remove(&name).unwrap_or_default();
+          resolved_sequence.push(ResolvedCsElement::Capture {
+            name,
+            mode,
+            constraints,
+          });
+        }
+        CsElement::Literal(text) => {
+          resolved_sequence.push(ResolvedCsElement::Literal(text));
+        }
+      }
+    }
+
+    // Check for unresolved constraints (constraints that reference non-existent captures)
+    if !constraint_map.is_empty() {
+      let unresolved: Vec<String> = constraint_map.keys().cloned().collect();
+      return Err(format!(
+        "Unresolved constraints for captures: {:?}",
+        unresolved
+      ));
+    }
+
+    Ok(ResolvedConcreteSyntax {
+      pattern: ResolvedCsPattern {
+        sequence: resolved_sequence,
+      },
+    })
+  }
+}
+
+#[cfg(test)]
+#[path = "unit_tests/resolver_test.rs"]
+mod resolver_test;

--- a/src/models/concrete_syntax/unit_tests/interpreter_test.rs
+++ b/src/models/concrete_syntax/unit_tests/interpreter_test.rs
@@ -28,8 +28,14 @@ fn run_test(
   let tree = parser.parse(code.as_bytes(), None).unwrap();
   let meta = ConcreteSyntax::parse(pattern).unwrap();
 
-  let (matches, _is_match_found) =
-    get_all_matches_for_concrete_syntax(&tree.root_node(), code.as_bytes(), &meta, true, None);
+  let resolved_meta = meta.resolve().unwrap();
+  let (matches, _is_match_found) = get_all_matches_for_concrete_syntax(
+    &tree.root_node(),
+    code.as_bytes(),
+    &resolved_meta,
+    true,
+    None,
+  );
 
   assert_eq!(matches.len(), expected_matches);
 
@@ -201,6 +207,20 @@ fn test_asterisk_one_or_more() {
     "class :[name] { :[body*] }",
     1,
     vec![vec![("name", "Example"), ("body", "int x = 1; int y = 2;")]],
+    JAVA,
+  );
+}
+
+#[test]
+fn test_where_clauses() {
+  run_test(
+    r#"foo(ab); foo("cd"); foo(1,2,3);"#,
+    r#"foo(:[args]) |> :[args] in ["ab", "\"cd\""]"#,
+    2, // now two matches
+    vec![
+      vec![("args", "ab")],
+      vec![("args", "\"cd\"")], // note the quotes are included
+    ],
     JAVA,
   );
 }

--- a/src/models/concrete_syntax/unit_tests/interpreter_test.rs
+++ b/src/models/concrete_syntax/unit_tests/interpreter_test.rs
@@ -212,7 +212,7 @@ fn test_asterisk_one_or_more() {
 }
 
 #[test]
-fn test_where_clauses() {
+fn test_simple_where_clause() {
   run_test(
     r#"foo(ab); foo("cd"); foo(1,2,3);"#,
     r#"foo(:[args]) |> :[args] in ["ab", "\"cd\""]"#,
@@ -221,6 +221,17 @@ fn test_where_clauses() {
       vec![("args", "ab")],
       vec![("args", "\"cd\"")], // note the quotes are included
     ],
+    JAVA,
+  );
+}
+
+#[test]
+fn test_mutliple_where_clause() {
+  run_test(
+    r#"foo(c, d); foo(1,4);"#,
+    r#"foo(:[arg1], :[arg2]) |> :[arg1] in ["1"], :[arg2] in ["4"]"#,
+    1, // now two matches
+    vec![vec![("arg1", "1"), ("arg2", "4")]],
     JAVA,
   );
 }

--- a/src/models/concrete_syntax/unit_tests/parser_test.rs
+++ b/src/models/concrete_syntax/unit_tests/parser_test.rs
@@ -299,7 +299,7 @@ mod tests {
     }
 
     // Test that Debug trait works (useful for debugging)
-    let debug_str = format!("{:?}", result);
+    let debug_str = format!("{result:?}");
     assert!(debug_str.contains("var"));
     assert!(debug_str.contains("OnePlus"));
     assert!(debug_str.contains("constraints"));

--- a/src/models/concrete_syntax/unit_tests/parser_test.rs
+++ b/src/models/concrete_syntax/unit_tests/parser_test.rs
@@ -12,6 +12,7 @@
 */
 
 use crate::models::concrete_syntax::parser::*;
+use crate::models::concrete_syntax::resolver::ResolvedCsElement;
 
 #[cfg(test)]
 mod tests {
@@ -270,13 +271,13 @@ mod tests {
 
   #[test]
   fn test_where() {
-    let input = ":[var+], where :[var] in [\"a\"]";
+    let input = ":[var+] |> :[var] in [\"a\"]";
     let result = ConcreteSyntax::parse(input).unwrap();
 
     // Check the pattern elements
     let elements = &result.pattern.sequence;
     assert_eq!(elements.len(), 1);
-    
+
     match &elements[0] {
       CsElement::Capture { name, mode } => {
         assert_eq!(name, "var");
@@ -288,7 +289,7 @@ mod tests {
     // Check the constraints
     let constraints = &result.pattern.constraints;
     assert_eq!(constraints.len(), 1);
-    
+
     match &constraints[0] {
       CsConstraint::In { capture, items } => {
         assert_eq!(capture, "var");
@@ -302,5 +303,44 @@ mod tests {
     assert!(debug_str.contains("var"));
     assert!(debug_str.contains("OnePlus"));
     assert!(debug_str.contains("constraints"));
+  }
+
+  #[test]
+  fn test_parse_and_resolve_flow() {
+    let input = ":[var+] |> :[var] in [\"a\"]";
+
+    // Parse
+    let parsed = ConcreteSyntax::parse(input).unwrap();
+
+    // Verify parsing separated constraints from elements
+    assert_eq!(parsed.pattern.sequence.len(), 1);
+    assert_eq!(parsed.pattern.constraints.len(), 1);
+
+    // Resolve
+    let resolved = parsed.resolve().unwrap();
+
+    // Verify resolution attached constraints to captures
+    assert_eq!(resolved.pattern.sequence.len(), 1);
+
+    match &resolved.pattern.sequence[0] {
+      ResolvedCsElement::Capture {
+        name,
+        mode,
+        constraints,
+      } => {
+        assert_eq!(name, "var");
+        assert_eq!(*mode, CaptureMode::OnePlus);
+        assert_eq!(constraints.len(), 1);
+
+        match &constraints[0] {
+          CsConstraint::In { capture, items } => {
+            assert_eq!(capture, "var");
+            assert_eq!(items.len(), 1);
+            assert_eq!(items[0], "a");
+          }
+        }
+      }
+      _ => panic!("Expected capture with constraints"),
+    }
   }
 }

--- a/src/models/concrete_syntax/unit_tests/resolver_test.rs
+++ b/src/models/concrete_syntax/unit_tests/resolver_test.rs
@@ -1,0 +1,118 @@
+/*
+ Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+use crate::models::concrete_syntax::parser::*;
+use crate::models::concrete_syntax::resolver::*;
+
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::models::concrete_syntax::parser::CsPattern;
+
+  #[test]
+  fn test_resolve_with_constraints() {
+    let concrete = ConcreteSyntax {
+      pattern: CsPattern {
+        sequence: vec![CsElement::Capture {
+          name: "var".to_string(),
+          mode: CaptureMode::OnePlus,
+        }],
+        constraints: vec![CsConstraint::In {
+          capture: "var".to_string(),
+          items: vec!["a".to_string(), "b".to_string()],
+        }],
+      },
+    };
+
+    let resolved = concrete.resolve().unwrap();
+
+    assert_eq!(resolved.pattern.sequence.len(), 1);
+    match &resolved.pattern.sequence[0] {
+      ResolvedCsElement::Capture {
+        name,
+        mode,
+        constraints,
+      } => {
+        assert_eq!(name, "var");
+        assert_eq!(*mode, CaptureMode::OnePlus);
+        assert_eq!(constraints.len(), 1);
+        match &constraints[0] {
+          CsConstraint::In { capture, items } => {
+            assert_eq!(capture, "var");
+            assert_eq!(items, &vec!["a".to_string(), "b".to_string()]);
+          }
+        }
+      }
+      _ => panic!("Expected capture"),
+    }
+  }
+
+  #[test]
+  fn test_resolve_without_constraints() {
+    let concrete = ConcreteSyntax {
+      pattern: CsPattern {
+        sequence: vec![
+          CsElement::Capture {
+            name: "var".to_string(),
+            mode: CaptureMode::Single,
+          },
+          CsElement::Literal("test".to_string()),
+        ],
+        constraints: vec![],
+      },
+    };
+
+    let resolved = concrete.resolve().unwrap();
+
+    assert_eq!(resolved.pattern.sequence.len(), 2);
+    match &resolved.pattern.sequence[0] {
+      ResolvedCsElement::Capture {
+        name,
+        mode,
+        constraints,
+      } => {
+        assert_eq!(name, "var");
+        assert_eq!(*mode, CaptureMode::Single);
+        assert_eq!(constraints.len(), 0);
+      }
+      _ => panic!("Expected capture"),
+    }
+
+    match &resolved.pattern.sequence[1] {
+      ResolvedCsElement::Literal(text) => {
+        assert_eq!(text, "test");
+      }
+      _ => panic!("Expected literal"),
+    }
+  }
+
+  #[test]
+  fn test_resolve_unresolved_constraint() {
+    let concrete = ConcreteSyntax {
+      pattern: CsPattern {
+        sequence: vec![CsElement::Capture {
+          name: "var".to_string(),
+          mode: CaptureMode::Single,
+        }],
+        constraints: vec![CsConstraint::In {
+          capture: "nonexistent".to_string(),
+          items: vec!["a".to_string()],
+        }],
+      },
+    };
+
+    let result = concrete.resolve();
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Unresolved constraints"));
+  }
+}

--- a/src/models/concrete_syntax/unit_tests/resolver_test.rs
+++ b/src/models/concrete_syntax/unit_tests/resolver_test.rs
@@ -13,7 +13,6 @@
 use crate::models::concrete_syntax::parser::*;
 use crate::models::concrete_syntax::resolver::*;
 
-
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src/models/concrete_syntax/unit_tests/test_parser.rs
+++ b/src/models/concrete_syntax/unit_tests/test_parser.rs
@@ -267,4 +267,40 @@ mod tests {
     assert!(debug_str.contains("var"));
     assert!(debug_str.contains("OnePlus"));
   }
+
+  #[test]
+  fn test_where() {
+    let input = ":[var+], where:[var]in[\"a\"]";
+    let result = ConcreteSyntax::parse(input).unwrap();
+
+    // Check the pattern elements
+    let elements = &result.pattern.sequence;
+    assert_eq!(elements.len(), 1);
+    
+    match &elements[0] {
+      CsElement::Capture { name, mode } => {
+        assert_eq!(name, "var");
+        assert_eq!(*mode, CaptureMode::OnePlus);
+      }
+      _ => panic!("Expected capture"),
+    }
+
+    // Check the constraints
+    let constraints = &result.pattern.constraints;
+    assert_eq!(constraints.len(), 1);
+    
+    match &constraints[0] {
+      CsConstraint::In { capture, items } => {
+        assert_eq!(capture, "var");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0], "a");
+      }
+    }
+
+    // Test that Debug trait works (useful for debugging)
+    let debug_str = format!("{:?}", result);
+    assert!(debug_str.contains("var"));
+    assert!(debug_str.contains("OnePlus"));
+    assert!(debug_str.contains("constraints"));
+  }
 }

--- a/src/models/concrete_syntax/unit_tests/test_parser.rs
+++ b/src/models/concrete_syntax/unit_tests/test_parser.rs
@@ -270,7 +270,7 @@ mod tests {
 
   #[test]
   fn test_where() {
-    let input = ":[var+], where:[var]in[\"a\"]";
+    let input = ":[var+], where :[var] in [\"a\"]";
     let result = ConcreteSyntax::parse(input).unwrap();
 
     // Check the pattern elements


### PR DESCRIPTION
This PR adds support for a where clause in concrete syntax. To achieve this I added a semantic analyzer (resolver.rs) to basically resolve the constraints and associate them with the template at hand. 

In summary:
- Added a semantic analyzer and tests (resolver.rs)
- Changed the grammar to accept `where`. The special keyword for where is `|>`
- Added support for an `in` constraint, that can be used like: 

``` 
:[x].someMethod(:[args)) |> :[x] in ["foo", "bar"]
```
