### PR TITLE
Adding debug statements for filter applications to help debugging

### DIFF
--- a/crates/core/src/models/filter.rs
+++ b/crates/core/src/models/filter.rs
@@ -17,6 +17,7 @@ use derive_builder::Builder;
 use getset::Getters;
 
 use itertools::Itertools;
+use log::debug;
 use pyo3::prelude::{pyclass, pymethods};
 
 use serde_derive::Deserialize;
@@ -338,6 +339,7 @@ impl SourceCodeUnit {
     let mut node_to_check = node;
     let instantiated_filter = filter.instantiate(substitutions);
 
+    debug!("Applying filter on potential match {:?} against potential match {:?}", instantiated_filter, node.to_sexp());
     if *filter.child_count() != default_child_count() {
       return node.named_child_count() == (*filter.child_count() as usize);
     }

--- a/crates/core/src/models/filter.rs
+++ b/crates/core/src/models/filter.rs
@@ -339,7 +339,7 @@ impl SourceCodeUnit {
     let mut node_to_check = node;
     let instantiated_filter = filter.instantiate(substitutions);
 
-    debug!("Applying filter on potential match {:?} against potential match {:?}", instantiated_filter, node.to_sexp());
+    debug!("Applying filter {:?} against potential match {:?}", instantiated_filter, node.to_sexp());
     if *filter.child_count() != default_child_count() {
       return node.named_child_count() == (*filter.child_count() as usize);
     }


### PR DESCRIPTION
In many cases, it's hard to understand why a particular filter did not match (i.e., it's currently tribal knowledge that regular substitutions are not propagated to filters).

This PR adds a simple debug statement to help visualize the filter for potential matches