### PR TITLE
Add a Directory Recursive scope to Piranha

### DIFF
--- a/crates/core/src/models/rule_graph.rs
+++ b/crates/core/src/models/rule_graph.rs
@@ -37,6 +37,7 @@ pub(crate) static GLOBAL: &str = "Global";
 pub(crate) static PARENT: &str = "Parent";
 pub(crate) static PARENT_ITERATIVE: &str = "ParentIterative";
 pub(crate) static DIRECTORY: &str = "Directory";
+pub(crate) static DIRECTORY_RECURSIVE: &str = "DirectoryRecursive";
 
 #[derive(Debug, Default, Getters, MutGetters, Builder, Clone, PartialEq)]
 #[builder(build_fn(name = "create"))]
@@ -203,7 +204,13 @@ impl RuleGraph {
       }
     }
     // Add empty entry, incase no next rule was found for a particular scope
-    for scope in [PARENT, PARENT_ITERATIVE, GLOBAL, DIRECTORY] {
+    for scope in [
+      PARENT,
+      PARENT_ITERATIVE,
+      GLOBAL,
+      DIRECTORY,
+      DIRECTORY_RECURSIVE,
+    ] {
       next_rules.entry(scope.to_string()).or_default();
     }
     next_rules

--- a/crates/core/src/tests/test_piranha_go.rs
+++ b/crates/core/src/tests/test_piranha_go.rs
@@ -42,7 +42,12 @@ create_rewrite_tests! {
       "stale_flag_name" => "staleFlag",
       "treated" => "false"
     };
-  test_package_scope_delete_method : "feature_flag/delete_method/private_pkg_fn", 2,
+    test_directory_scope_delete_method : "feature_flag/delete_method/private_pkg_fn", 2,
+    substitutions= substitutions! {
+      "name" => "someFunc"
+    };
+
+  test_directory_recursive_scope_delete_method : "feature_flag/delete_method/private_pkg_fn_recursive", 3,
     substitutions= substitutions! {
       "name" => "someFunc"
     };

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/configurations/edges.toml
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/configurations/edges.toml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[edges]]
+scope = "DirectoryRecursive"
+from = "func_returns_true"
+to = ["propagate_val"]

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/configurations/rules.toml
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/configurations/rules.toml
@@ -1,0 +1,32 @@
+# Copyright (c) 2023 Uber Technologies, Inc.
+#
+# <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy of the License at
+# <p>http://www.apache.org/licenses/LICENSE-2.0
+#
+# <p>Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[rules]]
+name = "func_returns_true"
+query = """cs func @name(:[args*]) bool {
+    return :[ret_val]
+}
+
+|> :[ret_val] in ["true", "false"]
+"""
+replace = ""
+replace_node = "*"
+holes = ["name"]
+is_seed_rule = true
+
+[[rules]]
+name = "propagate_val"
+groups = ["replace_expression_with_boolean_literal"]
+query = """cs @name(:[args*])"""
+replace = "@ret_val"
+replace_node = "*"
+holes = ["ret_val", "name"]
+is_seed_rule = false

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/expected/main.go
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/expected/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	"mycompany/featureflags/exp"
+)
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/expected/pkg1/file.go
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/expected/pkg1/file.go
@@ -1,0 +1,32 @@
+/*
+Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pkg1
+
+import (
+    "fmt"
+)
+
+// ProcessData processes some data using feature flags
+func ProcessData(input string) string {
+    if IsFeatureEnabled() {
+        return fmt.Sprintf("processed: %s", input)
+    }
+    return input
+}
+
+// HelperFunction demonstrates package scope rule application
+func HelperFunction() {
+    fmt.Println("Feature is enabled in sub folder")
+
+}

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/expected/pkg1/sample.go
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/expected/pkg1/sample.go
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pkg1
+
+
+import (
+    "fmt"
+    "mycompany/featureflags/exp"
+)
+
+
+
+func main() {
+    fmt.Println("Proceeding with new login flow...")
+
+}

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/expected/pkg1/sub_folder/file.go
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/expected/pkg1/sub_folder/file.go
@@ -1,0 +1,32 @@
+/*
+Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package sub_folder
+
+import (
+    "fmt"
+)
+
+// ProcessData processes some data using feature flags
+func ProcessData(input string) string {
+    if IsFeatureEnabled() {
+        return fmt.Sprintf("processed: %s", input)
+    }
+    return input
+}
+
+// HelperFunction demonstrates package scope rule application
+func HelperFunction() {
+    fmt.Println("Feature is enabled in sub folder")
+
+}

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/expected/pkg2/sample.go
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/expected/pkg2/sample.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pkg2
+
+import (
+    "fmt"
+    "mycompany/featureflags/exp"
+)
+
+func someFunc() bool {  
+    // Simulate a real feature flag check for a new login flow
+    if exp.BoolValue("enable_new_login_flow") {
+        // New login flow is enabled
+        fmt.Println("New login flow is enabled")
+        return true
+    }
+    // Fallback to old login flow
+    fmt.Println("Using old login flow")
+    return false
+}
+
+func main() {
+    if someFunc() {
+        fmt.Println("Proceeding with new login flow...")
+        // ... code for new login flow
+    } else {
+        fmt.Println("Proceeding with old login flow...")
+        // ... code for old login flow
+    }
+}

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/input/main.go
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/input/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	"mycompany/featureflags/exp"
+)
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/input/pkg1/file.go
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/input/pkg1/file.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pkg1
+
+import (
+    "fmt"
+)
+
+// ProcessData processes some data using feature flags
+func ProcessData(input string) string {
+    if IsFeatureEnabled() {
+        return fmt.Sprintf("processed: %s", input)
+    }
+    return input
+}
+
+// HelperFunction demonstrates package scope rule application
+func HelperFunction() {
+    result := someFunc()
+    if result {
+        fmt.Println("Feature is enabled in sub folder")
+    }
+}

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/input/pkg1/sample.go
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/input/pkg1/sample.go
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pkg1
+
+
+import (
+    "fmt"
+    "mycompany/featureflags/exp"
+)
+
+
+func someFunc() bool {
+    return true
+}
+
+func main() {
+    if someFunc() {
+        fmt.Println("Proceeding with new login flow...")
+        // ... code for new login flow
+    } else {
+        fmt.Println("Proceeding with old login flow...")
+        // ... code for old login flow
+    }
+}

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/input/pkg1/sub_folder/file.go
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/input/pkg1/sub_folder/file.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package sub_folder
+
+import (
+    "fmt"
+)
+
+// ProcessData processes some data using feature flags
+func ProcessData(input string) string {
+    if IsFeatureEnabled() {
+        return fmt.Sprintf("processed: %s", input)
+    }
+    return input
+}
+
+// HelperFunction demonstrates package scope rule application
+func HelperFunction() {
+    result := someFunc()
+    if result {
+        fmt.Println("Feature is enabled in sub folder")
+    }
+}

--- a/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/input/pkg2/sample.go
+++ b/crates/core/test-resources/go/feature_flag/delete_method/private_pkg_fn_recursive/input/pkg2/sample.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2023 Uber Technologies, Inc.
+
+ <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ except in compliance with the License. You may obtain a copy of the License at
+ <p>http://www.apache.org/licenses/LICENSE-2.0
+
+ <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pkg2
+
+import (
+    "fmt"
+    "mycompany/featureflags/exp"
+)
+
+func someFunc() bool {  
+    // Simulate a real feature flag check for a new login flow
+    if exp.BoolValue("enable_new_login_flow") {
+        // New login flow is enabled
+        fmt.Println("New login flow is enabled")
+        return true
+    }
+    // Fallback to old login flow
+    fmt.Println("Using old login flow")
+    return false
+}
+
+func main() {
+    if someFunc() {
+        fmt.Println("Proceeding with new login flow...")
+        // ... code for new login flow
+    } else {
+        fmt.Println("Proceeding with old login flow...")
+        // ... code for old login flow
+    }
+}


### PR DESCRIPTION
DirectoryRecursive rules are global rules that essentially only apply to the directory from which they were triggered (and respective directory tree).

Added a new test case for this new scope