### PR TITLE
Further simplify the release process by automatically generating a GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         twine upload --repository testpypi --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_TOKEN }} dist/*
 
     - name: Create GitHub Release
-      if: github.ref_type == 'tag'
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v2
       with:
         generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,3 +80,10 @@ jobs:
       run: |
         pip install twine
         twine upload --repository testpypi --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_TOKEN }} dist/*
+
+    - name: Create GitHub Release
+      if: github.ref_type == 'tag'
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true
+        files: dist/*

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,6 +6,5 @@ Releasing
  3. `git commit -am "Release X.Y.Z."` (where X.Y.Z is the new version)
  4. `git tag -a vX.Y.Z -m "Piranha X.Y.Z"` (where X.Y.Z is the new version)
  5. `git push && git push --tags`
- 6. The release workflow will automatically be triggered to build wheels and source distributions, and automatically upload to PyPI.
- 7. Visit [polyglot-piranha](https://pypi.org/project/polyglot-piranha/) to see if new release is there.
- 8. Create a [GitHub Release](https://github.com/uber/piranha/releases).
+ 6. The release workflow will automatically be triggered to build wheels and source distributions, automatically upload to PyPI, and then create a GitHub release.
+ 7. Visit [polyglot-piranha](https://pypi.org/project/polyglot-piranha/) in PyPI and [GitHub Release](https://github.com/uber/piranha/releases) to see if releases are there.


### PR DESCRIPTION
This PR adds automatic creation of GitHub releases to further simplify the release process (by simply updating the version number in Cargo and pushing the tag).

Tested in my private fork: https://github.com/yuxincs/piranha/releases/tag/v0.4.6