### PR TITLE
Prepare for concrete syntax WASM

### DIFF
--- a/src/models/concrete_syntax/cursor_utils.rs
+++ b/src/models/concrete_syntax/cursor_utils.rs
@@ -11,8 +11,8 @@
  limitations under the License.
 */
 
-use crate::models::matches::Range;
 use crate::models::concrete_syntax::tree_sitter_adapter::{Node, TreeCursor};
+use crate::models::matches::Range;
 
 /// Cursor navigation utilities for tree traversal during pattern matching.
 pub struct CursorNavigator;

--- a/src/models/concrete_syntax/cursor_utils.rs
+++ b/src/models/concrete_syntax/cursor_utils.rs
@@ -12,7 +12,7 @@
 */
 
 use crate::models::matches::Range;
-use tree_sitter::{Node, TreeCursor};
+use crate::models::concrete_syntax::tree_sitter_adapter::{Node, TreeCursor};
 
 /// Cursor navigation utilities for tree traversal during pattern matching.
 pub struct CursorNavigator;

--- a/src/models/concrete_syntax/interpreter.rs
+++ b/src/models/concrete_syntax/interpreter.rs
@@ -18,10 +18,10 @@ use crate::models::concrete_syntax::cursor_utils::CursorNavigator;
 use crate::models::concrete_syntax::parser::CaptureMode;
 use crate::models::concrete_syntax::parser::CsConstraint;
 use crate::models::concrete_syntax::resolver::{ResolvedConcreteSyntax, ResolvedCsElement};
+use crate::models::concrete_syntax::tree_sitter_adapter::{Node, TreeCursor};
 use crate::models::concrete_syntax::types::{CapturedNode, MatchingContext, PatternMatchResult};
 use crate::models::matches::Match;
 use std::collections::HashMap;
-use tree_sitter::{Node, TreeCursor};
 use tree_sitter_traversal::Cursor;
 
 // =============================================================================

--- a/src/models/concrete_syntax/mod.rs
+++ b/src/models/concrete_syntax/mod.rs
@@ -16,4 +16,5 @@ pub(crate) mod cursor_utils;
 pub(crate) mod interpreter;
 pub(crate) mod parser;
 pub(crate) mod resolver;
+pub(crate) mod tree_sitter_adapter;
 pub(crate) mod types;

--- a/src/models/concrete_syntax/tree_sitter_adapter.rs
+++ b/src/models/concrete_syntax/tree_sitter_adapter.rs
@@ -1,0 +1,143 @@
+/*
+ Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+//! Trait abstraction for tree-sitter dependencies
+//! This allows the concrete syntax module to work with different tree implementations
+
+use crate::models::matches::Range;
+
+/// Minimal node interface - only the methods actually used  
+pub trait SyntaxNode: PartialEq + Clone {
+    fn range(&self) -> Range;
+    fn kind(&self) -> &str;
+    fn child_count(&self) -> usize;
+    fn child(&self, index: usize) -> Option<Self>;
+    fn children(&self) -> Vec<Self>;
+    fn utf8_text<'a>(&self, source: &'a [u8]) -> Result<&'a str, std::str::Utf8Error>;
+    fn walk(&self) -> impl SyntaxCursor<Node = Self>;
+}
+
+/// Minimal cursor interface - only the methods actually used
+pub trait SyntaxCursor: Clone {
+    type Node: SyntaxNode;
+    
+    fn node(&self) -> Self::Node;
+    fn goto_first_child(&mut self) -> bool;
+    fn goto_next_sibling(&mut self) -> bool;
+    fn goto_parent(&mut self) -> bool;
+}
+
+// Native tree-sitter implementation
+#[derive(Clone, PartialEq)]
+pub struct NativeNode<'a> {
+    pub inner: tree_sitter::Node<'a>,
+}
+
+impl<'a> SyntaxNode for NativeNode<'a> {
+    fn range(&self) -> Range {
+        let ts_range = self.inner.range();
+        Range {
+            start_byte: ts_range.start_byte,
+            end_byte: ts_range.end_byte,
+            start_point: crate::models::matches::Point {
+                row: ts_range.start_point.row,
+                column: ts_range.start_point.column,
+            },
+            end_point: crate::models::matches::Point {
+                row: ts_range.end_point.row,
+                column: ts_range.end_point.column,
+            },
+        }
+    }
+    
+    fn kind(&self) -> &str {
+        self.inner.kind()
+    }
+    
+    fn child_count(&self) -> usize {
+        self.inner.child_count()
+    }
+    
+    fn child(&self, index: usize) -> Option<Self> {
+        self.inner.child(index).map(|node| NativeNode { inner: node })
+    }
+    
+    fn children(&self) -> Vec<Self> {
+        let mut cursor = self.inner.walk();
+        self.inner.children(&mut cursor)
+            .map(|node| NativeNode { inner: node })
+            .collect()
+    }
+    
+    fn utf8_text<'b>(&self, source: &'b [u8]) -> Result<&'b str, std::str::Utf8Error> {
+        self.inner.utf8_text(source)
+    }
+    
+    fn walk(&self) -> impl SyntaxCursor<Node = Self> {
+        NativeCursor { inner: self.inner.walk() }
+    }
+}
+
+#[derive(Clone)]
+pub struct NativeCursor<'a> {
+    pub inner: tree_sitter::TreeCursor<'a>,
+}
+
+impl<'a> SyntaxCursor for NativeCursor<'a> {
+    type Node = NativeNode<'a>;
+    
+    fn node(&self) -> Self::Node {
+        NativeNode { inner: self.inner.node() }
+    }
+    
+    fn goto_first_child(&mut self) -> bool {
+        self.inner.goto_first_child()
+    }
+    
+    fn goto_next_sibling(&mut self) -> bool {
+        self.inner.goto_next_sibling()
+    }
+    
+    fn goto_parent(&mut self) -> bool {
+        self.inner.goto_parent()
+    }
+}
+
+// Re-export tree-sitter types for backward compatibility
+pub use tree_sitter::{Node, TreeCursor};
+
+/// Adapter functions for working with tree-sitter types directly 
+/// These provide a bridge between the trait-based and direct tree-sitter APIs
+pub struct TreeSitterAdapter;
+
+impl TreeSitterAdapter {
+    /// Wrap a tree-sitter node in our trait wrapper
+    pub fn wrap_node<'a>(node: tree_sitter::Node<'a>) -> NativeNode<'a> {
+        NativeNode { inner: node }
+    }
+    
+    /// Wrap a tree-sitter cursor in our trait wrapper
+    pub fn wrap_cursor<'a>(cursor: tree_sitter::TreeCursor<'a>) -> NativeCursor<'a> {
+        NativeCursor { inner: cursor }
+    }
+    
+    /// Extract the tree-sitter node from our wrapper
+    pub fn unwrap_node<'a>(node: &NativeNode<'a>) -> tree_sitter::Node<'a> {
+        node.inner
+    }
+    
+    /// Extract the tree-sitter cursor from our wrapper  
+    pub fn unwrap_cursor<'a>(cursor: &'a NativeCursor<'a>) -> &'a tree_sitter::TreeCursor<'a> {
+        &cursor.inner
+    }
+} 

--- a/src/models/concrete_syntax/tree_sitter_adapter.rs
+++ b/src/models/concrete_syntax/tree_sitter_adapter.rs
@@ -18,126 +18,135 @@ use crate::models::matches::Range;
 
 /// Minimal node interface - only the methods actually used  
 pub trait SyntaxNode: PartialEq + Clone {
-    fn range(&self) -> Range;
-    fn kind(&self) -> &str;
-    fn child_count(&self) -> usize;
-    fn child(&self, index: usize) -> Option<Self>;
-    fn children(&self) -> Vec<Self>;
-    fn utf8_text<'a>(&self, source: &'a [u8]) -> Result<&'a str, std::str::Utf8Error>;
-    fn walk(&self) -> impl SyntaxCursor<Node = Self>;
+  fn range(&self) -> Range;
+  fn kind(&self) -> &str;
+  fn child_count(&self) -> usize;
+  fn child(&self, index: usize) -> Option<Self>;
+  fn children(&self) -> Vec<Self>;
+  fn utf8_text<'a>(&self, source: &'a [u8]) -> Result<&'a str, std::str::Utf8Error>;
+  fn walk(&self) -> impl SyntaxCursor<Node = Self>;
 }
 
 /// Minimal cursor interface - only the methods actually used
 pub trait SyntaxCursor: Clone {
-    type Node: SyntaxNode;
-    
-    fn node(&self) -> Self::Node;
-    fn goto_first_child(&mut self) -> bool;
-    fn goto_next_sibling(&mut self) -> bool;
-    fn goto_parent(&mut self) -> bool;
+  type Node: SyntaxNode;
+
+  fn node(&self) -> Self::Node;
+  fn goto_first_child(&mut self) -> bool;
+  fn goto_next_sibling(&mut self) -> bool;
+  fn goto_parent(&mut self) -> bool;
 }
 
 // Native tree-sitter implementation
 #[derive(Clone, PartialEq)]
 pub struct NativeNode<'a> {
-    pub inner: tree_sitter::Node<'a>,
+  pub inner: tree_sitter::Node<'a>,
 }
 
 impl<'a> SyntaxNode for NativeNode<'a> {
-    fn range(&self) -> Range {
-        let ts_range = self.inner.range();
-        Range {
-            start_byte: ts_range.start_byte,
-            end_byte: ts_range.end_byte,
-            start_point: crate::models::matches::Point {
-                row: ts_range.start_point.row,
-                column: ts_range.start_point.column,
-            },
-            end_point: crate::models::matches::Point {
-                row: ts_range.end_point.row,
-                column: ts_range.end_point.column,
-            },
-        }
+  fn range(&self) -> Range {
+    let ts_range = self.inner.range();
+    Range {
+      start_byte: ts_range.start_byte,
+      end_byte: ts_range.end_byte,
+      start_point: crate::models::matches::Point {
+        row: ts_range.start_point.row,
+        column: ts_range.start_point.column,
+      },
+      end_point: crate::models::matches::Point {
+        row: ts_range.end_point.row,
+        column: ts_range.end_point.column,
+      },
     }
-    
-    fn kind(&self) -> &str {
-        self.inner.kind()
+  }
+
+  fn kind(&self) -> &str {
+    self.inner.kind()
+  }
+
+  fn child_count(&self) -> usize {
+    self.inner.child_count()
+  }
+
+  fn child(&self, index: usize) -> Option<Self> {
+    self
+      .inner
+      .child(index)
+      .map(|node| NativeNode { inner: node })
+  }
+
+  fn children(&self) -> Vec<Self> {
+    let mut cursor = self.inner.walk();
+    self
+      .inner
+      .children(&mut cursor)
+      .map(|node| NativeNode { inner: node })
+      .collect()
+  }
+
+  fn utf8_text<'b>(&self, source: &'b [u8]) -> Result<&'b str, std::str::Utf8Error> {
+    self.inner.utf8_text(source)
+  }
+
+  fn walk(&self) -> impl SyntaxCursor<Node = Self> {
+    NativeCursor {
+      inner: self.inner.walk(),
     }
-    
-    fn child_count(&self) -> usize {
-        self.inner.child_count()
-    }
-    
-    fn child(&self, index: usize) -> Option<Self> {
-        self.inner.child(index).map(|node| NativeNode { inner: node })
-    }
-    
-    fn children(&self) -> Vec<Self> {
-        let mut cursor = self.inner.walk();
-        self.inner.children(&mut cursor)
-            .map(|node| NativeNode { inner: node })
-            .collect()
-    }
-    
-    fn utf8_text<'b>(&self, source: &'b [u8]) -> Result<&'b str, std::str::Utf8Error> {
-        self.inner.utf8_text(source)
-    }
-    
-    fn walk(&self) -> impl SyntaxCursor<Node = Self> {
-        NativeCursor { inner: self.inner.walk() }
-    }
+  }
 }
 
 #[derive(Clone)]
 pub struct NativeCursor<'a> {
-    pub inner: tree_sitter::TreeCursor<'a>,
+  pub inner: tree_sitter::TreeCursor<'a>,
 }
 
 impl<'a> SyntaxCursor for NativeCursor<'a> {
-    type Node = NativeNode<'a>;
-    
-    fn node(&self) -> Self::Node {
-        NativeNode { inner: self.inner.node() }
+  type Node = NativeNode<'a>;
+
+  fn node(&self) -> Self::Node {
+    NativeNode {
+      inner: self.inner.node(),
     }
-    
-    fn goto_first_child(&mut self) -> bool {
-        self.inner.goto_first_child()
-    }
-    
-    fn goto_next_sibling(&mut self) -> bool {
-        self.inner.goto_next_sibling()
-    }
-    
-    fn goto_parent(&mut self) -> bool {
-        self.inner.goto_parent()
-    }
+  }
+
+  fn goto_first_child(&mut self) -> bool {
+    self.inner.goto_first_child()
+  }
+
+  fn goto_next_sibling(&mut self) -> bool {
+    self.inner.goto_next_sibling()
+  }
+
+  fn goto_parent(&mut self) -> bool {
+    self.inner.goto_parent()
+  }
 }
 
 // Re-export tree-sitter types for backward compatibility
 pub use tree_sitter::{Node, TreeCursor};
 
-/// Adapter functions for working with tree-sitter types directly 
+/// Adapter functions for working with tree-sitter types directly
 /// These provide a bridge between the trait-based and direct tree-sitter APIs
 pub struct TreeSitterAdapter;
 
 impl TreeSitterAdapter {
-    /// Wrap a tree-sitter node in our trait wrapper
-    pub fn wrap_node<'a>(node: tree_sitter::Node<'a>) -> NativeNode<'a> {
-        NativeNode { inner: node }
-    }
-    
-    /// Wrap a tree-sitter cursor in our trait wrapper
-    pub fn wrap_cursor<'a>(cursor: tree_sitter::TreeCursor<'a>) -> NativeCursor<'a> {
-        NativeCursor { inner: cursor }
-    }
-    
-    /// Extract the tree-sitter node from our wrapper
-    pub fn unwrap_node<'a>(node: &NativeNode<'a>) -> tree_sitter::Node<'a> {
-        node.inner
-    }
-    
-    /// Extract the tree-sitter cursor from our wrapper  
-    pub fn unwrap_cursor<'a>(cursor: &'a NativeCursor<'a>) -> &'a tree_sitter::TreeCursor<'a> {
-        &cursor.inner
-    }
-} 
+  /// Wrap a tree-sitter node in our trait wrapper
+  pub fn wrap_node<'a>(node: tree_sitter::Node<'a>) -> NativeNode<'a> {
+    NativeNode { inner: node }
+  }
+
+  /// Wrap a tree-sitter cursor in our trait wrapper
+  pub fn wrap_cursor<'a>(cursor: tree_sitter::TreeCursor<'a>) -> NativeCursor<'a> {
+    NativeCursor { inner: cursor }
+  }
+
+  /// Extract the tree-sitter node from our wrapper
+  pub fn unwrap_node<'a>(node: &NativeNode<'a>) -> tree_sitter::Node<'a> {
+    node.inner
+  }
+
+  /// Extract the tree-sitter cursor from our wrapper  
+  pub fn unwrap_cursor<'a>(cursor: &'a NativeCursor<'a>) -> &'a tree_sitter::TreeCursor<'a> {
+    &cursor.inner
+  }
+}

--- a/src/models/concrete_syntax/types.rs
+++ b/src/models/concrete_syntax/types.rs
@@ -12,8 +12,8 @@
 */
 
 use crate::models::matches::Range;
+use crate::models::concrete_syntax::tree_sitter_adapter::{Node, TreeCursor};
 use std::collections::HashMap;
-use tree_sitter::{Node, TreeCursor};
 
 /// Represents a captured node during pattern matching
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/models/concrete_syntax/types.rs
+++ b/src/models/concrete_syntax/types.rs
@@ -11,8 +11,8 @@
  limitations under the License.
 */
 
-use crate::models::matches::Range;
 use crate::models::concrete_syntax::tree_sitter_adapter::{Node, TreeCursor};
+use crate::models::matches::Range;
 use std::collections::HashMap;
 
 /// Represents a captured node during pattern matching


### PR DESCRIPTION
This PR changes the concrete syntax algorithm to use traits, instead of tree sitter nodes. The idea is to separate it out from:

1. The specific tree-sitter version (whose API breaks often)
2. Tree-sitter itself, since it's nearly impossible to compile it to WASM due to stdlib / c libraries

We have implemented the trait for tree-sitter, such that we can still use it normally.