### PR TITLE
Update maturin version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,7 @@ documentation = "https://github.com/uber/piranha"
 repository = "https://github.com/uber/piranha"
 
 [build-system]
-# There is a bug with maturin 1.9.0 that incorrectly packages LICENSE file causing a problem.
-# For now we have to pin it to 1.8.7 (last stable version).
-# TODO: remove this check once maturin is fixed.
-requires = ["maturin>=1.4.0,<=1.8.7"]
+requires = ["maturin>=1.9.1"]
 build-backend = "maturin"
 
 [project.optional-dependencies]


### PR DESCRIPTION
maturin v1.9.1 fixed the problem of LICENSE file bundling, so we can unpin the version.