### PR TITLE
Fixing bug after previous fix was not complete

### DIFF
--- a/crates/core/src/models/edit.rs
+++ b/crates/core/src/models/edit.rs
@@ -139,8 +139,20 @@ impl SourceCodeUnit {
     //  we apply the rules in the order they are provided to each ancestor in the context
     for rule in &next_rules[PARENT] {
       for ancestor in &context() {
-        // Skip match-only rules - they should not create edits for parent scope
-        if !rule.rule().is_match_only_rule() {
+        if rule.rule().is_match_only_rule() {
+          // For match-only rules, get matches and create identity edit if found
+          let matches = self.get_matches(rule, rules_store, *ancestor, false);
+          if let Some(first_match) = matches.first() {
+            // Create identity edit - same range for old and new (no code change)
+            let identity_edit = Edit::new(
+              first_match.clone(),
+              first_match.matched_string().clone(), // Replace with same content = identity
+              rule.name(),
+              self.code(),
+            );
+            return Some(identity_edit);
+          }
+        } else {
           if let Some(edit) = self.get_edit(rule, rules_store, *ancestor, false) {
             return Some(edit);
           }
@@ -151,8 +163,20 @@ impl SourceCodeUnit {
     // we apply the rules to each ancestor in the context in the order they are provided
     for ancestor in &context() {
       for rule in &next_rules[PARENT_ITERATIVE] {
-        // Skip match-only rules - they should not create edits for parent scope
-        if !rule.rule().is_match_only_rule() {
+        if rule.rule().is_match_only_rule() {
+          // For match-only rules, get matches and create identity edit if found
+          let matches = self.get_matches(rule, rules_store, *ancestor, false);
+          if let Some(first_match) = matches.first() {
+            // Create identity edit - same range for old and new (no code change)
+            let identity_edit = Edit::new(
+              first_match.clone(),
+              first_match.matched_string().clone(), // Replace with same content = identity
+              rule.name(),
+              self.code(),
+            );
+            return Some(identity_edit);
+          }
+        } else {
           if let Some(edit) = self.get_edit(rule, rules_store, *ancestor, false) {
             return Some(edit);
           }

--- a/crates/core/src/models/edit.rs
+++ b/crates/core/src/models/edit.rs
@@ -152,10 +152,8 @@ impl SourceCodeUnit {
             );
             return Some(identity_edit);
           }
-        } else {
-          if let Some(edit) = self.get_edit(rule, rules_store, *ancestor, false) {
-            return Some(edit);
-          }
+        } else if let Some(edit) = self.get_edit(rule, rules_store, *ancestor, false) {
+          return Some(edit);
         }
       }
     }
@@ -176,10 +174,8 @@ impl SourceCodeUnit {
             );
             return Some(identity_edit);
           }
-        } else {
-          if let Some(edit) = self.get_edit(rule, rules_store, *ancestor, false) {
-            return Some(edit);
-          }
+        } else if let Some(edit) = self.get_edit(rule, rules_store, *ancestor, false) {
+          return Some(edit);
         }
       }
     }

--- a/crates/core/src/models/unit_tests/rule_test.rs
+++ b/crates/core/src/models/unit_tests/rule_test.rs
@@ -439,8 +439,11 @@ fn test_match_only_parent_rule_no_edit() {
   // Before the fix: this would return Some(edit) that deletes content
   // After the fix: this should return Some(identity_edit) that preserves content
   let edit = source_code_unit.get_edit_for_ancestors(&range, &mut rule_store, &next_rules);
-  assert!(edit.is_some(), "Match-only parent rules should create identity edits");
-  
+  assert!(
+    edit.is_some(),
+    "Match-only parent rules should create identity edits"
+  );
+
   let edit = edit.unwrap();
   // Verify it's an identity edit (replacement equals original content)
   assert_eq!(

--- a/crates/core/src/models/unit_tests/rule_test.rs
+++ b/crates/core/src/models/unit_tests/rule_test.rs
@@ -437,11 +437,16 @@ fn test_match_only_parent_rule_no_edit() {
   ]);
 
   // Before the fix: this would return Some(edit) that deletes content
-  // After the fix: this should return None because match-only rules shouldn't create edits
+  // After the fix: this should return Some(identity_edit) that preserves content
   let edit = source_code_unit.get_edit_for_ancestors(&range, &mut rule_store, &next_rules);
-  assert!(
-    edit.is_none(),
-    "Match-only parent rules should not create edits"
+  assert!(edit.is_some(), "Match-only parent rules should create identity edits");
+  
+  let edit = edit.unwrap();
+  // Verify it's an identity edit (replacement equals original content)
+  assert_eq!(
+    edit.replacement_string(),
+    edit.p_match().matched_string(),
+    "Match-only parent rules should create identity edits (no content change)"
   );
 }
 

--- a/tests/test_piranha.py
+++ b/tests/test_piranha.py
@@ -391,6 +391,8 @@ def test_match_only_parent_rule_bug_fix():
 if (obj.isLocEnabled() || x > 0) {
     // do something
     x = obj.isLocEnabled();
+    x = obj.isLocEnabled();
+    x = obj.isLocEnabled();
     if (other_check) { }
 } else {
     // do something else!
@@ -410,7 +412,8 @@ if (obj.isLocEnabled() || x > 0) {
     # This rule has no replace_node, making it match-only
     match_only_parent_rule = Rule(
         name="find_assignment_parent",
-        query="cs :[x] = true;"
+        query="cs :[x] = true;",
+        is_seed_rule=False
         # Note: no replace_node specified = match-only rule
     )
 
@@ -419,6 +422,7 @@ if (obj.isLocEnabled() || x > 0) {
         name="logic_triggered_only_after_match_only_parent_rule",
         query='cs if (other_check) { }',
         replace_node="*",
+        is_seed_rule=False
     )
 
 
@@ -455,9 +459,9 @@ if (obj.isLocEnabled() || x > 0) {
     assert "x = true;" in result_code
     
     # CRITICAL: The match-only parent rule should NOT delete the assignment
-    # Before the bug fix, this line would be deleted
-    # After the bug fix, this line should remain
-    assert "x = true;" in result_code, "Match-only parent rule incorrectly deleted the assignment"
+    # Before the bug fix, this line would be deleted (replaced with empty string)
+    # After the bug fix, this line should remain (identity edit preserves content)
+    assert "x = true;" in result_code, "Match-only parent rule must preserve the assignment"
     
-    # The if condition should also be deleted
-    assert "if (other_check) { }" not in result_code
+    # The subsequent rule should still be triggered and delete the if statement
+    assert "if (other_check) { }" not in result_code, "Subsequent rules should still be triggered"


### PR DESCRIPTION
The previous [bug fix](https://github.com/uber/piranha/pull/778) was partial. It would work for single application of rules, but not until fix point because I forgot to add the edit to the queue. I've modified the test to reflect the correct behavior and fixed the bug.