### PR TITLE
Bug fix in contains clause in concrete syntax

### DIFF
--- a/crates/concrete-syntax/src/models/concrete_syntax/constraint_checker.rs
+++ b/crates/concrete-syntax/src/models/concrete_syntax/constraint_checker.rs
@@ -17,6 +17,7 @@ use super::interpreter::get_all_matches_for_concrete_syntax;
 use super::tree_sitter_adapter::{Node, SyntaxNode};
 use crate::models::concrete_syntax::parser::CsConstraint;
 use crate::models::matches::CapturedNode;
+use crate::tree_sitter_adapter::SyntaxCursor;
 
 /// Simple context for contains constraint checking
 pub struct ConstraintContext<'a> {
@@ -64,12 +65,19 @@ fn check_contains_recursive(
 ) -> bool {
   // Run the resolved pattern against the entire AST
   let matches = get_all_matches_for_concrete_syntax(
-    context.ast_root,
+    &context.ast_root.walk().node(),
     context.source_code,
     resolved_pattern,
     true, // recursive
     None, // replace_node
   );
+
+  let node_code = context
+    .ast_root
+    .utf8_text(context.source_code)
+    .unwrap()
+    .trim();
+  println!("checking contains for {node_code:?}");
 
   // If we found any matches, the contains constraint is satisfied
   !matches.is_empty()

--- a/crates/concrete-syntax/src/models/concrete_syntax/interpreter.rs
+++ b/crates/concrete-syntax/src/models/concrete_syntax/interpreter.rs
@@ -394,7 +394,7 @@ fn try_match_node_range(
     let constraint_context = ConstraintContext {
       captured_node: &captured,
       source_code: ctx.source_code,
-      ast_root: ctx.top_node,
+      ast_root: &ctx.cursor.node(),
     };
     if satisfies_constraints(&captured, constraints, Some(&constraint_context)) {
       let mut sub_ctx = MatchingContext {


### PR DESCRIPTION
Concrete syntax contains was passing the wrong node for the checker, and was matching with nodes it shouldn't. It was a very subtle bug. This PR should fix it.