### PR TITLE
Adding optional match to concrete syntax

### DIFF
--- a/crates/concrete-syntax/src/concrete_syntax.pest
+++ b/crates/concrete-syntax/src/concrete_syntax.pest
@@ -7,7 +7,7 @@ element = _{ capture | literal_text }
 
 // Captures: :[name], :[name+], :[name*], @name
 capture = { (":[" ~ identifier ~ capture_mode? ~ "]") | "@"~identifier } // FIXME: Should remove @ from the grammar, because literals may be parsed incorrectly
-capture_mode = { "+" | "*" }
+capture_mode = { "+" | "*"  | "?"}
 identifier = { (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Literal text - single word/token without whitespace

--- a/crates/concrete-syntax/src/models/concrete_syntax/parser.rs
+++ b/crates/concrete-syntax/src/models/concrete_syntax/parser.rs
@@ -50,6 +50,7 @@ pub enum CaptureMode {
   Single,   // :[var]
   OnePlus,  // :[var+]
   ZeroPlus, // :[var*]
+  Optional, // :[var?]
 }
 
 /// Decode \" \\ \n \t \/ … inside a string literal.
@@ -253,6 +254,7 @@ impl ConcreteSyntax {
       match mode_pair.as_str() {
         "+" => CaptureMode::OnePlus,
         "*" => CaptureMode::ZeroPlus,
+        "?" => CaptureMode::Optional,
         _ => return Err(format!("Unknown capture mode: {}", mode_pair.as_str())),
       }
     } else {

--- a/crates/concrete-syntax/src/models/concrete_syntax/unit_tests/interpreter_test.rs
+++ b/crates/concrete-syntax/src/models/concrete_syntax/unit_tests/interpreter_test.rs
@@ -167,6 +167,39 @@ fn test_single_match() {
 }
 
 #[test]
+fn test_optional_match_single() {
+  run_test(
+    "package something; func (r *receiver) someName() { }",
+    "func :[receiver?] someName() { }",
+    1,
+    vec![vec![("receiver", "(r *receiver)"),]],
+    GO,
+  );
+}
+
+#[test]
+fn test_optional_match_zero() {
+  run_test(
+    "package something; func someName() { }",
+    "func :[receiver?] someName() { }",
+    1,
+    vec![vec![("receiver", ""),]],
+    GO,
+  );
+}
+
+#[test]
+fn test_optional_no_match() {
+  run_test(
+    "package something; func (r *receiver) someName() { }",
+    "func :[receiver_and_name?]() { }",
+    0,
+    vec![],
+    GO,
+  );
+}
+
+#[test]
 fn test_multiple_match() {
   run_test(
     "class Example { public int a = 10; public int b = 20; }",


### PR DESCRIPTION
- This PR adds support to an optional wildcard in concrete syntax.
- Added 3 end-to-end tests