### PR TITLE
Add contents:write permission for GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
     needs: build
     environment: pypi
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
softprops/action-gh-release with generate_release_notes:true requires the contents:write permission. Without it the job fails with: 'Resource not accessible by integration'